### PR TITLE
Bug fix on  example_bigquery_sensors.py dag

### DIFF
--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_sensors.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_sensors.py
@@ -38,7 +38,7 @@ dag_id = "example_bigquery_sensors"
 
 with DAG(
     dag_id,
-    schedule_interval="None",  # Override to match your needs
+    schedule_interval=None,  # Override to match your needs
     start_date=datetime(2021, 1, 1),
     catchup=False,
     tags=["example", "async", "bigquery", "sensors"],


### PR DESCRIPTION
This PR fixes a bug on example_bigquery_sensors.py where schedule interval was set to string none rather than type None.