### PR TITLE
Split the dependencies into multiple extras

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir -U -r ci/requirements.txt
 
 COPY . .
 
-RUN pip install -U .[tests]
+RUN pip install -U .[all,tests]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ jobs:
     executor:
       name: docker-executor
       python_version: "<<parameters.python_version>>"
+    parallelism: 4
     steps:
       - checkout
       - restore_cache:
@@ -96,7 +97,9 @@ jobs:
       - run:
           name: Run tests
           command: |
-            pytest --junit-xml=test-report/report.xml
+            set -e
+            TEST_FILES=$(circleci tests glob "tests/**/test_*.py" | circleci tests split --split-by=timings)
+            pytest --junit-xml=test-report/report.xml  $TEST_FILES
       - codecov/upload:
           file: coverage.xml
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
     executor:
       name: docker-executor
       python_version: "<<parameters.python_version>>"
-    parallelism: 4
+    parallelism: 2
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
             - mypy-main-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}
       - run:
           name: Install Dependencies
-          command: pip install -U -e .[mypy]
+          command: pip install -U -e .[all,mypy]
       - run:
           name: Run Mypy
           command: |
@@ -92,7 +92,7 @@ jobs:
             - deps-main-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}
       - run:
           name: Install Dependencies
-          command: pip install -U -e .[tests]
+          command: pip install -U -e .[all,tests]
       - run:
           name: Run tests
           command: |

--- a/.circleci/scripts/pre_commit_setup_cfg_all_extra.py
+++ b/.circleci/scripts/pre_commit_setup_cfg_all_extra.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""
+Pre-commit hook to sync an "all" extra in setup.cfg.
+It will contain all the dependencies apart from tests and mypy.
+"""
+import configparser
+from pathlib import Path
+
+repo_dir = Path(__file__).parent.parent.parent
+# print(repo_dir)
+# assert repo_dir.name == "astronomer-providers", repo_dir.name
+
+config = configparser.ConfigParser(strict=False)
+config.read(repo_dir / "setup.cfg")
+
+all_extra = []
+extra_to_exclude = {"tests", "mypy", "all"}
+for k in config["options.extras_require"].keys():
+    if k in extra_to_exclude:
+        continue
+    reqs = config["options.extras_require"][k].split()
+    all_extra.extend(reqs)
+
+expected_all_extra = set(all_extra)
+found_all_extra = set(config["options.extras_require"].get("all", "").split())
+if not found_all_extra:
+    raise SystemExit("Missing 'all' extra in setup.cfg")
+
+diff_extras = expected_all_extra - found_all_extra
+if diff_extras:
+    diff_extras_str = "\n \t" + "\n \t".join(sorted(diff_extras))
+    raise SystemExit(f"'all' extra in setup.cfg is missing some dependencies:\n {diff_extras_str}")

--- a/.circleci/scripts/pre_commit_setup_cfg_all_extra.py
+++ b/.circleci/scripts/pre_commit_setup_cfg_all_extra.py
@@ -7,8 +7,6 @@ import configparser
 from pathlib import Path
 
 repo_dir = Path(__file__).parent.parent.parent
-# print(repo_dir)
-# assert repo_dir.name == "astronomer-providers", repo_dir.name
 
 config = configparser.ConfigParser(strict=False)
 config.read(repo_dir / "setup.cfg")

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,3 +88,12 @@ repos:
           ^dev|
           .*example_dags/.*|
         additional_dependencies: ['toml']
+
+  - repo: local
+    hooks:
+      - id: sync-all-extras-setup.cfg
+        name: Sync "all" extra in setup.cfg
+        language: python
+        files: ^setup.cfg$
+        pass_filenames: false
+        entry: .circleci/scripts/pre_commit_setup_cfg_all_extra.py

--- a/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -24,8 +24,6 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
     """
 
     def __init__(self, *, poll_interval: int = 5, **kwargs: Any):
-        self.pod = None
-        self.pod_request_obj = None
         self.poll_interval = poll_interval
         super().__init__(**kwargs)
 

--- a/astronomer/providers/google/cloud/triggers/gcs.py
+++ b/astronomer/providers/google/cloud/triggers/gcs.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 class GCSBlobTrigger(BaseTrigger):
     """
     A trigger that fires and it finds the requested file or folder present in the given bucket.
+
     :param bucket: the bucket in the google cloud storage where the objects are residing.
     :param object_name: the file or folder present in the bucket
     :param google_cloud_conn_id: reference to the Google Connection

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -7,5 +7,5 @@ RUN apt-get update -y && apt-get install -y git
 COPY setup.cfg ${AIRFLOW_HOME}/astronomer_providers/setup.cfg
 COPY pyproject.toml ${AIRFLOW_HOME}/astronomer_providers/pyproject.toml
 
-RUN pip install -e "${AIRFLOW_HOME}/astronomer_providers[tests,mypy]"
+RUN pip install -e "${AIRFLOW_HOME}/astronomer_providers[all,tests,mypy]"
 USER astro

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,45 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line-length = 110
 target-version = ['py39']
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--tb=short --cov=astronomer --cov-report=xml"
+testpaths = [
+    "tests",
+]
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+
+[tool.mypy]
+namespace_packages = true
+explicit_package_bases = true
+pretty = true
+show_error_codes = true
+ignore_missing_imports = true
+no_implicit_optional = true
+warn_redundant_casts = true
+show_error_context = true
+color_output = true
+disallow_any_generics = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+warn_unused_configs = true
+warn_unused_ignores = true
+warn_return_any = true
+strict_equality = true
+
+# mypy per-module options:
+[[tool.mypy.overrides]]
+module = [
+    "airflow",
+    "asgiref"
+]
+ignore_missing_imports = true
+
+[tool.pydocstyle]
+inherit = false
+add_ignore = "D100,D104,D105,D107,D205,D400,D401"
+convention = "pep257"

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,22 +35,7 @@ install_requires =
     apache-airflow>=2.2.0
     aiohttp
     aiofiles
-    aioresponses
-    apache-airflow-providers-amazon>=3.0.0
-    apache-airflow-providers-cncf-kubernetes>=3
-    apache-airflow-providers-databricks>=2.2.0
-    apache-airflow-providers-google
-    # This is needed currently to install without constraints
-    # otherwise pip will loop around to find correct version that satisfies all requirements
-    # and will never install the correct version
-    # Related to https://github.com/googleapis/google-cloud-python/issues/10566
-    google-api-core>=1.25.1,<2.0.0
-    apache-airflow-providers-snowflake
     asgiref
-    aiobotocore>=2.1.1
-    kubernetes_asyncio
-    gcloud-aio-storage
-    gcloud-aio-bigquery
     typing_extensions; python_version < "3.8"
     # Markupsafe 2.1.0 breaks with error: import name 'soft_unicode' from 'markupsafe'.
     # This should be removed when either this issue is closed:
@@ -62,9 +47,29 @@ install_requires =
 zip_safe = false
 
 [options.extras_require]
+amazon =
+    apache-airflow-providers-amazon>=3.0.0
+    aiobotocore>=2.1.1
+cncf.kubernetes =
+    apache-airflow-providers-cncf-kubernetes>=3
+    kubernetes_asyncio
+databricks =
+    apache-airflow-providers-databricks>=2.2.0
+google =
+    apache-airflow-providers-google
+    # This is needed currently to install without constraints
+    # otherwise pip will loop around to find correct version that satisfies all requirements
+    # and will never install the correct version
+    # Related to https://github.com/googleapis/google-cloud-python/issues/10566
+    google-api-core>=1.25.1,<2.0.0
+    gcloud-aio-storage
+    gcloud-aio-bigquery
+snowflake =
+    apache-airflow-providers-snowflake
 tests =
-    parameterized
+    aioresponses
     asynctest
+    parameterized
     pytest
     pytest-asyncio
     pytest-cov
@@ -92,6 +97,19 @@ mypy =
     types-Markdown
     types-PyMySQL
     types-PyYAML
+
+# All extras from above except 'mypy' and 'tests'
+all =
+    aiobotocore>=2.1.1
+    apache-airflow-providers-amazon>=3.0.0
+    apache-airflow-providers-cncf-kubernetes>=3
+    apache-airflow-providers-databricks>=2.2.0
+    apache-airflow-providers-google
+    apache-airflow-providers-snowflake
+    gcloud-aio-bigquery
+    gcloud-aio-storage
+    google-api-core>=1.25.1,<2.0.0
+    kubernetes_asyncio
 
 [options.packages.find]
 include =
@@ -138,6 +156,3 @@ ignore_missing_imports = True
 inherit = false
 add_ignore = D100,D104,D105,D107,D205,D400,D401
 convention = pep257
-
-[darglint]
-docstring_style=sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -115,44 +115,7 @@ all =
 include =
     astronomer.*
 
-[tool:pytest]
-testpaths = tests
-addopts = --tb=short --cov=astronomer --cov-report=xml
-
 [flake8]
 exclude = venv/*,tox/*,specs/*
 ignore = E123,E128,E266,E402,W503,E731,W601
 max-line-length = 119
-
-[isort]
-profile = black
-multi_line_output = 3
-
-[mypy]
-namespace_packages = True
-explicit_package_bases = True
-pretty = True
-show_error_codes = True
-ignore_missing_imports = True
-no_implicit_optional = True
-warn_redundant_casts = True
-show_error_context = True
-color_output = True
-disallow_any_generics = True
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-warn_unused_configs = True
-warn_unused_ignores = True
-warn_return_any = True
-strict_equality = True
-
-[mypy-airflow.*]
-ignore_missing_imports = True
-
-[mypy-asgiref.*]
-ignore_missing_imports = True
-
-[pydocstyle]
-inherit = false
-add_ignore = D100,D104,D105,D107,D205,D400,D401
-convention = pep257

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,10 +51,10 @@ amazon =
     apache-airflow-providers-amazon>=3.0.0
     aiobotocore>=2.1.1
 cncf.kubernetes =
-    apache-airflow-providers-cncf-kubernetes>=3
+    apache-airflow-providers-cncf-kubernetes>=3,<3.1.0
     kubernetes_asyncio
 databricks =
-    apache-airflow-providers-databricks>=2.2.0
+    apache-airflow-providers-databricks>=2.2.0,<2.3.0
 google =
     apache-airflow-providers-google
     # This is needed currently to install without constraints
@@ -102,8 +102,8 @@ mypy =
 all =
     aiobotocore>=2.1.1
     apache-airflow-providers-amazon>=3.0.0
-    apache-airflow-providers-cncf-kubernetes>=3
-    apache-airflow-providers-databricks>=2.2.0
+    apache-airflow-providers-cncf-kubernetes>=3,<3.1.0
+    apache-airflow-providers-databricks>=2.2.0,<2.3.0
     apache-airflow-providers-google
     apache-airflow-providers-snowflake
     gcloud-aio-bigquery


### PR DESCRIPTION
This will allow users to just install dependencies of a single provider. For example if a user wants to just use K8s async operator, they shouldn't need to install GCP, AWS, Databricks or Snowflake dependencies

closes https://github.com/astronomer/astronomer-providers/issues/101