### PR TITLE
Fix Sphinx docs to have correct module paths

### DIFF
--- a/docs/_templates/autoapi/index.rst
+++ b/docs/_templates/autoapi/index.rst
@@ -1,0 +1,18 @@
+API Reference
+=============
+
+This page contains auto-generated API reference documentation.
+
+.. toctree::
+   :titlesonly:
+
+   {% for page in pages %}
+   {#
+      Add the top most levels in "astronomer.providers.X" to the index file
+      This is needed because we don't have __init__.py file in astronomer
+      and astronomer/providers package as we use nested implicit namespace packages.
+   #}
+   {% if (page.top_level_object or page.name.split('.') | length == 3) and page.display %}
+   {{ page.short_name | capitalize }} <{{ page.include_path }}>
+   {% endif %}
+   {% endfor %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@
 #
 import os
 import sys
-from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(".."))
 
@@ -85,8 +84,9 @@ html_theme_options = {
 # html_static_path = ["_static"]
 
 # -- AutoAPI ---------------------------------------------------------------
-autoapi_dirs = sorted([str(prov_dir) for prov_dir in Path("../astronomer/providers/").iterdir()])
+autoapi_dirs = ["../astronomer"]
 
+autoapi_template_dir = "_templates/autoapi"
 autoapi_generate_api_docs = True
 
 # The default options for autodoc directives. They are applied to all autodoc directives automatically.


### PR DESCRIPTION
closes https://github.com/astronomer/astronomer-providers/issues/201

Problem:
https://astronomer-providers.readthedocs.io/en/latest/_api/amazon/aws/sensors/s3/index.html does not contain `astronomer.providers` in the module name.

**Before**:
<img width="754" alt="image" src="https://user-images.githubusercontent.com/8811558/162185560-7ffdfe8a-d10b-410c-ae94-9d96e97068cc.png">

**After**:
<img width="930" alt="image" src="https://user-images.githubusercontent.com/8811558/162284725-228d649e-9ff0-433e-93b3-8f0ee8bbeaf8.png">

<img width="1122" alt="image" src="https://user-images.githubusercontent.com/8811558/162284803-960bda13-6897-4126-863d-13820bc4a6cd.png">

