### PR TITLE
Add `flake8` check for logging in Pre-commit Hooks

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -48,8 +48,8 @@ def get_report(dag_run_ids: List[str]) -> None:
                 channel=SLACK_CHANNEL,
                 username=SLACK_USERNAME,
             ).execute(context=None)
-        except Exception as e:
-            logging.error("Error occur while sending slack alert. \n %s", e)
+        except Exception:
+            logging.exception("Error occur while sending slack alert.")
 
 
 def prepare_dag_dependency(task_info, execution_time):

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
           - flake8-rst-docstrings
           - flake8-assertive
           - flake8-typing-imports
+          - flake8-logging-format
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -124,8 +124,8 @@ def delete_redshift_cluster_snapshot() -> None:
             if get_cluster_status() == "available":
                 time.sleep(30)
                 continue
-    except ClientError as e:
-        logging.info("%s", e)
+    except ClientError:
+        logging.exception("Error when deleting the cluster")
         return None
 
 
@@ -143,8 +143,8 @@ def delete_redshift_cluster() -> None:
             if get_cluster_status() == "deleting":
                 time.sleep(30)
                 continue
-    except ClientError as e:
-        logging.info("%s", e)
+    except ClientError:
+        logging.exception("Error when deleting the cluster")
         return None
 
 

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py
@@ -57,8 +57,8 @@ def delete_redshift_cluster() -> None:
             if get_cluster_status() == "deleting":
                 time.sleep(30)
                 continue
-    except ClientError as e:
-        logging.info("%s", e)
+    except ClientError:
+        logging.exception("Error deleting redshift cluster")
         return None
 
 

--- a/astronomer/providers/amazon/aws/hooks/emr.py
+++ b/astronomer/providers/amazon/aws/hooks/emr.py
@@ -73,7 +73,7 @@ class EmrStepSensorHookAsync(AwsBaseHookAsync):
                 response: Dict[str, Any] = await client.describe_step(
                     ClusterId=self.job_flow_id, StepId=self.step_id
                 )
-                self.log.debug(f"Response from AwsBaseHookAsync: {response}")
+                self.log.debug("Response from AwsBaseHookAsync: %s", response)
                 return response
             except ClientError as error:
                 raise error

--- a/astronomer/providers/amazon/aws/hooks/redshift_data.py
+++ b/astronomer/providers/amazon/aws/hooks/redshift_data.py
@@ -92,7 +92,7 @@ class RedshiftDataHook(AwsBaseHook):
             conn_params = self.get_conn_params()
             query_ids: List[str] = []
             for sql_statement in sql:
-                self.log.info(f"Executing statement: {sql_statement}")
+                self.log.info("Executing statement: %s", sql_statement)
                 response = client.execute_statement(
                     Database=conn_params["database"],
                     ClusterIdentifier=conn_params["cluster_identifier"],

--- a/astronomer/providers/amazon/aws/sensors/emr.py
+++ b/astronomer/providers/amazon/aws/sensors/emr.py
@@ -100,8 +100,8 @@ class EmrStepSensorAsync(EmrStepSensor):
             if event["status"] == "error":
                 raise AirflowException(event["message"])
 
-            self.log.info(f"{event.get('message')}")
-            self.log.info(f"{self.job_flow_id} completed successfully.")
+            self.log.info(event.get("message"))
+            self.log.info("%s completed successfully.", self.job_flow_id)
 
 
 class EmrJobFlowSensorAsync(EmrJobFlowSensor):

--- a/astronomer/providers/amazon/aws/triggers/emr.py
+++ b/astronomer/providers/amazon/aws/triggers/emr.py
@@ -134,7 +134,7 @@ class EmrStepSensorTrigger(BaseTrigger):
                         {"status": "error", "message": hook.failure_message_from_response(response)}
                     )
                     return
-                self.log.info(f"EMR step state is {state}. Sleeping for {self.poke_interval} seconds.")
+                self.log.info("EMR step state is %s. Sleeping for %s seconds.", state, self.poke_interval)
                 await asyncio.sleep(self.poke_interval)
         except Exception as e:
             yield TriggerEvent({"status": "error", "message": str(e)})

--- a/astronomer/providers/apache/livy/hooks/livy.py
+++ b/astronomer/providers/apache/livy/hooks/livy.py
@@ -132,7 +132,7 @@ class LivyHookAsync(HttpHookAsync, LoggingMixin):
                         url,
                     )
                     if not self._retryable_error_async(e) or attempt_num == self.retry_limit:
-                        self.log.error("HTTP error: %s", e)
+                        self.log.exception("HTTP error, status code: %s", e.status)
                         # In this case, the user probably made a mistake.
                         # Don't retry.
                         return {"Response": {e.message}, "Status Code": {e.status}, "status": "error"}
@@ -185,7 +185,7 @@ class LivyHookAsync(HttpHookAsync, LoggingMixin):
 
         if "state" not in result["response"]:
             self.log.info(
-                f"batch_state: error with as it is unable to get state for batch with id: {session_id}"
+                "batch_state: error with as it is unable to get state for batch with id: %s", session_id
             )
             return {
                 "batch_state": "error",

--- a/astronomer/providers/apache/livy/operators/livy.py
+++ b/astronomer/providers/apache/livy/operators/livy.py
@@ -46,7 +46,7 @@ class LivyOperatorAsync(LivyOperator):
         Submit the job and get the job_id using which we defer and poll in trigger
         """
         self._batch_id = self.get_hook().post_batch(**self.spark_params)
-        self.log.info(f"Generated batch-id is {self._batch_id}")
+        self.log.info("Generated batch-id is %s", self._batch_id)
 
         self.defer(
             timeout=self.execution_timeout,

--- a/astronomer/providers/databricks/hooks/databricks.py
+++ b/astronomer/providers/databricks/hooks/databricks.py
@@ -89,8 +89,7 @@ class DatabricksHookAsync(DatabricksHook):
             auth = base64.b64encode(encoded_bytes).decode("utf-8")
             headers["Authorization"] = f"Basic {auth}"
             host = self.databricks_conn.host
-            self.log.info(f"auth: {auth}")
-            self.log.info(f"host: {host}")
+            self.log.info("Auth: %s; Host: %s", auth, host)
 
         url = f"https://{self._parse_host(host)}/{endpoint}"
         async with aiohttp.ClientSession() as session:

--- a/astronomer/providers/http/hooks/http.py
+++ b/astronomer/providers/http/hooks/http.py
@@ -128,7 +128,7 @@ class HttpHookAsync(BaseHook):
                         url,
                     )
                     if not self._retryable_error_async(e) or attempt_num == self.retry_limit:
-                        self.log.error("HTTP error: %s", e)
+                        self.log.exception("HTTP error with status: %s", e.status)
                         # In this case, the user probably made a mistake.
                         # Don't retry.
                         raise AirflowException(str(e.status) + ":" + e.message)

--- a/astronomer/providers/snowflake/hooks/snowflake.py
+++ b/astronomer/providers/snowflake/hooks/snowflake.py
@@ -126,5 +126,5 @@ class SnowflakeHookAsync(SnowflakeHook):
                 self.log.error("error_message ", error_message)
                 return {"status": "error", "message": error_message, "type": "ERROR"}
         except Exception as e:
-            self.log.error(str(e))
+            self.log.exception("Unexpected error when retrieving query status:")
             return {"status": "error", "message": str(e), "type": "ERROR"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -123,6 +123,7 @@ include =
     astronomer.*
 
 [flake8]
+enable-extensions=G
 exclude = venv/*,tox/*,specs/*
 ignore = E123,E128,E266,E402,W503,E731,W601
 max-line-length = 119

--- a/tests/amazon/aws/sensors/test_emr.py
+++ b/tests/amazon/aws/sensors/test_emr.py
@@ -41,7 +41,7 @@ def test_emr_step_sensor_execute_complete_success():
         task.execute_complete(
             context={}, event={"status": "success", "message": "Job flow currently COMPLETED"}
         )
-    mock_log_info.assert_called_with(f"{JOB_FLOW_ID} completed successfully.")
+    mock_log_info.assert_called_with("%s completed successfully.", "j-T0CT8Z0C20NT")
 
 
 def test_emr_step_sensor_execute_complete_failure():


### PR DESCRIPTION
This commit adds flake8 plugin for logging - https://github.com/globality-corp/flake8-logging-format in pre-commit Hooks so that we always use Lazy loading of args in logs.