### PR TITLE
Add pre-commit hooks for detecting private key & AWS Creds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-useless-excludes
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml
@@ -15,6 +15,9 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+      - id: detect-private-key
+      - id: detect-aws-credentials
+        args: ["--allow-missing-credentials"]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0


### PR DESCRIPTION
This is not bullet proof but will prevent us adding Secrets in some scenarios which is good enough.