### PR TITLE
Add timeout for all DAGs and dataproc and bigquery_sensors

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -101,6 +101,8 @@ with DAG(
     google_task_info = [
         {"bigquery_dag": "example_async_bigquery_queries"},
         {"gcs_sensor_dag": "example_async_gcs_sensors"},
+        {"big_query_sensor_dag": "example_bigquery_sensors"},
+        {"dataproc_dag": "example_gcp_dataproc"},
     ]
     google_trigger_tasks, ids = prepare_dag_dependency(google_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -15,11 +15,16 @@ from astronomer.providers.amazon.aws.sensors.redshift_cluster import (
 REDSHIFT_CLUSTER_IDENTIFIER = os.environ.get("REDSHIFT_CLUSTER_IDENTIFIER", "astro-redshift-cluster-1")
 AWS_CONN_ID = os.environ.get("ASTRO_AWS_CONN_ID", "aws_default")
 
+default_args = {
+    "execution_timeout": timedelta(minutes=30),
+}
+
 with DAG(
     dag_id="example_async_redshift_cluster_management",
     start_date=datetime(2022, 1, 1),
     schedule_interval=None,
     catchup=False,
+    default_args=default_args,
     tags=["example", "async", "redshift"],
 ) as dag:
     start = DummyOperator(task_id="start")
@@ -29,7 +34,6 @@ with DAG(
         task_id="pause_redshift_cluster",
         cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
         aws_conn_id=AWS_CONN_ID,
-        execution_timeout=timedelta(minutes=15),
     )
     # [END howto_operator_redshift_pause_cluster_async]
 
@@ -38,7 +42,6 @@ with DAG(
         task_id="resume_redshift_cluster",
         cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
         aws_conn_id=AWS_CONN_ID,
-        execution_timeout=timedelta(minutes=15),
     )
     # [END howto_operator_redshift_resume_cluster_async]
 
@@ -48,7 +51,6 @@ with DAG(
         cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
         target_status="available",
         aws_conn_id=AWS_CONN_ID,
-        execution_timeout=timedelta(minutes=15),
     )
     # [START howto_operator_redshift_cluster_sensor_async]
 

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from airflow.models.dag import DAG
 
@@ -9,11 +9,16 @@ from astronomer.providers.amazon.aws.operators.redshift_sql import (
 
 REDSHIFT_CONN_ID = os.environ.get("ASTRO_REDSHIFT_CONN_ID", "redshift_default")
 
+default_args = {
+    "execution_timeout": timedelta(minutes=30),
+}
+
 with DAG(
     dag_id="example_async_redshift_sql",
     start_date=datetime(2022, 1, 1),
     schedule_interval=None,
     catchup=False,
+    default_args=default_args,
     tags=["example", "async", "redshift"],
 ) as dag:
     task_create_func = RedshiftSQLOperatorAsync(

--- a/astronomer/providers/amazon/aws/example_dags/example_s3.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_s3.py
@@ -17,11 +17,6 @@ from astronomer.providers.amazon.aws.sensors.s3 import (
     S3PrefixSensorAsync,
 )
 
-default_args = {
-    "retry": 5,
-    "retry_delay": timedelta(minutes=1),
-}
-
 S3_BUCKET_NAME = os.environ.get("S3_BUCKET_NAME", "test-bucket-astronomer-providers")
 S3_BUCKET_KEY = os.environ.get("S3_BUCKET_KEY", "test/example_s3_test_file.txt")
 S3_BUCKET_WILDCARD_KEY = os.environ.get("S3_BUCKET_WILDCARD_KEY", "test*")
@@ -30,6 +25,10 @@ INACTIVITY_PERIOD = float(os.environ.get("INACTIVITY_PERIOD", 5))
 REGION_NAME = os.environ.get("REGION_NAME", "us-east-2")
 LOCAL_FILE_PATH = os.environ.get("LOCAL_FILE_PATH", "/usr/local/airflow/dags/example_s3_test_file.txt")
 AWS_CONN_ID = os.environ.get("ASTRO_AWS_S3_CONN_ID", "aws_s3_default")
+
+default_args = {
+    "execution_timeout": timedelta(minutes=30),
+}
 
 with DAG(
     dag_id="example_s3_sensor",
@@ -60,7 +59,6 @@ with DAG(
         bucket_key=S3_BUCKET_KEY,
         wildcard_match=False,
         bucket_name=S3_BUCKET_NAME,
-        execution_timeout=timedelta(seconds=60),
         aws_conn_id=AWS_CONN_ID,
     )
 
@@ -69,7 +67,6 @@ with DAG(
         bucket_key=S3_BUCKET_WILDCARD_KEY,
         wildcard_match=True,
         bucket_name=S3_BUCKET_NAME,
-        execution_timeout=timedelta(seconds=60),
         aws_conn_id=AWS_CONN_ID,
     )
 
@@ -78,7 +75,6 @@ with DAG(
         bucket_key=S3_BUCKET_KEY,
         wildcard_match=False,
         bucket_name=S3_BUCKET_NAME,
-        execution_timeout=timedelta(seconds=60),
         aws_conn_id=AWS_CONN_ID,
     )
 
@@ -87,7 +83,6 @@ with DAG(
         bucket_key=S3_BUCKET_WILDCARD_KEY,
         wildcard_match=True,
         bucket_name=S3_BUCKET_NAME,
-        execution_timeout=timedelta(seconds=60),
         aws_conn_id=AWS_CONN_ID,
     )
 
@@ -99,7 +94,6 @@ with DAG(
         allow_delete=True,
         previous_objects=set(),
         inactivity_period=INACTIVITY_PERIOD,
-        execution_timeout=timedelta(seconds=60),
         aws_conn_id=AWS_CONN_ID,
     )
 
@@ -107,7 +101,6 @@ with DAG(
         task_id="check_s3_prefix_sensor",
         bucket_name=S3_BUCKET_NAME,
         prefix=PREFIX,
-        execution_timeout=timedelta(seconds=60),
         aws_conn_id=AWS_CONN_ID,
     )
 

--- a/astronomer/providers/cncf/kubernetes/example_dags/example_kubernetes_pod_operator.py
+++ b/astronomer/providers/cncf/kubernetes/example_dags/example_kubernetes_pod_operator.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.configuration import conf
@@ -17,12 +17,16 @@ else:
     in_cluster = True
     config_file = None
 
+default_args = {
+    "execution_timeout": timedelta(minutes=30),
+}
 
 with DAG(
     dag_id="example_kubernetes_operator",
     start_date=datetime(2022, 1, 1),
     schedule_interval=None,
     catchup=False,
+    default_args=default_args,
     tags=["example", "async", "k8s"],
 ) as dag:
     create_k8s_pod = KubernetesPodOperatorAsync(

--- a/astronomer/providers/core/example_dags/example_external_task.py
+++ b/astronomer/providers/core/example_dags/example_external_task.py
@@ -18,11 +18,16 @@ from airflow.utils.timezone import datetime
 
 from astronomer.providers.core.sensors.external_task import ExternalTaskSensorAsync
 
+default_args = {
+    "execution_timeout": timedelta(minutes=30),
+}
+
 with DAG(
     dag_id="test_external_task_async",
     start_date=datetime(2022, 1, 1),
     schedule_interval=None,
     catchup=False,
+    default_args=default_args,
     tags=["example", "async", "core"],
 ) as dag:
     start = DummyOperator(task_id="start")
@@ -32,7 +37,6 @@ with DAG(
         task_id="external_task_async",
         external_task_id="start",
         external_dag_id="test_external_task_async",
-        execution_timeout=timedelta(seconds=60),
     )
     # [END howto_operator_external_task_sensor_async]
 

--- a/astronomer/providers/core/example_dags/example_external_task_wait_for_me.py
+++ b/astronomer/providers/core/example_dags/example_external_task_wait_for_me.py
@@ -3,17 +3,21 @@ from datetime import datetime, timedelta
 from airflow import DAG
 from airflow.sensors.time_sensor import TimeSensorAsync
 
+default_args = {
+    "execution_timeout": timedelta(minutes=30),
+}
+
 with DAG(
     dag_id="test_external_task_async_waits_for_me",
     start_date=datetime(2022, 1, 1),
     schedule_interval=None,
     catchup=False,
+    default_args=default_args,
     tags=["example", "async", "core"],
 ) as dag:
     # [START howto_operator_time_sensor_async]
     wait_for_me = TimeSensorAsync(
         task_id="wait_for_me",
         target_time=(datetime.utcnow() + timedelta(seconds=3)).time(),
-        execution_timeout=timedelta(seconds=60),
     )
     # [START howto_operator_time_sensor_async]

--- a/astronomer/providers/core/example_dags/example_file_sensor.py
+++ b/astronomer/providers/core/example_dags/example_file_sensor.py
@@ -8,11 +8,16 @@ from astronomer.providers.core.sensors.filesystem import FileSensorAsync
 
 FS_CONN_ID = os.environ.get("ASTRO_FS_CONN_ID", "fs_default")
 
+default_args = {
+    "execution_timeout": timedelta(minutes=30),
+}
+
 with DAG(
     dag_id="example_async_file_sensor",
     start_date=datetime(2022, 1, 1),
     schedule_interval=None,
     catchup=False,
+    default_args=default_args,
     tags=["example", "async", "core"],
 ) as dag:
     # [START howto_operator_file_sensor_async]
@@ -20,6 +25,5 @@ with DAG(
         task_id="file_sensor_task",
         filepath="example_file_async_sensor.txt",
         fs_conn_id=FS_CONN_ID,
-        execution_timeout=timedelta(seconds=60),
     )
     # [END howto_operator_file_sensor_async]

--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py
@@ -3,7 +3,7 @@ Example Airflow DAG for Google BigQuery service.
 Uses Async version of BigQueryInsertJobOperator and BigQueryCheckOperator.
 """
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
@@ -43,12 +43,16 @@ INSERT_ROWS_QUERY = (
     f"(42, 'fishy fish', '{INSERT_DATE}');"
 )
 
+default_args = {
+    "execution_timeout": timedelta(minutes=30),
+}
 
 with DAG(
     dag_id="example_async_bigquery_queries",
     schedule_interval=None,
     start_date=datetime(2022, 1, 1),
     catchup=False,
+    default_args=default_args,
     tags=["example", "async", "bigquery"],
     user_defined_macros={"DATASET": DATASET, "TABLE": TABLE_1},
 ) as dag:

--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_sensors.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_sensors.py
@@ -1,6 +1,6 @@
 """Example Airflow DAG for Google BigQuery Sensors."""
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.providers.google.cloud.operators.bigquery import (
@@ -34,15 +34,15 @@ SCHEMA = [
     {"name": "ds", "type": "DATE", "mode": "NULLABLE"},
 ]
 
-dag_id = "example_bigquery_sensors"
+default_args = {"execution_timeout": timedelta(minutes=15), "gcp_conn_id": GCP_CONN_ID}
 
 with DAG(
-    dag_id,
+    dag_id="example_bigquery_sensors",
     schedule_interval=None,  # Override to match your needs
     start_date=datetime(2021, 1, 1),
     catchup=False,
+    default_args=default_args,
     tags=["example", "async", "bigquery", "sensors"],
-    default_args={"gcp_conn_id": GCP_CONN_ID},
 ) as dag:
 
     create_dataset = BigQueryCreateEmptyDatasetOperator(

--- a/astronomer/providers/google/cloud/example_dags/example_dataproc.py
+++ b/astronomer/providers/google/cloud/example_dags/example_dataproc.py
@@ -1,7 +1,7 @@
 """Example Airflow DAG that shows how to use DataprocSubmitJobOperatorAsync."""
 
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from airflow import models
 from airflow.providers.google.cloud.operators.dataproc import (
@@ -142,12 +142,18 @@ WORKFLOW_TEMPLATE = {
     "jobs": [{"step_id": "pig_job_1", "pig_job": PIG_JOB["pig_job"]}],
 }
 
+default_args = {
+    "execution_timeout": timedelta(minutes=30),
+}
+
 
 with models.DAG(
-    "example_gcp_dataproc",
-    schedule_interval="@once",
+    dag_id="example_gcp_dataproc",
+    schedule_interval=None,
     start_date=datetime(2021, 1, 1),
     catchup=False,
+    default_args=default_args,
+    tags=["example", "async", "dataproc"],
 ) as dag:
     # [START how_to_cloud_dataproc_create_cluster_operator]
     create_cluster = DataprocCreateClusterOperator(

--- a/astronomer/providers/google/cloud/example_dags/example_gcs.py
+++ b/astronomer/providers/google/cloud/example_dags/example_gcs.py
@@ -26,12 +26,16 @@ PATH_TO_UPLOAD_FILE = "dags/example_gcs.py"
 PATH_TO_UPLOAD_FILE_PREFIX = "example_"
 BUCKET_FILE_LOCATION = "example_gcs.py"
 
+default_args = {
+    "execution_timeout": timedelta(minutes=30),
+}
 
 with DAG(
     "example_async_gcs_sensors",
     start_date=datetime(2022, 1, 1),
     schedule_interval=None,
     catchup=False,
+    default_args=default_args,
     tags=["example", "async", "gcs"],
 ) as dag:
     # [START howto_create_bucket_task]
@@ -66,7 +70,6 @@ with DAG(
         bucket=BUCKET_1,
         object=BUCKET_FILE_LOCATION,
         task_id="gcs_object_exists_task",
-        execution_timeout=timedelta(seconds=60),
         google_cloud_conn_id=GCP_CONN_ID,
     )
     # [END howto_sensor_object_exists_task]
@@ -75,7 +78,6 @@ with DAG(
         bucket=BUCKET_1,
         prefix=PATH_TO_UPLOAD_FILE_PREFIX,
         task_id="gcs_object_with_prefix_exists_task",
-        execution_timeout=timedelta(seconds=60),
         google_cloud_conn_id=GCP_CONN_ID,
     )
     # [END howto_sensor_object_with_prefix_exists_task]
@@ -88,7 +90,6 @@ with DAG(
         allow_delete=True,
         previous_objects=set(),
         task_id="gcs_upload_session_complete_task",
-        execution_timeout=timedelta(seconds=60),
         google_cloud_conn_id=GCP_CONN_ID,
     )
     # [END howto_sensor_gcs_upload_session_complete_task]
@@ -97,7 +98,6 @@ with DAG(
         bucket=BUCKET_1,
         object=BUCKET_FILE_LOCATION,
         task_id="gcs_object_update_sensor_task_async",
-        execution_timeout=timedelta(seconds=60),
         google_cloud_conn_id=GCP_CONN_ID,
     )
     # [END howto_sensor_object_update_exists_task]

--- a/astronomer/providers/http/example_dags/example_http.py
+++ b/astronomer/providers/http/example_dags/example_http.py
@@ -8,11 +8,17 @@ from astronomer.providers.http.sensors.http import HttpSensorAsync
 
 HTTP_CONN_ID = os.environ.get("ASTRO_HTTP_CONN_ID", "http_default")
 
+default_args = {
+    "execution_timeout": timedelta(minutes=30),
+}
+
+
 with DAG(
     dag_id="example_async_http_sensor",
     start_date=datetime(2022, 1, 1),
     schedule_interval=None,
     catchup=False,
+    default_args=default_args,
     tags=["example", "async", "http"],
 ) as dag:
     # [START howto_operator_http_sensor_async]
@@ -24,7 +30,6 @@ with DAG(
         # TODO response_check is currently not supported
         # response_check=lambda response: "httpbin" in response.text,
         poke_interval=5,
-        execution_timeout=timedelta(seconds=60),
     )
     # [START howto_operator_file_sensor_async]
 

--- a/astronomer/providers/snowflake/example_dags/example_snowflake.py
+++ b/astronomer/providers/snowflake/example_dags/example_snowflake.py
@@ -1,6 +1,7 @@
 """Example use of SnowflakeAsync related providers."""
 
 import os
+from datetime import timedelta
 
 from airflow import DAG
 from airflow.utils.timezone import datetime
@@ -22,11 +23,13 @@ SNOWFLAKE_SLACK_MESSAGE = (
     "Results in an ASCII table:\n```{{ results_df | tabulate(tablefmt='pretty', headers='keys') }}```"
 )
 
+default_args = {"execution_timeout": timedelta(minutes=30), "snowflake_conn_id": SNOWFLAKE_CONN_ID}
+
 with DAG(
     dag_id="example_snowflake",
     start_date=datetime(2022, 1, 1),
     schedule_interval=None,
-    default_args={"snowflake_conn_id": SNOWFLAKE_CONN_ID},
+    default_args=default_args,
     tags=["example", "async", "snowflake"],
     catchup=False,
 ) as dag:


### PR DESCRIPTION
Related issue: https://github.com/astronomer/astronomer-providers/issues/63
Cleanup example by adding execution_timeout in default_args in dags and removed from individual operator/sensor since now all the operator/sensor have execution_timeout
- Add execution_timeout for all examples DAG
- Included dataproc and bigquery_sensors in master DAG