### PR TITLE
Docs: Sort API reference by Module Name

### DIFF
--- a/docs/_templates/autoapi/index.rst
+++ b/docs/_templates/autoapi/index.rst
@@ -6,7 +6,7 @@ This page contains auto-generated API reference documentation.
 .. toctree::
    :titlesonly:
 
-   {% for page in pages %}
+   {% for page in pages | sort %}
    {#
       Add the top most levels in "astronomer.providers.X" to the index file
       This is needed because we don't have __init__.py file in astronomer


### PR DESCRIPTION
**Before**:
<img width="911" alt="image" src="https://user-images.githubusercontent.com/8811558/162292683-1c0984f8-7c2e-4761-b96c-be78f53bffc5.png">


**After:**
<img width="922" alt="image" src="https://user-images.githubusercontent.com/8811558/162292793-fbedb6d7-f3be-4621-8794-9fe1c2f5e168.png">
