### PR TITLE
Unpin Kubernetes Provider dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ amazon =
     apache-airflow-providers-amazon>=3.0.0
     aiobotocore>=2.1.1
 cncf.kubernetes =
-    apache-airflow-providers-cncf-kubernetes>=3,<3.1.0
+    apache-airflow-providers-cncf-kubernetes>=3
     kubernetes_asyncio
 databricks =
     apache-airflow-providers-databricks>=2.2.0
@@ -106,7 +106,7 @@ mypy =
 all =
     aiobotocore>=2.1.1
     apache-airflow-providers-amazon>=3.0.0
-    apache-airflow-providers-cncf-kubernetes>=3,<3.1.0
+    apache-airflow-providers-cncf-kubernetes>=3
     apache-airflow-providers-databricks>=2.2.0
     apache-airflow-providers-google
     apache-airflow-providers-snowflake

--- a/tests/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -29,6 +29,7 @@ def create_context(task):
         "task": task,
         "ti": task_instance,
         "task_instance": task_instance,
+        "run_id": dag_run.run_id,
     }
 
 


### PR DESCRIPTION
Tis PR remove the upper bound version constraints for `apache-airflow-providers-cncf-kubernetes`