### PR TITLE
Bump to Release 1.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+1.1.0 (2022-03-23)
+--------------------
+
+Improvements
+"""""""""""""
+
+This release fixes a bug on the Async Databricks Triggerer failing due to malformed authentication
+header along with improved exception handling to send the Triggerer errors back to the worker to understand
+why a particular job execution has failed.
+
+
+
 1.1.0a2 (2022-03-19)
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,22 +4,10 @@ Changelog
 1.1.0 (2022-03-23)
 --------------------
 
-Improvements
-"""""""""""""
-
-This release fixes a bug on the Async Databricks Triggerer failing due to malformed authentication
-header along with improved exception handling to send the Triggerer errors back to the worker to understand
-why a particular job execution has failed.
-
-
-
-1.1.0a2 (2022-03-19)
---------------------
-
 New Operators
 """""""""""""
 
-This release adds the following 6 new async sensors/operators:
+This release adds the following 7 new async sensors/operators:
 
 .. list-table::
    :header-rows: 1
@@ -50,19 +38,27 @@ This release adds the following 6 new async sensors/operators:
      - .. code-block:: python
 
         from astronomer.providers.google.cloud.sensors.gcs import GCSObjectsWithPrefixExistenceSensorAsync
-     - `Example DAG <https://github.com/astronomer/astronomer-providers/blob/main//Users/kaxilnaik/Documents/GitHub/astronomer/astronomer-providers/astronomer/providers/google/cloud/example_dags/example_gcs.py>`__
+     - `Example DAG <https://github.com/astronomer/astronomer-providers/blob/main/astronomer/providers/google/cloud/example_dags/example_gcs.py>`__
 
    * - ``GCSObjectUpdateSensorAsync``
      - .. code-block:: python
 
         from astronomer.providers.google.cloud.sensors.gcs import GCSObjectUpdateSensorAsync
-     - `Example DAG <https://github.com/astronomer/astronomer-providers/blob/main//Users/kaxilnaik/Documents/GitHub/astronomer/astronomer-providers/astronomer/providers/google/cloud/example_dags/example_gcs.py>`__
+     - `Example DAG <https://github.com/astronomer/astronomer-providers/blob/main/astronomer/providers/google/cloud/example_dags/example_gcs.py>`__
 
    * - ``GCSUploadSessionCompleteSensorAsync``
      - .. code-block:: python
 
         from astronomer.providers.google.cloud.sensors.gcs import GCSUploadSessionCompleteSensorAsync
-     - `Example DAG <https://github.com/astronomer/astronomer-providers/blob/main//Users/kaxilnaik/Documents/GitHub/astronomer/astronomer-providers/astronomer/providers/google/cloud/example_dags/example_gcs.py>`__
+     - `Example DAG <https://github.com/astronomer/astronomer-providers/blob/main/astronomer/providers/google/cloud/example_dags/example_gcs.py>`__
+
+   * - ``BigQueryTableExistenceSensorAsync``
+     - .. code-block:: python
+
+        from astronomer.providers.google.cloud.sensors.bigquery import BigQueryTableExistenceSensorAsync
+     - `Example DAG <https://github.com/astronomer/astronomer-providers/blob/main/astronomer/providers/google/cloud/example_dags/example_bigquery_sensors.py>`__
+
+
 
 Improvements
 """"""""""""
@@ -100,6 +96,10 @@ The dependencies for installing this repo are now split into multiple extras as 
 This will allow users to just install dependencies of a single provider. For example, if a user
 wants to just use ``KubernetesPodOperatorAsync``, they should not need to install GCP, AWS or
 Snowflake dependencies by running ``pip install 'astronomer-providers[cncf.kubernetes]'``.
+
+This release also fixes a bug on the Async Databricks Triggerer failing due to malformed authentication
+header along with improved exception handling to send the Triggerer errors back to the worker to understand
+why a particular job execution has failed.
 
 1.0.0 (2022-03-01)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -97,9 +97,12 @@ This will allow users to just install dependencies of a single provider. For exa
 wants to just use ``KubernetesPodOperatorAsync``, they should not need to install GCP, AWS or
 Snowflake dependencies by running ``pip install 'astronomer-providers[cncf.kubernetes]'``.
 
-This release also fixes a bug on the Async Databricks Triggerer failing due to malformed authentication
-header along with improved exception handling to send the Triggerer errors back to the worker to understand
-why a particular job execution has failed.
+Bug Fixes
+"""""""""
+
+* Fixes a bug on the **Async Databricks Triggerer** failing due to malformed authentication
+  header along with improved exception handling to send the Triggerer errors back to the worker to understand
+  why a particular job execution has failed. (`#147 <https://github.com/astronomer/astronomer-providers/pull/147>`_)
 
 1.0.0 (2022-03-01)
 ------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ project = "Astronomer Providers"
 author = "Astronomer Inc."
 
 # The full version, including alpha/beta/rc tags
-release = "1.1.0a2"
+release = "1.1.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = astronomer-providers
-version = 1.1.0a2
+version = 1.1.0
 url = https://github.com/astronomer/astronomer-providers/
 author = Astronomer
 author_email = humans@astronomer.io


### PR DESCRIPTION
This PR includes changes for the Astronomer Providers Release 1.1.0 and includes the below items:

- Databricks triggerer fails to check databricks job state
- Improved exception handling on the Async Databricks Operator
- Documentation changes for the release

Closes #148