### PR TITLE
Enable perioding resuming to fetch logs for KPOA

### DIFF
--- a/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -46,7 +46,7 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
                 raise AirflowException(description)
 
     def defer(self, last_log_time=None, **kwargs):
-        """Defers to WaitContainerTrigger optionally with last log time."""
+        """Defers to ``WaitContainerTrigger`` optionally with last log time."""
         if kwargs:
             raise ValueError(
                 f"Received keyword arguments {list(kwargs.keys())} but "

--- a/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -121,15 +121,14 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
             if self.do_xcom_push:
                 result = self.extract_xcom(pod=self.pod)
             remote_pod = self.pod_manager.await_pod_completion(self.pod)
-        except Exception as e:
-            if isinstance(e, TaskDeferred):
-                raise e
-            else:
-                self.cleanup(
-                    pod=self.pod or self.pod_request_obj,
-                    remote_pod=remote_pod,
-                )
-                raise e
+        except TaskDeferred:
+            raise
+        except Exception:
+            self.cleanup(
+                pod=self.pod or self.pod_request_obj,
+                remote_pod=remote_pod,
+            )
+            raise
         self.cleanup(
             pod=self.pod or self.pod_request_obj,
             remote_pod=remote_pod,

--- a/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -122,6 +122,7 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
                     since_time=last_log_time,
                 )
                 if pod_log_status.running:
+                    self.log.info("Container still running; deferring again.")
                     self.defer(pod_log_status.last_log_time)
 
             if self.do_xcom_push:

--- a/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -6,6 +6,7 @@ from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
     KubernetesPodOperator,
 )
 from airflow.utils.context import Context
+from pendulum import DateTime
 
 from astronomer.providers.cncf.kubernetes.triggers.wait_container import (
     PodLaunchTimeoutException,
@@ -48,7 +49,7 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
             else:
                 raise AirflowException(description)
 
-    def defer(self, last_log_time=None, **kwargs):
+    def defer(self, last_log_time: Optional[DateTime] = None, **kwargs) -> None:
         """Defers to ``WaitContainerTrigger`` optionally with last log time."""
         if kwargs:
             raise ValueError(

--- a/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -106,7 +106,7 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
                 raise PodNotFoundException("Could not find pod after resuming from deferral")
 
             if self.get_logs:
-                last_log_time = event.get("last_log_time")
+                last_log_time = event and event.get("last_log_time")
                 if last_log_time:
                     self.log.info("Resuming logs read from time %r", last_log_time)
                 pod_log_status = self.pod_manager.fetch_container_logs(
@@ -129,6 +129,7 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
                     pod=self.pod or self.pod_request_obj,
                     remote_pod=remote_pod,
                 )
+                raise e
         self.cleanup(
             pod=self.pod or self.pod_request_obj,
             remote_pod=remote_pod,

--- a/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -23,7 +23,7 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
 
     .. warning::
         By default, logs will not be available in the Airflow Webserver until the task completes. However,
-        you can configure KubernetesPodOperatorAsync to periodically resume and fetch logs.  This behavior
+        you can configure ``KubernetesPodOperatorAsync`` to periodically resume and fetch logs.  This behavior
         is controlled by param ``logging_interval``.
 
     :param poll_interval: interval in seconds to sleep between checking pod status

--- a/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -22,11 +22,14 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
     Async (deferring) version of KubernetesPodOperator
 
     .. warning::
-        The logs would not be available in the Airflow Webserver until the task completes. This is
-        the main difference between this operator and the
-        :class:`~airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator`.
+        By default, logs will not be available in the Airflow Webserver until the task completes. However,
+        you can configure KubernetesPodOperatorAsync to periodically resume and fetch logs.  This behavior
+        is controlled by param ``logging_interval``.
 
     :param poll_interval: interval in seconds to sleep between checking pod status
+    :param logging_interval: max time in seconds that task should be in deferred state before
+        resuming to fetch latest logs. If None, then the task will remain in deferred state until pod
+        is done, and no logs will be visible until that time.
     """
 
     def __init__(self, *, poll_interval: int = 5, logging_interval: Optional[int] = None, **kwargs: Any):

--- a/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -29,7 +29,7 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
 
     :param poll_interval: interval in seconds to sleep between checking pod status
     :param logging_interval: max time in seconds that task should be in deferred state before
-        resuming to fetch latest logs. If None, then the task will remain in deferred state until pod
+        resuming to fetch latest logs. If ``None``, then the task will remain in deferred state until pod
         is done, and no logs will be visible until that time.
     """
 

--- a/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -6,6 +6,7 @@ from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
     KubernetesPodOperator,
 )
 from airflow.utils.context import Context
+from kubernetes.client import models as k8s
 from pendulum import DateTime
 
 from astronomer.providers.cncf.kubernetes.triggers.wait_container import (
@@ -49,7 +50,7 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
             else:
                 raise AirflowException(description)
 
-    def defer(self, last_log_time: Optional[DateTime] = None, **kwargs) -> None:
+    def defer(self, last_log_time: Optional[DateTime] = None, **kwargs: Any) -> None:
         """Defers to ``WaitContainerTrigger`` optionally with last log time."""
         if kwargs:
             raise ValueError(
@@ -77,7 +78,7 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
 
     def execute(self, context: Context) -> None:  # noqa: D102
         self.pod_request_obj = self.build_pod_request_obj(context)
-        self.pod = self.get_or_create_pod(self.pod_request_obj, context)
+        self.pod: k8s.V1Pod = self.get_or_create_pod(self.pod_request_obj, context)
         self.defer()
 
     def execute_complete(self, context: Context, event: Dict[str, Any]) -> Any:

--- a/astronomer/providers/cncf/kubernetes/triggers/wait_container.py
+++ b/astronomer/providers/cncf/kubernetes/triggers/wait_container.py
@@ -35,6 +35,7 @@ class WaitContainerTrigger(BaseTrigger):
     :param poll_interval: number of seconds between reading pod state
     :param logging_interval: number of seconds to wait before kicking it back to
         the operator to print latest logs. If ``None`` will wait until container done.
+    :param last_log_time: where to resume logs from
     """
 
     def __init__(

--- a/astronomer/providers/cncf/kubernetes/triggers/wait_container.py
+++ b/astronomer/providers/cncf/kubernetes/triggers/wait_container.py
@@ -11,6 +11,7 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils import timezone
 from kubernetes_asyncio.client import CoreV1Api
+from pendulum import DateTime
 
 from astronomer.providers.cncf.kubernetes.hooks.kubernetes_async import (
     KubernetesHookAsync,
@@ -49,7 +50,7 @@ class WaitContainerTrigger(BaseTrigger):
         pending_phase_timeout: float = 120,
         poll_interval: float = 5,
         logging_interval: Optional[int] = None,
-        last_log_time: Optional[int] = None,
+        last_log_time: Optional[DateTime] = None,
     ):
         super().__init__()
         self.kubernetes_conn_id = kubernetes_conn_id

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ amazon =
     apache-airflow-providers-amazon>=3.0.0
     aiobotocore>=2.1.1
 cncf.kubernetes =
-    apache-airflow-providers-cncf-kubernetes>=3
+    apache-airflow-providers-cncf-kubernetes>=4
     kubernetes_asyncio
 databricks =
     apache-airflow-providers-databricks>=2.2.0
@@ -120,7 +120,7 @@ mypy =
 all =
     aiobotocore>=2.1.1
     apache-airflow-providers-amazon>=3.0.0
-    apache-airflow-providers-cncf-kubernetes>=3
+    apache-airflow-providers-cncf-kubernetes>=4
     apache-airflow-providers-databricks>=2.2.0
     apache-airflow-providers-google
     apache-airflow-providers-apache-livy

--- a/tests/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -148,3 +148,33 @@ def test_trigger_error(
                 "description": "any message",
             },
         )
+
+
+def test_defer_with_kwargs():
+    op = KubernetesPodOperatorAsync(task_id="test_task", name="test-pod", get_logs=True)
+    with pytest.raises(ValueError):
+        op.defer(kwargs={"timeout": 10})
+
+
+@mock.patch(
+    "astronomer.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperatorAsync.build_pod_request_obj"
+)
+@mock.patch(
+    "astronomer.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperatorAsync.get_or_create_pod"
+)
+@mock.patch("astronomer.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperatorAsync.defer")
+def test_execute(mock_defer, mock_get_or_create_pod, mock_build_pod_request_obj):
+    mock_get_or_create_pod.return_value = {}
+    mock_build_pod_request_obj.return_value = {}
+    mock_defer.return_value = {}
+    op = KubernetesPodOperatorAsync(task_id="test_task", name="test-pod", get_logs=True)
+    assert op.execute(context=create_context(op)) is None
+
+
+@mock.patch(
+    "astronomer.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperatorAsync.trigger_reentry"
+)
+def test_execute_complete(mock_trigger_reentry):
+    mock_trigger_reentry.return_value = {}
+    op = KubernetesPodOperatorAsync(task_id="test_task", name="test-pod", get_logs=True)
+    assert op.execute_complete(context=create_context(op), event={}) is None

--- a/tests/cncf/kubernetes/triggers/test_wait_container.py
+++ b/tests/cncf/kubernetes/triggers/test_wait_container.py
@@ -152,7 +152,8 @@ async def test_pending_running(load_kube_config, wait_completion):
     If we get Running phase within the timeout period we should move on to wait
     for pod completion.
     """
-    wait_completion.return_value = None
+    expected_event = TriggerEvent({"status": "done"})
+    wait_completion.return_value = expected_event
     trigger = WaitContainerTrigger(
         pod_name=mock.ANY,
         pod_namespace=mock.ANY,
@@ -162,7 +163,7 @@ async def test_pending_running(load_kube_config, wait_completion):
         logging_interval=None,
     )
 
-    assert await trigger.run().__anext__() == TriggerEvent({"status": "done"})
+    assert await trigger.run().__anext__() == expected_event
     wait_completion.assert_awaited()
 
 

--- a/tests/cncf/kubernetes/triggers/test_wait_container.py
+++ b/tests/cncf/kubernetes/triggers/test_wait_container.py
@@ -30,6 +30,8 @@ def test_serialize():
         "pod_namespace": "pod_namespace",
         "pending_phase_timeout": 120,
         "poll_interval": 5,
+        "logging_interval": None,
+        "last_log_time": None,
     }
     trigger = WaitContainerTrigger(**expected_kwargs)
     classpath, actual_kwargs = trigger.serialize()
@@ -128,12 +130,14 @@ async def test_pending_running(load_kube_config, wait_completion):
     If we get Running phase within the timeout period we should move on to wait
     for pod completion.
     """
+    wait_completion.return_value = None
     trigger = WaitContainerTrigger(
         pod_name=mock.ANY,
         pod_namespace=mock.ANY,
         container_name=mock.ANY,
         pending_phase_timeout=5,
         poll_interval=2,
+        logging_interval=None,
     )
 
     assert await trigger.run().__anext__() == TriggerEvent({"status": "done"})

--- a/tests/cncf/kubernetes/triggers/test_wait_container.py
+++ b/tests/cncf/kubernetes/triggers/test_wait_container.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock
 
 import pytest
 from airflow.triggers.base import TriggerEvent
+from pendulum import DateTime
+from pytest import param
 
 from astronomer.providers.cncf.kubernetes.triggers.wait_container import (
     WaitContainerTrigger,
@@ -39,7 +41,9 @@ def test_serialize():
     assert actual_kwargs == expected_kwargs
 
 
-def get_read_pod_mock(phases_to_emit=None):
+def get_read_pod_mock_phases(phases_to_emit=None):
+    """emit pods with given phases sequentially"""
+
     async def mock_read_namespaced_pod(*args, **kwargs):
         event_mock = MagicMock()
         event_mock.status.phase = phases_to_emit.pop(0)
@@ -48,8 +52,26 @@ def get_read_pod_mock(phases_to_emit=None):
     return mock_read_namespaced_pod
 
 
+def get_read_pod_mock_containers(statuses_to_emit=None):
+    """
+    Emit pods with given phases sequentially.
+    `statuses_to_emit` should be a list of bools indicating running or not.
+    """
+
+    async def mock_read_namespaced_pod(*args, **kwargs):
+        container_mock = MagicMock()
+        container_mock.state.running = statuses_to_emit.pop(0)
+        event_mock = MagicMock()
+        event_mock.status.container_statuses = [container_mock]
+        return event_mock
+
+    return mock_read_namespaced_pod
+
+
 @pytest.mark.asyncio
-@mock.patch(READ_NAMESPACED_POD_PATH, new=get_read_pod_mock(["Pending", "Pending", "Pending", "Pending"]))
+@mock.patch(
+    READ_NAMESPACED_POD_PATH, new=get_read_pod_mock_phases(["Pending", "Pending", "Pending", "Pending"])
+)
 @mock.patch("kubernetes_asyncio.config.load_kube_config")
 async def test_pending_timeout(load_kube_config):
     """Verify that PodLaunchTimeoutException is yielded when timeout reached"""
@@ -101,7 +123,7 @@ async def test_other_exception(load_kube_config, read_mock):
 
 
 @pytest.mark.asyncio
-@mock.patch(READ_NAMESPACED_POD_PATH, new=get_read_pod_mock(["Pending", "Succeeded"]))
+@mock.patch(READ_NAMESPACED_POD_PATH, new=get_read_pod_mock_phases(["Pending", "Succeeded"]))
 @mock.patch(f"{TRIGGER_CLASS}.wait_for_container_completion")
 @mock.patch("kubernetes_asyncio.config.load_kube_config")
 async def test_pending_succeeded(load_kube_config, wait_completion):
@@ -122,7 +144,7 @@ async def test_pending_succeeded(load_kube_config, wait_completion):
 
 
 @pytest.mark.asyncio
-@mock.patch(READ_NAMESPACED_POD_PATH, new=get_read_pod_mock(["Pending", "Running"]))
+@mock.patch(READ_NAMESPACED_POD_PATH, new=get_read_pod_mock_phases(["Pending", "Running"]))
 @mock.patch(f"{TRIGGER_CLASS}.wait_for_container_completion")
 @mock.patch("kubernetes_asyncio.config.load_kube_config")
 async def test_pending_running(load_kube_config, wait_completion):
@@ -145,7 +167,7 @@ async def test_pending_running(load_kube_config, wait_completion):
 
 
 @pytest.mark.asyncio
-@mock.patch(READ_NAMESPACED_POD_PATH, new=get_read_pod_mock(["Failed"]))
+@mock.patch(READ_NAMESPACED_POD_PATH, new=get_read_pod_mock_phases(["Failed"]))
 @mock.patch(f"{TRIGGER_CLASS}.wait_for_container_completion")
 @mock.patch("kubernetes_asyncio.config.load_kube_config")
 async def test_failed(load_kube_config, wait_completion):
@@ -164,3 +186,35 @@ async def test_failed(load_kube_config, wait_completion):
 
     assert await trigger.run().__anext__() == TriggerEvent({"status": "done"})
     wait_completion.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "logging_interval, exp_event",
+    [
+        param(0, {"status": "running", "last_log_time": DateTime(2022, 1, 1)}, id="short_interval"),
+        param(None, {"status": "done"}, id="no_interval"),
+    ],
+)
+@mock.patch(READ_NAMESPACED_POD_PATH, new=get_read_pod_mock_containers([1, 1, None, None]))
+@mock.patch("kubernetes_asyncio.config.load_kube_config")
+async def test_running_log_inteval(load_kube_config, logging_interval, exp_event):
+    """
+    If log interval given, should emit event with running status and last log time.
+    Otherwise, should should make it to second loop and emit "done" event.
+    For this test we emit container statuses "running running not".
+    The first "running" status gets us out of wait_for_pod_start.
+    The second "running" will fire a "running" event when logging interval is non-None.  When logging
+    interval is None, the second "running" status will just result in continuation of the loop.  And
+    when in the next loop we get a non-running status, the trigger fires a "done" event.
+    """
+    trigger = WaitContainerTrigger(
+        pod_name=mock.ANY,
+        pod_namespace=mock.ANY,
+        container_name=mock.ANY,
+        pending_phase_timeout=5,
+        poll_interval=1,
+        logging_interval=logging_interval,
+        last_log_time=DateTime(2022, 1, 1),
+    )
+    assert await trigger.run().__anext__() == TriggerEvent(exp_event)


### PR DESCRIPTION
This PR modifies Async KPO to periodicall resume the sync portion of the task to fetch and emit the latest logs before deferring again.  

To control this behavior a new param is added: `logging_interval`.  If `None` then Async KPO operates as it did before, never resuming the sync task until the pod is done running.  If logging_interval is given a value (integer seconds) then the trigger will resume every `logging_interval` seconds to fetch latest logs and defer again (until pod is done).

Here's a task example you can test this with:

```python
test_kubernetes_pod = KubernetesPodOperatorAsync(
    namespace='airflow',
    image='python:3.8-slim',
    cmds=[
        "bash",
        "-cx",
        (
            "i=0; "
            "while [ $i -ne 30 ]; "
            "do i=$(($i+1)); "
            "echo $i; "
            "sleep 1; "
            "done; "
            "mkdir -p /airflow/xcom/; "
            "echo '{\"message\": \"good afternoon!\"}' > /airflow/xcom/return.json"
        ),
    ],
    name="test_kubernetes_pod",
    in_cluster=False,
    task_id="test_kubernetes_pod",
    logging_interval=10,
    dag=dag,
    is_delete_operator_pod=False,
    # do_xcom_push=True,
)
```
