### PR TITLE
RedshiftClusterSensorAsync timeout fix and S3 conn name change 

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -29,7 +29,7 @@ with DAG(
         task_id="pause_redshift_cluster",
         cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
         aws_conn_id=AWS_CONN_ID,
-        execution_timeout=timedelta(seconds=60),
+        execution_timeout=timedelta(minutes=15),
     )
     # [END howto_operator_redshift_pause_cluster_async]
 
@@ -38,7 +38,7 @@ with DAG(
         task_id="resume_redshift_cluster",
         cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
         aws_conn_id=AWS_CONN_ID,
-        execution_timeout=timedelta(seconds=60),
+        execution_timeout=timedelta(minutes=15),
     )
     # [END howto_operator_redshift_resume_cluster_async]
 
@@ -48,7 +48,7 @@ with DAG(
         cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
         target_status="available",
         aws_conn_id=AWS_CONN_ID,
-        execution_timeout=timedelta(seconds=60),
+        execution_timeout=timedelta(minutes=15),
     )
     # [START howto_operator_redshift_cluster_sensor_async]
 

--- a/astronomer/providers/amazon/aws/example_dags/example_s3.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_s3.py
@@ -29,7 +29,7 @@ PREFIX = os.environ.get("S3_PREFIX", "test")
 INACTIVITY_PERIOD = float(os.environ.get("INACTIVITY_PERIOD", 5))
 REGION_NAME = os.environ.get("REGION_NAME", "us-east-2")
 LOCAL_FILE_PATH = os.environ.get("LOCAL_FILE_PATH", "/usr/local/airflow/dags/example_s3_test_file.txt")
-AWS_CONN_ID = os.environ.get("ASTRO_AWS_CONN_ID", "aws_default")
+AWS_CONN_ID = os.environ.get("ASTRO_AWS_S3_CONN_ID", "aws_s3_default")
 
 with DAG(
     dag_id="example_s3_sensor",


### PR DESCRIPTION
- Increase execution timeout for redshift cluster mgmt from 60 sec to 15 min
- change the s3 connection name default value and env variable name since it was conflicting with the amazon web service connection 