### PR TITLE
Remove path import for USER_AGENT_HEADER and declare it

### DIFF
--- a/astronomer/providers/databricks/hooks/databricks.py
+++ b/astronomer/providers/databricks/hooks/databricks.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Tuple, cast
 
 import aiohttp
 from aiohttp import ClientResponseError
+from airflow import __version__
 from airflow.exceptions import AirflowException
 from airflow.providers.databricks.hooks.databricks import (
     GET_RUN_ENDPOINT,
@@ -11,9 +12,8 @@ from airflow.providers.databricks.hooks.databricks import (
     RunState,
 )
 from asgiref.sync import sync_to_async
-from airflow import __version__
 
-USER_AGENT_HEADER = {'user-agent': f'airflow-{__version__}'}
+USER_AGENT_HEADER = {"user-agent": f"airflow-{__version__}"}
 
 
 class DatabricksHookAsync(DatabricksHook):

--- a/astronomer/providers/databricks/hooks/databricks.py
+++ b/astronomer/providers/databricks/hooks/databricks.py
@@ -7,11 +7,13 @@ from aiohttp import ClientResponseError
 from airflow.exceptions import AirflowException
 from airflow.providers.databricks.hooks.databricks import (
     GET_RUN_ENDPOINT,
-    USER_AGENT_HEADER,
     DatabricksHook,
     RunState,
 )
 from asgiref.sync import sync_to_async
+from airflow import __version__
+
+USER_AGENT_HEADER = {'user-agent': f'airflow-{__version__}'}
 
 
 class DatabricksHookAsync(DatabricksHook):

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ cncf.kubernetes =
     apache-airflow-providers-cncf-kubernetes>=3,<3.1.0
     kubernetes_asyncio
 databricks =
-    apache-airflow-providers-databricks>=2.2.0,<2.3.0
+    apache-airflow-providers-databricks>=2.2.0
 google =
     apache-airflow-providers-google
     # This is needed currently to install without constraints
@@ -107,7 +107,7 @@ all =
     aiobotocore>=2.1.1
     apache-airflow-providers-amazon>=3.0.0
     apache-airflow-providers-cncf-kubernetes>=3,<3.1.0
-    apache-airflow-providers-databricks>=2.2.0,<2.3.0
+    apache-airflow-providers-databricks>=2.2.0
     apache-airflow-providers-google
     apache-airflow-providers-snowflake
     gcloud-aio-bigquery

--- a/tests/databricks/hooks/test_databricks.py
+++ b/tests/databricks/hooks/test_databricks.py
@@ -3,13 +3,11 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+from airflow import __version__ as provider_version
 from airflow.exceptions import AirflowException
 from airflow.providers.databricks.hooks.databricks import (
     GET_RUN_ENDPOINT,
     SUBMIT_RUN_ENDPOINT,
-)
-from airflow.providers.databricks.hooks.databricks import (
-    __version__ as provider_version,
 )
 from packaging import version
 


### PR DESCRIPTION
 - [USER_AGENT_HEADER](https://github.com/astronomer/astronomer-providers/blob/1a27d231246e1c3c400ca7a3343d9372b6b51acf/astronomer/providers/databricks/hooks/databricks.py#L10) is imported from [airflow.providers.databricks.hooks.databricks](https://github.com/apache/airflow/blob/main/airflow/providers/databricks/hooks/databricks.py) as part of this [commit](https://github.com/apache/airflow/commit/27d19e7626ef80687997a6799762fa00162c1328). This is causing DatabricksSubmitRunOperatorAsync to throw an import error .This is for latest apache-airflow-providers-databricks==2.3.0
 - Remove path import for USER_AGENT_HEADER and declare it

closes: #130 