### PR TITLE
Add `docker-compose` file for Dev Environment with `CeleryExecutor`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ __pycache__/
 .vscode/
 .autoenv*
 .idea
+
+# Dev Logs
+dev/logs/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: dev clean stop help
+
+dev: ## Create a development Environment using `docker-compose` file.
+	docker-compose -f dev/docker-compose.yaml up -d
+
+logs: ## View logs of the all the containers
+	docker-compose -f dev/docker-compose.yaml logs --follow
+
+stop: ## Stop all the containers
+	docker-compose -f dev/docker-compose.yaml down
+
+clean: ## Remove all the containers along with volumes
+	docker-compose -f dev/docker-compose.yaml down  --volumes --remove-orphans
+	rm -rf dev/logs
+
+help: ## Prints this message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.rst
+++ b/README.rst
@@ -2,3 +2,25 @@ Astronomer Operators
 ====================
 
 Closed-source Airflow operators for Astronomer customers.
+
+Development Environment
+------------------------
+
+Run the following commands from the root of the repository:
+
+- ``make dev`` - To create a development Environment using `docker-compose` file.
+- ``make logs`` - To view the logs of the all the containers
+- ``make stop`` - To stop all the containers
+- ``make clean`` - To remove all the containers along with volumes
+- ``make help`` - To view the available commands
+
+Following ports are accessible from the host machine:
+
+- ``8080`` - Webserver
+- ``5555`` - Flower
+- ``5432`` - Postgres
+
+Dev Directories:
+
+- ``dev/dags/`` - DAG Files
+- ``dev/logs`` - Logs files of the Airflow containers

--- a/dev/.dockerignore
+++ b/dev/.dockerignore
@@ -1,0 +1,6 @@
+.astro
+.git
+.env
+airflow_settings.yaml
+logs/
+tests/

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,0 +1,10 @@
+ARG IMAGE_NAME="quay.io/astronomer/ap-airflow:2.2.3"
+FROM ${IMAGE_NAME}
+
+USER root
+COPY astronomer_operators ${AIRFLOW_HOME}/astronomer_operators/astronomer_operators
+COPY setup.cfg ${AIRFLOW_HOME}/astronomer_operators/setup.cfg
+COPY setup.py ${AIRFLOW_HOME}/astronomer_operators/setup.py
+
+RUN pip install -e ${AIRFLOW_HOME}/astronomer_operators
+USER astro

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,16 @@
+## Development Environment
+
+- Put the DAGs you want to run in the `dags` directory
+- Run `docker-compose up` to start all the services
+- If you want to add additional dependencies, add them to `setup.cfg` and re-run `docker-compose up`
+
+## Useful Commands
+
+- **Stop** all the services
+    ```shell
+    docker-compose down
+    ```
+- **Cleanup** the environment
+    ```shell
+    docker-compose down --volumes --remove-orphans
+    ```

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -1,0 +1,197 @@
+---
+version: '3'
+x-airflow-common:
+  &airflow-common
+  # In order to add custom dependencies or upgrade provider packages you can use your extended image.
+  # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
+  # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
+  image: astronomer-operators-dev
+  build:
+    context: ..
+    dockerfile: dev/Dockerfile
+    args:
+      IMAGE_NAME: ${IMAGE_NAME:-quay.io/astronomer/ap-airflow:2.2.3}
+  environment:
+    &airflow-common-env
+    DB_BACKEND: postgres
+    AIRFLOW__CORE__EXECUTOR: CeleryExecutor
+    AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
+    AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@postgres:5432/airflow
+    AIRFLOW__CELERY__BROKER_URL: redis://:@redis:6379/0
+    AIRFLOW__CORE__FERNET_KEY: ''
+    AIRFLOW__CORE__LOAD_EXAMPLES: "False"
+    AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "True"
+    AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL: "5"
+  volumes:
+    - ./dags:/usr/local/airflow/dags
+    - ./logs:/usr/local/airflow/logs
+    - ./plugins:/usr/local/airflow/plugins
+    - ../../astronomer-operators:/usr/local/airflow/astronomer_operators
+  depends_on:
+    &airflow-common-depends-on
+    redis:
+      condition: service_healthy
+    postgres:
+      condition: service_healthy
+
+services:
+  postgres:
+    image: postgres:13
+    environment:
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+      POSTGRES_DB: airflow
+    command: postgres -c 'idle_in_transaction_session_timeout=60000'   # 1 minute timeout
+    volumes:
+      - postgres-db-volume:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "airflow"]
+      interval: 5s
+      retries: 5
+    restart: always
+
+  redis:
+    image: redis:latest
+    expose:
+      - 6379
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 30s
+      retries: 50
+    restart: always
+
+  airflow-webserver:
+    <<: *airflow-common
+    command: airflow webserver
+    ports:
+      - 8080:8080
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    restart: always
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+
+  airflow-scheduler:
+    <<: *airflow-common
+    command: airflow scheduler
+    healthcheck:
+      test: ["CMD-SHELL", 'airflow jobs check --job-type SchedulerJob --hostname "$${HOSTNAME}"']
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    restart: always
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+
+  airflow-worker:
+    <<: *airflow-common
+    command: airflow celery worker
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - 'celery --app airflow.executors.celery_executor.app inspect ping -d "celery@$${HOSTNAME}"'
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    environment:
+      <<: *airflow-common-env
+    restart: always
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+
+  airflow-triggerer:
+    <<: *airflow-common
+    command: airflow triggerer
+    healthcheck:
+      test: ["CMD-SHELL", 'airflow jobs check --job-type TriggererJob --hostname "$${HOSTNAME}"']
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    restart: always
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+
+  airflow-init:
+    <<: *airflow-common
+    entrypoint: /bin/bash
+    # yamllint disable rule:line-length
+    command:
+      - -c
+      - |
+        one_meg=1048576
+        mem_available=$$(($$(getconf _PHYS_PAGES) * $$(getconf PAGE_SIZE) / one_meg))
+        cpus_available=$$(grep -cE 'cpu[0-9]+' /proc/stat)
+        disk_available=$$(df / | tail -1 | awk '{print $$4}')
+        warning_resources="false"
+        if (( mem_available < 4000 )) ; then
+          echo
+          echo -e "\033[1;33mWARNING!!!: Not enough memory available for Docker.\e[0m"
+          echo "At least 4GB of memory required. You have $$(numfmt --to iec $$((mem_available * one_meg)))"
+          echo
+          warning_resources="true"
+        fi
+        if (( cpus_available < 2 )); then
+          echo
+          echo -e "\033[1;33mWARNING!!!: Not enough CPUS available for Docker.\e[0m"
+          echo "At least 2 CPUs recommended. You have $${cpus_available}"
+          echo
+          warning_resources="true"
+        fi
+        if (( disk_available < one_meg * 10 )); then
+          echo
+          echo -e "\033[1;33mWARNING!!!: Not enough Disk space available for Docker.\e[0m"
+          echo "At least 10 GBs recommended. You have $$(numfmt --to iec $$((disk_available * 1024 )))"
+          echo
+          warning_resources="true"
+        fi
+        if [[ $${warning_resources} == "true" ]]; then
+          echo
+          echo -e "\033[1;33mWARNING!!!: You have not enough resources to run Airflow (see above)!\e[0m"
+          echo "Please follow the instructions to increase amount of resources available:"
+          echo "   https://airflow.apache.org/docs/apache-airflow/stable/start/docker.html#before-you-begin"
+          echo
+        fi
+        mkdir -p /sources/logs /sources/dags /sources/plugins
+        airflow users  create --role Admin --username admin --email admin \
+              --firstname admin --lastname admin --password admin
+        exec /entrypoint bash -c "airflow db upgrade && airflow version"
+    # yamllint enable rule:line-length
+    environment:
+      <<: *airflow-common-env
+    volumes:
+      - .:/sources
+
+  flower:
+    <<: *airflow-common
+    command: airflow celery flower
+    ports:
+      - 5555:5555
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:5555/"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    environment:
+      <<: *airflow-common-env
+    restart: always
+    depends_on:
+      <<: *airflow-common-depends-on
+      airflow-init:
+        condition: service_completed_successfully
+
+volumes:
+  postgres-db-volume:


### PR DESCRIPTION
This should provide a dev environment with `CeleryExecutor` where there is no need to restart the services for a minor change in source code.

Further Improvements:
~- We should wrap this commands in a MAKEFILE, example - https://github.com/astronomer/astro-runtime/blob/main/Makefile
so it becomes very convenient~