### PR TITLE
Add pre-commit to keep package version in sync

### DIFF
--- a/.circleci/scripts/pre_commit_sync_version_docs.py
+++ b/.circleci/scripts/pre_commit_sync_version_docs.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Pre-commit hook to sync the "version" in setup.cfg and version in docs/conf.py."""
+import configparser
+import re
+from pathlib import Path
+
+repo_dir = Path(__file__).parent.parent.parent
+
+config = configparser.ConfigParser(strict=False)
+config.read(repo_dir / "setup.cfg")
+
+version_in_setup_cfg = config["metadata"]["version"]
+
+conf_py_path = repo_dir / "docs" / "conf.py"
+
+with open(conf_py_path, "r") as f:
+    conf_py_contents = f.read()
+
+new_text = re.sub(
+    r"release =(.*)", f'release = "{version_in_setup_cfg}"', conf_py_contents, flags=re.MULTILINE
+)
+
+with open(str(repo_dir / "docs/conf.py"), "w") as f:
+    f.write(new_text)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,3 +97,9 @@ repos:
         files: ^setup.cfg$
         pass_filenames: false
         entry: .circleci/scripts/pre_commit_setup_cfg_all_extra.py
+      - id: sync-version-setup.cfg-docs-conf
+        name: Sync "version" of the package in setup.cfg and docs/conf.py
+        language: python
+        files: ^setup.cfg$|^docs/conf.py$
+        pass_filenames: false
+        entry: .circleci/scripts/pre_commit_sync_version_docs.py

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,9 @@ Astronomer Providers
 .. image:: https://codecov.io/gh/astronomer/astronomer-providers/branch/main/graph/badge.svg?token=LPHFRC3CB3
     :target: https://codecov.io/gh/astronomer/astronomer-providers
     :alt: CodeCov
+.. image:: https://readthedocs.org/projects/astronomer-providers/badge/?version=latest
+    :target: https://astronomer-providers.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status
 
 `Apache Airflow <https://airflow.apache.org/>`_ Providers containing Deferrable Operators & Sensors from Astronomer.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
 project_urls =
     Source Code=https://github.com/astronomer/astronomer-providers/
     Homepage=https://astronomer.io/
+    Documentation=https://astronomer-providers.rtfd.io/
     Changelog=https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst
 
 [options]


### PR DESCRIPTION
This PR:
- adds pre-commit to keep package version in setup.cfg and docs/conf.py in sync
- Adds ReadTheDocs Docs Build Badge
- Add docs link in project_urls