### PR TITLE
Fix docstrings for ``BigQueryTableExistenceSensorAsync``

### DIFF
--- a/astronomer/providers/google/cloud/sensors/bigquery.py
+++ b/astronomer/providers/google/cloud/sensors/bigquery.py
@@ -12,27 +12,28 @@ from astronomer.providers.google.cloud.triggers.bigquery import (
 class BigQueryTableExistenceSensorAsync(BigQueryTableExistenceSensor):
     """
     Checks for the existence of a table in Google Big Query.
-     :param project_id: The Google cloud project in which to look for the table.
-        The connection supplied to the hook must provide
-        access to the specified project.
-     :param dataset_id: The name of the dataset in which to look for the table.
-        storage bucket.
-     :param table_id: The name of the table to check the existence of.
-     :param gcp_conn_id: The connection ID used to connect to Google Cloud.
-     :param bigquery_conn_id: (Deprecated) The connection ID used to connect to Google Cloud.
-        This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
-     :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
-     :param impersonation_chain: Optional service account to impersonate using short-term
-        credentials, or chained list of accounts required to get the access_token
-        of the last account in the list, which will be impersonated in the request.
-        If set as a string, the account must grant the originating account
-        the Service Account Token Creator IAM role.
-        If set as a sequence, the identities from the list must grant
-        Service Account Token Creator IAM role to the directly preceding identity, with first
-        account from the list granting this role to the originating account (templated).
-     :param polling_interval: The interval in seconds to wait between checks table existence.
+
+    :param project_id: The Google cloud project in which to look for the table.
+       The connection supplied to the hook must provide
+       access to the specified project.
+    :param dataset_id: The name of the dataset in which to look for the table.
+       storage bucket.
+    :param table_id: The name of the table to check the existence of.
+    :param gcp_conn_id: The connection ID used to connect to Google Cloud.
+    :param bigquery_conn_id: (Deprecated) The connection ID used to connect to Google Cloud.
+       This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+       if any. For this to work, the service account making the request must have
+       domain-wide delegation enabled.
+    :param impersonation_chain: Optional service account to impersonate using short-term
+       credentials, or chained list of accounts required to get the access_token
+       of the last account in the list, which will be impersonated in the request.
+       If set as a string, the account must grant the originating account
+       the Service Account Token Creator IAM role.
+       If set as a sequence, the identities from the list must grant
+       Service Account Token Creator IAM role to the directly preceding identity, with first
+       account from the list granting this role to the originating account (templated).
+    :param polling_interval: The interval in seconds to wait between checks table existence.
     """
 
     def __init__(


### PR DESCRIPTION
This PR/commit fixes docstrings so they are rendered correctly in Sphinx.

**Before**:

<img width="809" alt="image" src="https://user-images.githubusercontent.com/8811558/159715408-a8de3fc7-8ebc-4e88-b048-289b6f70f6bd.png">


**After**:

<img width="698" alt="image" src="https://user-images.githubusercontent.com/8811558/159716047-6c01eb45-ecee-459a-af4c-4ef0aef33ed9.png">
