### PR TITLE
Allow CodeCoverage toleration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+---
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        only_pulls: true


### PR DESCRIPTION
This PR adds some toleration for Code Coverage.

It won't always be the case that we can achieve the coverage we need. 2% is  an arbitrary number currently, we can increase or decrease in future.