### PR TITLE
Automate inventory list for all providers

### DIFF
--- a/astronomer/providers/apache/livy/hooks/livy.py
+++ b/astronomer/providers/apache/livy/hooks/livy.py
@@ -239,10 +239,9 @@ class LivyHookAsync(HttpHookAsync, LoggingMixin):
         log_batch_size = 100
 
         while log_start_line <= log_total_lines:
-            # Livy log  endpoint is paginated.
+            # Livy log endpoint is paginated.
             result = await self.get_batch_logs(session_id, log_start_line, log_batch_size)
             if result["status"] == "success":
-                log_total_lines = self._parse_request_response(result["response"], "total")
                 log_start_line += log_batch_size
                 log_lines = self._parse_request_response(result["response"], "log")
                 for log_line in log_lines:

--- a/astronomer/providers/apache/livy/operators/livy.py
+++ b/astronomer/providers/apache/livy/operators/livy.py
@@ -40,7 +40,7 @@ class LivyOperatorAsync(LivyOperator):
             See Tenacity documentation at https://github.com/jd/tenacity
     """
 
-    def execute(self, context: "Context") -> Any:
+    def execute(self, context: "Context") -> None:
         """
         Airflow runs this method on the worker and defers using the trigger.
         Submit the job and get the job_id using which we defer and poll in trigger

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,15 +6,19 @@
 
 # -- Path setup --------------------------------------------------------------
 
+import configparser
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import re
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(".."))
-
+repo_dir = Path(__file__).parent.parent
 
 # -- Project information -----------------------------------------------------
 
@@ -131,18 +135,17 @@ suppress_warnings = [
 autoapi_python_use_implicit_namespaces = True
 
 # -- Intersphinx configuration ------------------------------------------------
+# Get all the providers from setup.cfg and use them to generate the intersphinx inventories
+# for all the providers
+config = configparser.ConfigParser(strict=False)
+config.read(repo_dir / "setup.cfg")
+
+prov_deps = [
+    re.match(r"([a-zA-Z-]+)", dep).groups()[0]
+    for dep in config["options.extras_require"]["all"].split()
+    if dep.startswith("apache-airflow-providers-")
+]
 intersphinx_mapping = {
     "airflow": ("https://airflow.apache.org/docs/apache-airflow/stable/", None),
-    "airflow-databricks": (
-        "https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/",
-        None,
-    ),
-    "airflow-google": ("https://airflow.apache.org/docs/apache-airflow-providers-google/stable/", None),
-    "airflow-kubernetes": (
-        "https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/",
-        None,
-    ),
-    "airflow-snowflake": ("https://airflow.apache.org/docs/apache-airflow-providers-snowflake/stable/", None),
-    "airflow-amazon": ("https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/", None),
-    "airflow-http": ("https://airflow.apache.org/docs/apache-airflow-providers-http/stable/", None),
+    **{provider: (f"https://airflow.apache.org/docs/{provider}/stable", None) for provider in prov_deps},
 }


### PR DESCRIPTION
This commit autogenerates the list using the list of providers in "all" extras in setup.cfg. This way we don't need to manually add providers when we add operators for new Providers. This also fixes the issue with missing Livy inventory.

This helps in the docs as shown below by allow users to click on the link for the docs of Base/inherited class.

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/8811558/163276645-dda3d0af-c222-44a2-984e-518d164b01f8.png">

But because Livy doesn't have an inventory, it doesn't show right now:
<img width="771" alt="image" src="https://user-images.githubusercontent.com/8811558/163276832-e5b12282-119b-4318-a8f2-fefb883dd513.png">
