### PR TITLE
Store databricks job_id in xcom for DatabricksSubmitRunOperatorAsync operator

### DIFF
--- a/astronomer/providers/databricks/example_dags/example_databricks.py
+++ b/astronomer/providers/databricks/example_dags/example_databricks.py
@@ -11,21 +11,22 @@ from astronomer.providers.databricks.operators.databricks import (
 )
 
 DATABRICKS_CONN_ID = os.environ.get("ASTRO_DATABRICKS_CONN_ID", "databricks_default")
-DATABRICKS_CLUSTER_ID = os.environ.get("DATABRICKS_CLUSTER_ID", "0806-193014-swab896")
-DATABRICKS_JOB_ID = os.environ.get("DATABRICKS_JOB_ID", "1003")
 # Notebook path as a Json object
-# Example: {"notebook_path": "/Users/andrew.godwin@astronomer.io/quickstart_notebook"}
-notebook_path = '{"notebook_path": "/Users/andrew.godwin@astronomer.io/quickstart_notebook"}'
-NOTEBOOK_TASK = json.loads(os.environ.get("DATABRICKS_NOTEBOOK_TASK", notebook_path))
+# Example: {"notebook_path": "/Users/pankaj.singh@astronomer.io/quick_start"}
+notebook_task = '{"notebook_path": "/Users/pankaj.singh@astronomer.io/quick_start"}'
+NOTEBOOK_TASK = json.loads(os.environ.get("DATABRICKS_NOTEBOOK_TASK", notebook_task))
+notebook_params = {"Variable": 5}
 
 default_args = {
-    "owner": "airflow",
-    "depends_on_past": False,
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "retries": 1,
-    "retry_delay": timedelta(seconds=10),
+    "execution_timeout": timedelta(minutes=10),
 }
+
+new_cluster = {
+    "spark_version": "7.3.x-scala2.12",
+    "num_workers": 2,
+    "node_type_id": "i3en.large",
+}
+
 
 with DAG(
     dag_id="example_async_databricks",
@@ -38,16 +39,16 @@ with DAG(
     opr_submit_run = DatabricksSubmitRunOperatorAsync(
         task_id="submit_run",
         databricks_conn_id=DATABRICKS_CONN_ID,
-        existing_cluster_id=DATABRICKS_CLUSTER_ID,
+        new_cluster=new_cluster,
         notebook_task=NOTEBOOK_TASK,
-        polling_period_seconds=30,
+        do_xcom_push=True,
     )
 
     opr_run_now = DatabricksRunNowOperatorAsync(
         task_id="run_now",
         databricks_conn_id=DATABRICKS_CONN_ID,
-        job_id=DATABRICKS_JOB_ID,
-        polling_period_seconds=30,
+        job_id="{{ task_instance.xcom_pull(task_ids='submit_run', dag_id='example_async_databricks', key='job_id') }}",
+        notebook_params=notebook_params,
     )
 
-    opr_submit_run >> opr_run_now
+opr_submit_run >> opr_run_now

--- a/astronomer/providers/databricks/example_dags/example_databricks.py
+++ b/astronomer/providers/databricks/example_dags/example_databricks.py
@@ -1,6 +1,7 @@
 import json
 import os
 from datetime import timedelta
+from typing import Dict, Optional
 
 from airflow.models.dag import DAG
 from airflow.utils.timezone import datetime
@@ -15,7 +16,7 @@ DATABRICKS_CONN_ID = os.environ.get("ASTRO_DATABRICKS_CONN_ID", "databricks_defa
 # Example: {"notebook_path": "/Users/pankaj.singh@astronomer.io/quick_start"}
 notebook_task = '{"notebook_path": "/Users/pankaj.singh@astronomer.io/quick_start"}'
 NOTEBOOK_TASK = json.loads(os.environ.get("DATABRICKS_NOTEBOOK_TASK", notebook_task))
-notebook_params = {"Variable": 5}
+notebook_params: Optional[Dict[str, str]] = {"Variable": "5"}
 
 default_args = {
     "execution_timeout": timedelta(minutes=10),

--- a/astronomer/providers/databricks/triggers/databricks.py
+++ b/astronomer/providers/databricks/triggers/databricks.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, AsyncIterator, Dict, Tuple
+from typing import Any, AsyncIterator, Dict, Optional, Tuple
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
@@ -15,11 +15,13 @@ class DatabricksTrigger(BaseTrigger):  # noqa: D101
         retry_limit: int,
         retry_delay: int,
         polling_period_seconds: int,
+        job_id: Optional[int] = None,
     ):
         super().__init__()
         self.conn_id = conn_id
         self.task_id = task_id
         self.run_id = run_id
+        self.job_id = job_id
         self.retry_limit = retry_limit
         self.retry_delay = retry_delay
         self.polling_period_seconds = polling_period_seconds
@@ -32,6 +34,7 @@ class DatabricksTrigger(BaseTrigger):  # noqa: D101
                 "conn_id": self.conn_id,
                 "task_id": self.task_id,
                 "run_id": self.run_id,
+                "job_id": self.job_id,
                 "retry_limit": self.retry_limit,
                 "retry_delay": self.retry_delay,
                 "polling_period_seconds": self.polling_period_seconds,
@@ -49,7 +52,7 @@ class DatabricksTrigger(BaseTrigger):  # noqa: D101
             run_state = await hook.get_run_state_async(self.run_id)
             if run_state.is_terminal:
                 if run_state.is_successful:
-                    yield TriggerEvent({"status": "success"})
+                    yield TriggerEvent({"status": "success", "job_id": self.job_id})
                     return
                 else:
                     error_message = f"{self.task_id} failed with terminal state: {run_state}"

--- a/tests/databricks/operators/test_databricks.py
+++ b/tests/databricks/operators/test_databricks.py
@@ -30,14 +30,18 @@ def context():
 
 
 @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.submit_run")
+@mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_job_id")
 @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
-def test_databricks_submit_run_operator_async(submit_run_response, get_run_page_url_response, context):
+def test_databricks_submit_run_operator_async(
+    submit_run_response, get_job_id, get_run_page_url_response, context
+):
     """
     Asserts that a task is deferred and an DatabricksTrigger will be fired
     when the DatabricksSubmitRunOperatorAsync is executed.
     """
     submit_run_response.return_value = {"run_id": RUN_ID}
     get_run_page_url_response.return_value = RUN_PAGE_URL
+    get_job_id.return_value = None
 
     operator = DatabricksSubmitRunOperatorAsync(
         task_id="submit_run",

--- a/tests/databricks/operators/test_databricks.py
+++ b/tests/databricks/operators/test_databricks.py
@@ -1,7 +1,12 @@
+from datetime import datetime
 from unittest import mock
 
 import pytest
+from airflow import DAG
 from airflow.exceptions import AirflowException, TaskDeferred
+from airflow.models.dagrun import DagRun
+from airflow.models.taskinstance import TaskInstance
+from airflow.utils.types import DagRunType
 
 from astronomer.providers.databricks.operators.databricks import (
     DatabricksRunNowOperatorAsync,
@@ -112,6 +117,27 @@ def test_databricks_run_now_execute_complete_error(submit_run_response, get_run_
         operator.execute_complete(context={}, event={"status": "error", "message": "error"})
 
 
+def create_context(task):
+    dag = DAG(dag_id="dag")
+    execution_date = datetime(2022, 1, 1, 0, 0, 0)
+    dag_run = DagRun(
+        dag_id=dag.dag_id,
+        execution_date=execution_date,
+        run_id=DagRun.generate_run_id(DagRunType.MANUAL, execution_date),
+    )
+    task_instance = TaskInstance(task=task)
+    task_instance.dag_run = dag_run
+    task_instance.dag_id = dag.dag_id
+    task_instance.xcom_push = mock.Mock()
+    return {
+        "dag": dag,
+        "run_id": dag_run.run_id,
+        "task": task,
+        "ti": task_instance,
+        "task_instance": task_instance,
+    }
+
+
 @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.submit_run")
 @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
 def test_databricks_run_now_execute_complete_success(submit_run_response, get_run_page_url_response, context):
@@ -128,4 +154,10 @@ def test_databricks_run_now_execute_complete_success(submit_run_response, get_ru
         notebook_task={"notebook_path": "/Users/test@astronomer.io/Quickstart Notebook"},
     )
 
-    assert operator.execute_complete(context={}, event={"status": "success", "message": "success"}) is None
+    assert (
+        operator.execute_complete(
+            context=create_context(operator),
+            event={"status": "success", "message": "success", "job_id": "12345"},
+        )
+        is None
+    )

--- a/tests/databricks/triggers/test_databricks.py
+++ b/tests/databricks/triggers/test_databricks.py
@@ -38,6 +38,7 @@ def test_databricks_trigger_serialization():
         "retry_limit": 2,
         "retry_delay": 1.0,
         "polling_period_seconds": 1.0,
+        "job_id": None,
     }
 
 


### PR DESCRIPTION
Issue: https://github.com/astronomer/astronomer-providers/issues/159
- storing databricks job_id in xcom of DatabricksSubmitRunOperatorAsync operator
- DatabricksSubmitRunOperatorAsync example will now create a new cluster so using `new_cluster` args of operator earlier it was using existing cluster
- DatabricksRunNowOperatorAsync example was earlier dependent on the environment variable for `job_id` now we are getting this from xcom.