### PR TITLE
Add `EmrStepSensorAsync`

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -93,7 +93,7 @@ with DAG(
         {"s3_sensor_dag": "example_s3_sensor"},
         {"redshift_sql_dag": "example_async_redshift_sql"},
         {"redshift_cluster_mgmt_dag": "example_async_redshift_cluster_management"},
-        {"emr_cluster_dag": "example_emr_job_flow_manual_steps"},
+        {"emr_cluster_dag": "example_emr_step_sensor"},
     ]
     amazon_trigger_tasks, ids = prepare_dag_dependency(amazon_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)

--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -93,6 +93,7 @@ with DAG(
         {"s3_sensor_dag": "example_s3_sensor"},
         {"redshift_sql_dag": "example_async_redshift_sql"},
         {"redshift_cluster_mgmt_dag": "example_async_redshift_cluster_management"},
+        {"emr_cluster_dag": "example_emr_job_flow_manual_steps"},
     ]
     amazon_trigger_tasks, ids = prepare_dag_dependency(amazon_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)

--- a/astronomer/providers/amazon/aws/example_dags/example_emr_job_flow_manual_steps.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_job_flow_manual_steps.py
@@ -1,0 +1,104 @@
+"""Example DAG for AWS EMR related operator and sensor"""
+
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.models.baseoperator import chain
+from airflow.providers.amazon.aws.operators.emr import (
+    EmrAddStepsOperator,
+    EmrCreateJobFlowOperator,
+    EmrTerminateJobFlowOperator,
+)
+
+from astronomer.providers.amazon.aws.sensors.emr import EmrStepSensorAsync
+
+JOB_FLOW_ROLE = os.getenv("EMR_JOB_FLOW_ROLE", "EMR_EC2_DefaultRole")
+SERVICE_ROLE = os.getenv("EMR_SERVICE_ROLE", "EMR_DefaultRole")
+AWS_CONN_ID = os.getenv("ASTRO_AWS_CONN_ID", "aws_default")
+EMR_CONN_ID = os.getenv("ASTRO_EMR_CONN_ID", "emr_default")
+
+
+SPARK_STEPS = [
+    {
+        "Name": "calculate_pi",
+        "ActionOnFailure": "CONTINUE",
+        "HadoopJarStep": {
+            "Jar": "command-runner.jar",
+            "Args": ["/usr/lib/spark/bin/run-example", "SparkPi", "10"],
+        },
+    }
+]
+
+JOB_FLOW_OVERRIDES = {
+    "Name": "PiCalc",
+    "ReleaseLabel": "emr-5.29.0",
+    "Applications": [{"Name": "Spark"}],
+    "Instances": {
+        "InstanceGroups": [
+            {
+                "Name": "Primary node",
+                "Market": "ON_DEMAND",
+                "InstanceRole": "MASTER",
+                "InstanceType": "m4.large",
+                "InstanceCount": 1,
+            },
+        ],
+        "KeepJobFlowAliveWhenNoSteps": False,
+        "TerminationProtected": False,
+    },
+    "JobFlowRole": JOB_FLOW_ROLE,
+    "ServiceRole": SERVICE_ROLE,
+}
+
+DEFAULT_ARGS = {
+    "execution_timeout": timedelta(minutes=30),
+}
+
+with DAG(
+    dag_id="example_emr_job_flow_manual_steps",
+    schedule_interval=None,
+    start_date=datetime(2022, 1, 1),
+    default_args=DEFAULT_ARGS,
+    tags=["example", "async", "emr"],
+    catchup=False,
+) as dag:
+
+    cluster_creator = EmrCreateJobFlowOperator(
+        task_id="create_job_flow",
+        job_flow_overrides=JOB_FLOW_OVERRIDES,
+        emr_conn_id=EMR_CONN_ID,
+    )
+
+    # [START howto_operator_emr_add_steps]
+    step_adder = EmrAddStepsOperator(
+        task_id="add_steps",
+        job_flow_id=cluster_creator.output,
+        steps=SPARK_STEPS,
+        aws_conn_id=AWS_CONN_ID,
+    )
+    # [END howto_operator_emr_add_steps]
+
+    # [START howto_sensor_emr_step_sensor_async]
+    step_checker = EmrStepSensorAsync(
+        task_id="watch_step",
+        job_flow_id=cluster_creator.output,
+        step_id="{{ task_instance.xcom_pull(task_ids='add_steps', key='return_value')[0] }}",
+        aws_conn_id=AWS_CONN_ID,
+    )
+    # [END howto_sensor_emr_step_sensor_async]
+
+    # [START howto_operator_emr_terminate_job_flow]
+    cluster_remover = EmrTerminateJobFlowOperator(
+        task_id="remove_cluster",
+        job_flow_id=cluster_creator.output,
+        aws_conn_id=AWS_CONN_ID,
+        trigger_rule="all_done",
+    )
+    # [END howto_operator_emr_terminate_job_flow]
+
+    chain(
+        step_adder,
+        step_checker,
+        cluster_remover,
+    )

--- a/astronomer/providers/amazon/aws/example_dags/example_emr_step_sensor.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_step_sensor.py
@@ -84,7 +84,7 @@ with DAG(
     Defer and poll until it reaches the target state
     The Default value of target state is COMPLETED
     For more detail see here
-    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr.html#EMR.Client.describe_step
+        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr.html#EMR.Client.describe_step
     """
     step_checker = EmrStepSensorAsync(
         task_id="watch_step",

--- a/astronomer/providers/amazon/aws/example_dags/example_emr_step_sensor.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_step_sensor.py
@@ -80,8 +80,12 @@ with DAG(
     # [END howto_operator_emr_add_steps]
 
     # [START howto_sensor_emr_step_sensor_async]
-    # Defer and poll until it reaches the target state
-    # The Default value of target state is COMPLETED
+    """
+    Defer and poll until it reaches the target state
+    The Default value of target state is COMPLETED
+    For more detail see here
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr.html#EMR.Client.describe_step
+    """
     step_checker = EmrStepSensorAsync(
         task_id="watch_step",
         job_flow_id=cluster_creator.output,

--- a/astronomer/providers/amazon/aws/example_dags/example_emr_step_sensor.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_step_sensor.py
@@ -56,7 +56,7 @@ DEFAULT_ARGS = {
 }
 
 with DAG(
-    dag_id="example_emr_job_flow_manual_steps",
+    dag_id="example_emr_step_sensor",
     schedule_interval=None,
     start_date=datetime(2022, 1, 1),
     default_args=DEFAULT_ARGS,
@@ -80,6 +80,8 @@ with DAG(
     # [END howto_operator_emr_add_steps]
 
     # [START howto_sensor_emr_step_sensor_async]
+    # Defer and poll until it reaches the target state
+    # The Default value of target state is COMPLETED
     step_checker = EmrStepSensorAsync(
         task_id="watch_step",
         job_flow_id=cluster_creator.output,

--- a/astronomer/providers/amazon/aws/sensors/emr.py
+++ b/astronomer/providers/amazon/aws/sensors/emr.py
@@ -1,11 +1,7 @@
 from typing import Any, Dict
 
 from airflow import AirflowException
-from airflow.providers.amazon.aws.sensors.emr import (
-    EmrContainerSensor,
-    EmrStepSensor,
-)
-
+from airflow.providers.amazon.aws.sensors.emr import EmrContainerSensor, EmrStepSensor
 
 from astronomer.providers.amazon.aws.triggers.emr import (
     EmrContainerSensorTrigger,
@@ -18,6 +14,7 @@ class EmrContainerSensorAsync(EmrContainerSensor):
     EmrContainerSensorAsync is async version of EmrContainerSensor,
     Asks for the state of the job run until it reaches a failure state or success state.
     If the job run fails, the task will fail.
+
     :param virtual_cluster_id: Reference Emr cluster id
     :param job_id: job_id to check the state
     :param max_retries: Number of times to poll for query state before
@@ -57,9 +54,11 @@ class EmrContainerSensorAsync(EmrContainerSensor):
 class EmrStepSensorAsync(EmrStepSensor):
     """
     Async (deferring) version of EmrStepSensor
+
     Asks for the state of the step until it reaches any of the target states.
     If the sensor errors out, then the task will fail
     With the default target states, sensor waits step to be COMPLETED.
+
     :param job_flow_id: job_flow_id which contains the step check the state of
     :param step_id: step to check the state of
     :param target_states: the target states, sensor waits until

--- a/astronomer/providers/amazon/aws/sensors/emr.py
+++ b/astronomer/providers/amazon/aws/sensors/emr.py
@@ -59,6 +59,9 @@ class EmrStepSensorAsync(EmrStepSensor):
     If the sensor errors out, then the task will fail
     With the default target states, sensor waits step to be COMPLETED.
 
+    For more details see
+        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/emr.html#EMR.Client.describe_step
+
     :param job_flow_id: job_flow_id which contains the step check the state of
     :param step_id: step to check the state of
     :param target_states: the target states, sensor waits until

--- a/astronomer/providers/amazon/aws/sensors/emr.py
+++ b/astronomer/providers/amazon/aws/sensors/emr.py
@@ -1,9 +1,16 @@
 from typing import Any, Dict
 
 from airflow import AirflowException
-from airflow.providers.amazon.aws.sensors.emr import EmrContainerSensor
+from airflow.providers.amazon.aws.sensors.emr import (
+    EmrContainerSensor,
+    EmrStepSensor,
+)
 
-from astronomer.providers.amazon.aws.triggers.emr import EmrContainerSensorTrigger
+
+from astronomer.providers.amazon.aws.triggers.emr import (
+    EmrContainerSensorTrigger,
+    EmrStepSensorTrigger,
+)
 
 
 class EmrContainerSensorAsync(EmrContainerSensor):
@@ -11,7 +18,6 @@ class EmrContainerSensorAsync(EmrContainerSensor):
     EmrContainerSensorAsync is async version of EmrContainerSensor,
     Asks for the state of the job run until it reaches a failure state or success state.
     If the job run fails, the task will fail.
-
     :param virtual_cluster_id: Reference Emr cluster id
     :param job_id: job_id to check the state
     :param max_retries: Number of times to poll for query state before
@@ -46,3 +52,46 @@ class EmrContainerSensorAsync(EmrContainerSensor):
                 raise AirflowException(event["message"])
             self.log.info(event["message"])
         return None
+
+
+class EmrStepSensorAsync(EmrStepSensor):
+    """
+    Async (deferring) version of EmrStepSensor
+    Asks for the state of the step until it reaches any of the target states.
+    If the sensor errors out, then the task will fail
+    With the default target states, sensor waits step to be COMPLETED.
+    :param job_flow_id: job_flow_id which contains the step check the state of
+    :param step_id: step to check the state of
+    :param target_states: the target states, sensor waits until
+        step reaches any of these states
+    :param failed_states: the failure states, sensor fails when
+        step reaches any of these states
+    """
+
+    def execute(self, context: Dict[str, Any]) -> None:
+        """Deferred and give control to trigger"""
+        self.defer(
+            timeout=self.execution_timeout,
+            trigger=EmrStepSensorTrigger(
+                job_flow_id=self.job_flow_id,
+                step_id=self.step_id,
+                target_states=self.target_states,
+                failed_states=self.failed_states,
+                aws_conn_id=self.aws_conn_id,
+                poke_interval=self.poke_interval,
+            ),
+            method_name="execute_complete",
+        )
+
+    def execute_complete(self, context: Dict[str, Any], event: Dict[str, Any]) -> None:
+        """
+        Callback for when the trigger fires - returns immediately.
+        Relies on trigger to throw an exception, otherwise it assumes execution was
+        successful.
+        """
+        if event:
+            if event["status"] == "error":
+                raise AirflowException(event["message"])
+
+            self.log.info(f"{event.get('message')}")
+            self.log.info(f"{self.job_flow_id} completed successfully.")

--- a/astronomer/providers/amazon/aws/triggers/emr.py
+++ b/astronomer/providers/amazon/aws/triggers/emr.py
@@ -1,16 +1,18 @@
 import asyncio
-from typing import Any, AsyncIterator, Dict, Optional, Tuple
+from typing import Any, AsyncIterator, Dict, Optional, Iterable, Tuple
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
-from astronomer.providers.amazon.aws.hooks.emr import EmrContainerHookAsync
+from astronomer.providers.amazon.aws.hooks.emr import (
+    EmrContainerHookAsync,
+    EmrStepSensorHookAsync,
+)
 
 
 class EmrContainerSensorTrigger(BaseTrigger):
     """
     The EmrContainerSensorTrigger is triggered when EMR container is created, it polls for the AWS EMR EKS Virtual
     Cluster Job status. It is fired as deferred class with params to run the task in trigger worker
-
     :param virtual_cluster_id: Reference Emr cluster id
     :param job_id:  job_id to check the state
     :param max_retries: maximum retry for poll for the status
@@ -62,6 +64,75 @@ class EmrContainerSensorTrigger(BaseTrigger):
                     msg = "EMR Containers sensors completed"
                     yield TriggerEvent({"status": "success", "message": msg})
                     return
+        except Exception as e:
+            yield TriggerEvent({"status": "error", "message": str(e)})
+            return
+
+
+class EmrStepSensorTrigger(BaseTrigger):
+    """
+    A trigger that fires once AWS EMR cluster step reaches either target or failed state
+    :param job_flow_id: job_flow_id which contains the step check the state of
+    :param step_id: step to check the state of
+    :param aws_conn_id: aws connection to use, defaults to 'aws_default'
+    :param poke_interval: Time in seconds to wait between two consecutive call to
+        check emr cluster step state
+    :param target_states: the target states, sensor waits until
+        step reaches any of these states
+    :param failed_states: the failure states, sensor fails when
+        step reaches any of these states
+    """
+
+    def __init__(
+            self,
+            job_flow_id: str,
+            step_id: str,
+            aws_conn_id: str,
+            poke_interval: float,
+            target_states: Optional[Iterable[str]] = None,
+            failed_states: Optional[Iterable[str]] = None,
+    ):
+        super().__init__()
+        self.job_flow_id = job_flow_id
+        self.step_id = step_id
+        self.aws_conn_id = aws_conn_id
+        self.poke_interval = poke_interval
+        self.target_states = target_states or ["COMPLETED"]
+        self.failed_states = failed_states or ["CANCELLED", "FAILED", "INTERRUPTED"]
+
+    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+        """Serializes EmrStepSensorTrigger arguments and classpath."""
+        return (
+            "astronomer.providers.amazon.aws.triggers.emr.EmrStepSensorTrigger",
+            {
+                "job_flow_id": self.job_flow_id,
+                "step_id": self.step_id,
+                "aws_conn_id": self.aws_conn_id,
+                "poke_interval": self.poke_interval,
+                "target_states": self.target_states,
+                "failed_states": self.failed_states,
+            },
+        )
+
+    async def run(self) -> AsyncIterator["TriggerEvent"]:  # type: ignore[override]
+        """Run until AWS EMR cluster step reach target or failed state"""
+        hook = EmrStepSensorHookAsync(
+            aws_conn_id=self.aws_conn_id, job_flow_id=self.job_flow_id, step_id=self.step_id
+        )
+        try:
+            while True:
+                response = await hook.emr_describe_step()
+                state = hook.state_from_response(response)
+                if state in self.target_states:
+                    yield TriggerEvent({"status": "success", "message": f"Job flow currently {state}"})
+                    return
+                elif state in self.failed_states:
+                    yield TriggerEvent(
+                        {"status": "error", "message": hook.failure_message_from_response(response)}
+                    )
+                    return
+                self.log.info(f"EMR step state is {state}. Sleeping for {self.poke_interval} seconds.")
+                await asyncio.sleep(self.poke_interval)
         except Exception as e:
             yield TriggerEvent({"status": "error", "message": str(e)})
             return

--- a/astronomer/providers/amazon/aws/triggers/emr.py
+++ b/astronomer/providers/amazon/aws/triggers/emr.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, AsyncIterator, Dict, Optional, Iterable, Tuple
+from typing import Any, AsyncIterator, Dict, Iterable, Optional, Tuple
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
@@ -72,6 +72,7 @@ class EmrContainerSensorTrigger(BaseTrigger):
 class EmrStepSensorTrigger(BaseTrigger):
     """
     A trigger that fires once AWS EMR cluster step reaches either target or failed state
+
     :param job_flow_id: job_flow_id which contains the step check the state of
     :param step_id: step to check the state of
     :param aws_conn_id: aws connection to use, defaults to 'aws_default'
@@ -84,13 +85,13 @@ class EmrStepSensorTrigger(BaseTrigger):
     """
 
     def __init__(
-            self,
-            job_flow_id: str,
-            step_id: str,
-            aws_conn_id: str,
-            poke_interval: float,
-            target_states: Optional[Iterable[str]] = None,
-            failed_states: Optional[Iterable[str]] = None,
+        self,
+        job_flow_id: str,
+        step_id: str,
+        aws_conn_id: str,
+        poke_interval: float,
+        target_states: Optional[Iterable[str]] = None,
+        failed_states: Optional[Iterable[str]] = None,
     ):
         super().__init__()
         self.job_flow_id = job_flow_id

--- a/astronomer/providers/amazon/aws/triggers/emr.py
+++ b/astronomer/providers/amazon/aws/triggers/emr.py
@@ -13,6 +13,7 @@ class EmrContainerSensorTrigger(BaseTrigger):
     """
     The EmrContainerSensorTrigger is triggered when EMR container is created, it polls for the AWS EMR EKS Virtual
     Cluster Job status. It is fired as deferred class with params to run the task in trigger worker
+
     :param virtual_cluster_id: Reference Emr cluster id
     :param job_id:  job_id to check the state
     :param max_retries: maximum retry for poll for the status

--- a/tests/amazon/aws/hooks/test_emr.py
+++ b/tests/amazon/aws/hooks/test_emr.py
@@ -3,11 +3,16 @@ from unittest import mock
 import pytest
 from botocore.exceptions import ClientError
 
-from astronomer.providers.amazon.aws.hooks.emr import EmrContainerHookAsync
+from astronomer.providers.amazon.aws.hooks.emr import (
+    EmrContainerHookAsync,
+    EmrStepSensorHookAsync,
+)
 
 VIRTUAL_CLUSTER_ID = "test_cluster_1"
 JOB_ID = "jobid-12122"
 AWS_CONN_ID = "aws_default"
+JOB_FLOW_ID = "j-T0CT8Z0C20NT"
+STEP_ID = "s-34RJO0CKERRPL"
 
 
 @pytest.mark.asyncio
@@ -80,3 +85,83 @@ async def test_emr_container_cluster_exception(mock_client):
     hook = EmrContainerHookAsync(aws_conn_id=AWS_CONN_ID, virtual_cluster_id=VIRTUAL_CLUSTER_ID)
     with pytest.raises(ClientError):
         await hook.check_job_status(job_id=JOB_ID)
+
+
+def _emr_describe_step_response(state: str = "", reason: str = "", message: str = "", logfile: str = ""):
+    """Return a dummy response for emr_describe_step method"""
+    return {
+        "Step": {
+            "Id": STEP_ID,
+            "Name": "PiCir",
+            "ActionOnFailure": "TERMINATE_JOB_FLOW",
+            "Status": {
+                "State": state,
+                "FailureDetails": {
+                    "Reason": reason,
+                    "Message": message,
+                    "LogFile": logfile,
+                },
+            },
+        }
+    }
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.amazon.aws.hooks.emr.EmrStepSensorHookAsync.get_client_async")
+async def test_emr_describe_step_success(mock_client):
+    """Assert check_job_status method return Steps"""
+    expected = _emr_describe_step_response()
+    mock_client.return_value.__aenter__.return_value.describe_step.return_value = expected
+
+    hook = EmrStepSensorHookAsync(aws_conn_id=AWS_CONN_ID, job_flow_id=JOB_FLOW_ID, step_id=STEP_ID)
+    response = await hook.emr_describe_step()
+    assert response == expected
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.amazon.aws.hooks.emr.EmrStepSensorHookAsync.get_client_async")
+async def test_emr_describe_step_failed(mock_client):
+    """Assert emr_describe_step method throw exception"""
+    mock_client.return_value.__aenter__.return_value.describe_step.side_effect = ClientError(
+        error_response={}, operation_name=""
+    )
+    hook = EmrStepSensorHookAsync(aws_conn_id=AWS_CONN_ID, job_flow_id=JOB_FLOW_ID, step_id=STEP_ID)
+    with pytest.raises(ClientError):
+        await hook.emr_describe_step()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    [
+        _emr_describe_step_response("PENDING"),
+        _emr_describe_step_response("CANCEL_PENDING"),
+        _emr_describe_step_response("RUNNING"),
+        _emr_describe_step_response("COMPLETED"),
+        _emr_describe_step_response("CANCELLED"),
+        _emr_describe_step_response("FAILED"),
+        _emr_describe_step_response("INTERRUPTED"),
+    ],
+)
+def test_state_from_response(state):
+    """Assert state_from_response function response"""
+    response = _emr_describe_step_response(state=state)
+    expected_state = EmrStepSensorHookAsync.state_from_response(response)
+    assert expected_state == state
+
+
+def test_failure_message_from_response():
+    """Assert failure_message_from_response function response"""
+    state = "FAILED"
+    reason = "Unknown Error"
+    message = "failed with Unknown Error"
+    logfile = "/usr/logs/emr.log"
+    response = _emr_describe_step_response(state=state, reason=reason, message=message, logfile=logfile)
+    error_message = EmrStepSensorHookAsync.failure_message_from_response(response)
+
+    assert error_message == f"for reason {reason} with message {message} and log file {logfile}"
+
+    # assert for FailureDetails missing in response
+    response["Step"]["Status"] = {"State": "FAILED"}
+    error_message = EmrStepSensorHookAsync.failure_message_from_response(response)
+    assert error_message is None

--- a/tests/amazon/aws/sensors/test_emr.py
+++ b/tests/amazon/aws/sensors/test_emr.py
@@ -1,0 +1,55 @@
+from unittest import mock
+
+import pytest
+from airflow.exceptions import AirflowException, TaskDeferred
+
+from astronomer.providers.amazon.aws.sensors.emr import EmrStepSensorAsync
+from astronomer.providers.amazon.aws.triggers.emr import EmrStepSensorTrigger
+
+JOB_FLOW_ID = "j-T0CT8Z0C20NT"
+STEP_ID = "s-34RJO0CKERRPL"
+
+
+@pytest.fixture
+def context():
+    """Creates an empty context."""
+    context = {}
+    yield context
+
+
+def test_emr_step_sensor_async():
+    """Assert execute method defer for EmrStepSensorAsync sensor"""
+    task = EmrStepSensorAsync(
+        task_id="test_execute",
+        job_flow_id=JOB_FLOW_ID,
+        step_id=STEP_ID,
+    )
+    with pytest.raises(TaskDeferred) as exc:
+        task.execute(context)
+    assert isinstance(exc.value.trigger, EmrStepSensorTrigger), "Trigger is not a EmrStepSensorTrigger"
+
+
+def test_emr_step_sensor_execute_complete_success():
+    """Assert execute_complete log success message when triggerer fire with target state"""
+    task = EmrStepSensorAsync(
+        task_id="test_execute_complete",
+        job_flow_id=JOB_FLOW_ID,
+        step_id=STEP_ID,
+    )
+
+    with mock.patch.object(task.log, "info") as mock_log_info:
+        task.execute_complete(
+            context={}, event={"status": "success", "message": "Job flow currently COMPLETED"}
+        )
+    mock_log_info.assert_called_with(f"{JOB_FLOW_ID} completed successfully.")
+
+
+def test_emr_step_sensor_execute_complete_failure():
+    """Assert execute_complete method fail"""
+    task = EmrStepSensorAsync(
+        task_id="test_execute_complete",
+        job_flow_id=JOB_FLOW_ID,
+        step_id=STEP_ID,
+    )
+    with pytest.raises(AirflowException):
+        task.execute_complete(context={}, event={"status": "error", "message": ""})

--- a/tests/amazon/aws/triggers/test_emr.py
+++ b/tests/amazon/aws/triggers/test_emr.py
@@ -4,7 +4,10 @@ from unittest import mock
 import pytest
 from airflow.triggers.base import TriggerEvent
 
-from astronomer.providers.amazon.aws.triggers.emr import EmrContainerSensorTrigger
+from astronomer.providers.amazon.aws.triggers.emr import (
+    EmrContainerSensorTrigger,
+    EmrStepSensorTrigger,
+)
 
 TASK_ID = "test_emr_container_sensor"
 VIRTUAL_CLUSTER_ID = "test_cluster_1"
@@ -12,6 +15,8 @@ JOB_ID = "jobid-12122"
 AWS_CONN_ID = "aws_default"
 MAX_RETRIES = 5
 POLL_INTERVAL = 5
+JOB_FLOW_ID = "j-U0CTOZ0R20QG"
+STEP_ID = "s-34RIO9CJERRJL"
 
 
 def test_emr_container_sensors_trigger_serialization():
@@ -132,6 +137,119 @@ async def test_emr_container_sensors_trigger_exception(mock_query_status):
         max_retries=MAX_RETRIES,
         aws_conn_id=AWS_CONN_ID,
         poll_interval=POLL_INTERVAL,
+    )
+    task = [i async for i in trigger.run()]
+    assert len(task) == 1
+    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+
+
+def test_emr_step_sensor_serialization():
+    """Asserts that the EmrStepSensorTrigger correctly serializes its arguments and classpath."""
+    trigger = EmrStepSensorTrigger(
+        job_flow_id=JOB_FLOW_ID, step_id=STEP_ID, aws_conn_id=AWS_CONN_ID, poke_interval=60
+    )
+
+    classpath, kwargs = trigger.serialize()
+    assert classpath == "astronomer.providers.amazon.aws.triggers.emr.EmrStepSensorTrigger"
+    assert kwargs == {
+        "job_flow_id": JOB_FLOW_ID,
+        "step_id": STEP_ID,
+        "aws_conn_id": AWS_CONN_ID,
+        "poke_interval": 60,
+        "target_states": ["COMPLETED"],
+        "failed_states": ["CANCELLED", "FAILED", "INTERRUPTED"],
+    }
+
+
+def _emr_describe_step_response(state):
+    """Return dummy response dict for emr_describe_step method"""
+    return {
+        "Step": {
+            "Id": STEP_ID,
+            "Name": "PiCir",
+            "ActionOnFailure": "TERMINATE_JOB_FLOW",
+            "Status": {
+                "State": state,
+                "FailureDetails": {"Reason": "Unknown Error", "Message": "", "LogFile": ""},
+            },
+        }
+    }
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.amazon.aws.hooks.emr.EmrStepSensorHookAsync.emr_describe_step")
+async def test_emr_step_sensor_trigger_run_success(emr_describe_step):
+    """Assert EmrStepSensorTrigger run method success"""
+    emr_describe_step.return_value = _emr_describe_step_response("COMPLETED")
+    trigger = EmrStepSensorTrigger(
+        job_flow_id=JOB_FLOW_ID, step_id=STEP_ID, aws_conn_id=AWS_CONN_ID, poke_interval=60
+    )
+    task = [i async for i in trigger.run()]
+    response = TriggerEvent({"status": "success", "message": "Job flow currently COMPLETED"})
+    assert len(task) == 1
+    assert response in task
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mock_response",
+    [
+        _emr_describe_step_response("PENDING"),
+        _emr_describe_step_response("CANCEL_PENDING"),
+        _emr_describe_step_response("RUNNING"),
+        _emr_describe_step_response(None),
+    ],
+)
+@mock.patch("astronomer.providers.amazon.aws.hooks.emr.EmrStepSensorHookAsync.emr_describe_step")
+async def test_emr_step_sensor_trigger_run_pending(emr_describe_step, mock_response):
+    """Assert run method of EmrStepSensorHookAsync sleep"""
+    emr_describe_step.return_value = mock_response
+    trigger = EmrStepSensorTrigger(
+        job_flow_id=JOB_FLOW_ID, step_id=STEP_ID, aws_conn_id=AWS_CONN_ID, poke_interval=5
+    )
+    task = asyncio.create_task(trigger.run().__anext__())
+    await asyncio.sleep(0.5)
+
+    # TriggerEvent was not returned
+    assert task.done() is False
+    asyncio.get_event_loop().stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mock_response",
+    [
+        _emr_describe_step_response("CANCELLED"),
+        _emr_describe_step_response("FAILED"),
+        _emr_describe_step_response("INTERRUPTED"),
+    ],
+)
+@mock.patch("astronomer.providers.amazon.aws.hooks.emr.EmrStepSensorHookAsync.emr_describe_step")
+async def test_emr_step_sensor_trigger_run_fail(emr_describe_step, mock_response):
+    """Assert run method of EmrStepSensorHookAsync fail"""
+    emr_describe_step.return_value = mock_response
+    trigger = EmrStepSensorTrigger(
+        job_flow_id=JOB_FLOW_ID,
+        step_id=STEP_ID,
+        aws_conn_id=AWS_CONN_ID,
+        poke_interval=5,
+        failed_states=["CANCELLED", "FAILED", "INTERRUPTED"],
+    )
+    task = [i async for i in trigger.run()]
+    response = TriggerEvent(
+        {"status": "error", "message": "for reason Unknown Error with message  and log file "}
+    )
+    assert len(task) == 1
+    assert response in task
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.amazon.aws.hooks.emr.EmrStepSensorHookAsync.emr_describe_step")
+async def test_emr_step_sensor_trigger_run_failure(emr_describe_step):
+    """Test EmrStepSensorTrigger run method fail"""
+    emr_describe_step.side_effect = Exception("Test exception")
+    trigger = EmrStepSensorTrigger(
+        job_flow_id=JOB_FLOW_ID, step_id=STEP_ID, aws_conn_id=AWS_CONN_ID, poke_interval=60
     )
     task = [i async for i in trigger.run()]
     assert len(task) == 1


### PR DESCRIPTION
Issue: https://github.com/astronomer/astronomer-providers/issues/120

EmrStepSensorAsync is a async (deferring) version of [EmrStepSensor](https://airflow.apache.org/docs/apache-airflow/1.10.13/_modules/airflow/contrib/sensors/emr_step_sensor.html)

This PR has the following changes 
- Add EmrStepSensorAsync/EmrStepSensorHookAsync/EmrStepSensorTrigger implementation
- Add unit test
- Add a self-sufficient example DAG 