### PR TITLE
Docs: Ignore Example DAGs from API reference

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,7 +85,7 @@ html_theme_options = {
 # html_static_path = ["_static"]
 
 # -- AutoAPI ---------------------------------------------------------------
-autoapi_dirs = [str(prov_dir) for prov_dir in Path("../astronomer/providers/").iterdir()]
+autoapi_dirs = sorted([str(prov_dir) for prov_dir in Path("../astronomer/providers/").iterdir()])
 
 autoapi_generate_api_docs = True
 
@@ -116,6 +116,11 @@ autoapi_options = [
     "show-inheritance",
     "show-module-summary",
     "special-members",
+]
+
+# Ignore example DAGs from the API docs
+autoapi_ignore = [
+    "*example_dags*",
 ]
 
 suppress_warnings = [


### PR DESCRIPTION
Example DAGs don't define any classes so it does not make sense to include them in the docs.

**Before**:

<img width="792" alt="image" src="https://user-images.githubusercontent.com/8811558/158492800-354763c3-f455-416d-b8a9-cc07c762eb93.png">


**After**:

<img width="617" alt="image" src="https://user-images.githubusercontent.com/8811558/158492815-e2863781-5be5-40a6-8327-a377ef5a2cc9.png">
