### PR TITLE
Add trigger rule on last task of bigquery example DAG

### DIFF
--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py
@@ -79,6 +79,7 @@ with DAG(
         dataset_id=DATASET,
         delete_contents=True,
         gcp_conn_id=GCP_CONN_ID,
+        trigger_rule="all_done",
     )
 
     # [START howto_operator_bigquery_insert_job_async]


### PR DESCRIPTION
This PR introduces an "all_done" rule on the last task of bigquery example DAG, so that the resources will be deleted even if the predecessor tasks on the DAG fail.

Closes #210 