### PR TITLE
bump up astro-runtime image version

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:4.1.0-base"
+ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:4.2.4-base"
 FROM ${IMAGE_NAME}
 
 USER root


### PR DESCRIPTION
Airflow runtime image is at 4.2.4. So bumping the version of image in Dockerfile.