### PR TITLE
Persist Databricks xcom value

### DIFF
--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -44,6 +44,7 @@ class DatabricksSubmitRunOperatorAsync(DatabricksSubmitRunOperator):  # noqa: D1
                 task_id=self.task_id,
                 run_id=str(self.run_id),
                 job_id=job_id,
+                run_page_url=self.run_page_url,
                 retry_limit=self.databricks_retry_limit,
                 retry_delay=self.databricks_retry_delay,
                 polling_period_seconds=self.polling_period_seconds,
@@ -62,6 +63,10 @@ class DatabricksSubmitRunOperatorAsync(DatabricksSubmitRunOperator):  # noqa: D1
         self.log.info("%s completed successfully.", self.task_id)
         if event.get("job_id"):
             context["ti"].xcom_push(key="job_id", value=event["job_id"])
+
+        if self.do_xcom_push:
+            context["ti"].xcom_push(key=XCOM_RUN_ID_KEY, value=event.get("run_id"))
+            context["ti"].xcom_push(key=XCOM_RUN_PAGE_URL_KEY, value=event.get("run_page_url"))
 
 
 class DatabricksRunNowOperatorAsync(DatabricksRunNowOperator):  # noqa: D101
@@ -92,6 +97,7 @@ class DatabricksRunNowOperatorAsync(DatabricksRunNowOperator):  # noqa: D101
                 task_id=self.task_id,
                 conn_id=self.databricks_conn_id,
                 run_id=str(self.run_id),
+                run_page_url=self.run_page_url,
                 retry_limit=self.databricks_retry_limit,
                 retry_delay=self.databricks_retry_delay,
                 polling_period_seconds=self.polling_period_seconds,
@@ -108,4 +114,7 @@ class DatabricksRunNowOperatorAsync(DatabricksRunNowOperator):  # noqa: D101
         successful.
         """
         self.log.info("%s completed successfully.", self.task_id)
+        if self.do_xcom_push:
+            context["ti"].xcom_push(key=XCOM_RUN_ID_KEY, value=event.get("run_id"))
+            context["ti"].xcom_push(key=XCOM_RUN_PAGE_URL_KEY, value=event.get("run_page_url"))
         return None

--- a/astronomer/providers/databricks/triggers/databricks.py
+++ b/astronomer/providers/databricks/triggers/databricks.py
@@ -16,12 +16,14 @@ class DatabricksTrigger(BaseTrigger):  # noqa: D101
         retry_delay: int,
         polling_period_seconds: int,
         job_id: Optional[int] = None,
+        run_page_url: Optional[str] = None,
     ):
         super().__init__()
         self.conn_id = conn_id
         self.task_id = task_id
         self.run_id = run_id
         self.job_id = job_id
+        self.run_page_url = run_page_url
         self.retry_limit = retry_limit
         self.retry_delay = retry_delay
         self.polling_period_seconds = polling_period_seconds
@@ -35,6 +37,7 @@ class DatabricksTrigger(BaseTrigger):  # noqa: D101
                 "task_id": self.task_id,
                 "run_id": self.run_id,
                 "job_id": self.job_id,
+                "run_page_url": self.run_page_url,
                 "retry_limit": self.retry_limit,
                 "retry_delay": self.retry_delay,
                 "polling_period_seconds": self.polling_period_seconds,
@@ -52,7 +55,14 @@ class DatabricksTrigger(BaseTrigger):  # noqa: D101
             run_state = await hook.get_run_state_async(self.run_id)
             if run_state.is_terminal:
                 if run_state.is_successful:
-                    yield TriggerEvent({"status": "success", "job_id": self.job_id})
+                    yield TriggerEvent(
+                        {
+                            "status": "success",
+                            "job_id": self.job_id,
+                            "run_id": self.run_id,
+                            "run_page_url": self.run_page_url,
+                        }
+                    )
                     return
                 else:
                     error_message = f"{self.task_id} failed with terminal state: {run_state}"

--- a/tests/databricks/operators/test_databricks.py
+++ b/tests/databricks/operators/test_databricks.py
@@ -90,10 +90,11 @@ def test_databricks_run_now_execute_complete():
     operator = DatabricksRunNowOperatorAsync(
         task_id=TASK_ID,
         databricks_conn_id=CONN_ID,
+        do_xcom_push=True,
     )
     operator.run_page_url = RUN_PAGE_URL
     with mock.patch.object(operator.log, "info") as mock_log_info:
-        operator.execute_complete({})
+        operator.execute_complete(create_context(operator), {})
     mock_log_info.assert_called_with("%s completed successfully.", "databricks_check")
 
 
@@ -152,12 +153,19 @@ def test_databricks_run_now_execute_complete_success(submit_run_response, get_ru
         databricks_conn_id=CONN_ID,
         existing_cluster_id="xxxx-xxxxxx-xxxxxx",
         notebook_task={"notebook_path": "/Users/test@astronomer.io/Quickstart Notebook"},
+        do_xcom_push=True,
     )
 
     assert (
         operator.execute_complete(
             context=create_context(operator),
-            event={"status": "success", "message": "success", "job_id": "12345"},
+            event={
+                "status": "success",
+                "message": "success",
+                "job_id": "12345",
+                "run_id": RUN_ID,
+                "run_page_url": RUN_PAGE_URL,
+            },
         )
         is None
     )

--- a/tests/databricks/triggers/test_databricks.py
+++ b/tests/databricks/triggers/test_databricks.py
@@ -39,6 +39,7 @@ def test_databricks_trigger_serialization():
         "retry_delay": 1.0,
         "polling_period_seconds": 1.0,
         "job_id": None,
+        "run_page_url": None,
     }
 
 


### PR DESCRIPTION
Issue: https://github.com/astronomer/astronomer-providers/issues/167

- Pushing xcom values in in `execute_complete()` method for both DatabricksRunNowOperatorAsync and DatabricksSubmitRunOperatorAsync.
- Keeping the logic as it is in `execute` method so that value would be available also during execution