### PR TITLE
Add logical_date in context for tests

### DIFF
--- a/tests/core/sensors/test_external_task.py
+++ b/tests/core/sensors/test_external_task.py
@@ -26,7 +26,7 @@ def context():
     """
     Creates a context with default execution date.
     """
-    context = {"execution_date": DEFAULT_DATE}
+    context = {"execution_date": DEFAULT_DATE, "logical_date": DEFAULT_DATE}
     yield context
 
 


### PR DESCRIPTION
- Fix test for the core for missing `logical_date` in context.