### PR TITLE
Fix Databricks triggerer fails to check databricks job state

### DIFF
--- a/astronomer/providers/databricks/hooks/databricks.py
+++ b/astronomer/providers/databricks/hooks/databricks.py
@@ -118,7 +118,7 @@ class DatabricksHookAsync(DatabricksHook):
                     if not self._retryable_error_async(e):
                         # In this case, the user probably made a mistake.
                         # Don't retry.
-                        return f"Response: {e.message}, Status Code: {e.status}"
+                        return {"Response": {e.message}, "Status Code": {e.status}}
                     self._log_request_error(attempt_num, str(e))
 
                 if attempt_num == self.retry_limit:

--- a/astronomer/providers/databricks/hooks/databricks.py
+++ b/astronomer/providers/databricks/hooks/databricks.py
@@ -118,7 +118,7 @@ class DatabricksHookAsync(DatabricksHook):
                     if not self._retryable_error_async(e):
                         # In this case, the user probably made a mistake.
                         # Don't retry.
-                        raise AirflowException(f"Response: {e.message}, Status Code: {e.status}")
+                        return cast(Dict[str, Any], await response.json())
                     self._log_request_error(attempt_num, str(e))
 
                 if attempt_num == self.retry_limit:

--- a/astronomer/providers/databricks/hooks/databricks.py
+++ b/astronomer/providers/databricks/hooks/databricks.py
@@ -118,7 +118,7 @@ class DatabricksHookAsync(DatabricksHook):
                     if not self._retryable_error_async(e):
                         # In this case, the user probably made a mistake.
                         # Don't retry.
-                        return cast(Dict[str, Any], await response.json())
+                        return f"Response: {e.message}, Status Code: {e.status}"
                     self._log_request_error(attempt_num, str(e))
 
                 if attempt_num == self.retry_limit:

--- a/astronomer/providers/databricks/hooks/databricks.py
+++ b/astronomer/providers/databricks/hooks/databricks.py
@@ -87,7 +87,7 @@ class DatabricksHookAsync(DatabricksHook):
             auth_str = f"{self.databricks_conn.login}:{self.databricks_conn.password}"
             encoded_bytes = auth_str.encode("utf-8")
             auth = base64.b64encode(encoded_bytes).decode("utf-8")
-            headers["Authorization"] = f"Basic: {auth}"
+            headers["Authorization"] = f"Basic {auth}"
             host = self.databricks_conn.host
             self.log.info(f"auth: {auth}")
             self.log.info(f"host: {host}")

--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any
 
+from airflow.exceptions import AirflowException
 from airflow.providers.databricks.operators.databricks import (
     XCOM_RUN_ID_KEY,
     XCOM_RUN_PAGE_URL_KEY,
@@ -54,6 +55,8 @@ class DatabricksSubmitRunOperatorAsync(DatabricksSubmitRunOperator):  # noqa: D1
         Relies on trigger to throw an exception, otherwise it assumes execution was
         successful.
         """
+        if event["status"] == "error":
+            raise AirflowException(event["message"])
         self.log.info("%s completed successfully.", self.task_id)
         return None
 

--- a/tests/databricks/hooks/test_databricks.py
+++ b/tests/databricks/hooks/test_databricks.py
@@ -139,10 +139,9 @@ async def test_do_api_call_async_non_retryable_error(aioresponse):
         status=400,
     )
 
-    with pytest.raises(AirflowException) as exc:
-        await hook._do_api_call_async(GET_RUN_ENDPOINT, params)
+    response = await hook._do_api_call_async(GET_RUN_ENDPOINT, params)
 
-    assert str(exc.value) == "Response: Bad Request, Status Code: 400"
+    assert response == {"Response": {"Bad Request"}, "Status Code": {400}}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Remove the colon in the auth header in the hooks. The issue was that the authentication header is malformed.

`Basic: <credential>`

There should not be a colon in the header.
`Basic <credential>`

- Propagate the error message from triggerer to work in case life_cycle_state: `TERMINATED`, `SKIPPED` or `INTERNAL_ERROR`.
- Update the tests



Closes: #143 