### PR TITLE
Add example_emr_sensor in integration test

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -93,8 +93,7 @@ with DAG(
         {"s3_sensor_dag": "example_s3_sensor"},
         {"redshift_sql_dag": "example_async_redshift_sql"},
         {"redshift_cluster_mgmt_dag": "example_async_redshift_cluster_management"},
-        {"emr_job_flow_sensor_dag": "example_emr_job_flow_sensor"},
-        {"emr_cluster_dag": "example_emr_step_sensor"},
+        {"example_emr_sensor_dag": "example_emr_sensor"},
     ]
     amazon_trigger_tasks, ids = prepare_dag_dependency(amazon_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)

--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -93,7 +93,7 @@ with DAG(
         {"s3_sensor_dag": "example_s3_sensor"},
         {"redshift_sql_dag": "example_async_redshift_sql"},
         {"redshift_cluster_mgmt_dag": "example_async_redshift_cluster_management"},
-        {"example_emr_sensor_dag": "example_emr_sensor"},
+        {"emr_sensor_dag": "example_emr_sensor"},
     ]
     amazon_trigger_tasks, ids = prepare_dag_dependency(amazon_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)


### PR DESCRIPTION
Include example_emr_sensor DAG in the integration test and remove example_emr_job_flow_sensor and example_emr_step_sensor DAG since example_emr_sensor contain both