### PR TITLE
Fix the pre-commit dependency check

### DIFF
--- a/.circleci/scripts/pre_commit_setup_cfg_all_extra.py
+++ b/.circleci/scripts/pre_commit_setup_cfg_all_extra.py
@@ -26,7 +26,7 @@ if not found_all_extra:
 
 """
 Use XOR operator ^ to find the missing dependencies instead of set A - set B
-set A - set B will only show difference of set A from set B, but not set B from set A
+set A - set B will only show difference of set A from set B, but we want see overall diff
 """
 diff_extras = expected_all_extra ^ found_all_extra
 if diff_extras:

--- a/.circleci/scripts/pre_commit_setup_cfg_all_extra.py
+++ b/.circleci/scripts/pre_commit_setup_cfg_all_extra.py
@@ -24,7 +24,11 @@ found_all_extra = set(config["options.extras_require"].get("all", "").split())
 if not found_all_extra:
     raise SystemExit("Missing 'all' extra in setup.cfg")
 
-diff_extras = expected_all_extra - found_all_extra
+"""
+Use XOR operator ^ to find the missing dependencies instead of set A - set B
+set A - set B will only show difference of set A from set B, but not set B from set A
+"""
+diff_extras = expected_all_extra ^ found_all_extra
 if diff_extras:
     diff_extras_str = "\n \t" + "\n \t".join(sorted(diff_extras))
     raise SystemExit(f"'all' extra in setup.cfg is missing some dependencies:\n {diff_extras_str}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,12 +111,12 @@ all =
     apache-airflow-providers-cncf-kubernetes>=3
     apache-airflow-providers-databricks>=2.2.0
     apache-airflow-providers-google
+    apache-airflow-providers-apache-livy
     apache-airflow-providers-snowflake
     gcloud-aio-bigquery
     gcloud-aio-storage
     google-api-core>=1.25.1,<2.0.0
     kubernetes_asyncio
-    apache-airflow-providers-apache-livy
 
 [options.packages.find]
 include =


### PR DESCRIPTION
This PR fixes a bug in the pre commit dependency config check script. The current logic uses a one side diff between two sets (`expected_all_extra` - `found_all_extra`).However it won't work in cases when the set `found_all_extra` contains an additional element which is not in set `expected_all_extra`.

Closes #218 