### PR TITLE
CircleCI job for automatic deployment and execution of Integration Suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,17 @@ workflows:
             - Needs-Approval
           <<: *version_tag_only
 
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 19 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - deploy
+
 executors:
   docker-executor:
     parameters:
@@ -215,3 +226,17 @@ jobs:
       - store_artifacts:
           path: /tmp/workspace/dist/
           destination: dist
+
+  deploy:
+    executor:
+      name: docker-executor
+      python_version: "3.9"
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.12
+      - run:
+          name: Deploy
+          command: |
+            cd .circleci/integration-tests
+            bash script.sh $ASTRO_BASE_DOMAIN $ASTRO_RELEASE_NAME $ASTRO_API_KEY

--- a/.circleci/integration-tests/script.sh
+++ b/.circleci/integration-tests/script.sh
@@ -8,9 +8,8 @@ function echo_help() {
     echo "Usage:"
     echo "BASEDOMAIN:        Astro cloud instance domain"
     echo "RELEASE_NAME:      Astro release name of a deployment"
-    echo "BUILD_NUMBER       Docker image tag"
-    echo "API_KEY            Deployment service account api key"
-    echo "sh script.sh <BASEDOMAIN> <RELEASE_NAME> <BUILD_NUMBER> <API_KEY>"
+    echo "ASTRO_API_KEY      Deployment service account api key"
+    echo "bash script.sh <BASEDOMAIN> <RELEASE_NAME>  <ASTRO_API_KEY>"
 }
 
 # Delete if source old source files exist
@@ -23,15 +22,14 @@ function clean() {
   find  . -name "example_*" -exec rm {} \;
 }
 
-if [ "$1" == "-h" ] || [ "$#" -ne 4 ]; then
+if [ "$1" == "-h" ] || [ "$#" -ne 3 ]; then
   echo_help
   exit
 fi
 
 BASE_DOMAIN=$1
 RELEASE_NAME=$2
-BUILD_NUMBER=$3
-API_KEY=$4
+ASTRO_API_KEY=$3
 
 clean
 
@@ -47,9 +45,10 @@ touch requirements.txt
 for dag in $(find "${PROVIDER_PATH}" -type f -name 'example_*'); do cp "${dag}" "${SCRIPT_PATH}"; done;
 
 # Build image and deploy
+BUILD_NUMBER=`awk 'BEGIN {srand(); print srand()}'`
 IMAGE_NAME=registry.${BASE_DOMAIN}/${RELEASE_NAME}/airflow:ci-${BUILD_NUMBER}
 docker build -t "${IMAGE_NAME}" -f "${SCRIPT_PATH}"/Dockerfile "${SCRIPT_PATH}"
-docker login registry.staging.astronomer.io  -u _ -p "${API_KEY}"
+docker login registry.staging.astronomer.io  -u _ -p "${ASTRO_API_KEY}"
 docker push "${IMAGE_NAME}"
 
 clean


### PR DESCRIPTION
Automate cloud deployment from circleci.

I have created a new workflow called nightly and a job deploy which runs at the scheduled time, at present, it will run daily around 0:0:0 IST and deploy main branch on the cloud.  

The integration test script now depends on env variable which comes from circleci for scheduled workflow.