### PR TITLE
Update execution timeout for dag

### DIFF
--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/astro-runtime:4.2.4-base
+FROM quay.io/astronomer/ap-airflow:2.2.4
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 

--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -93,11 +93,18 @@ with DAG(
         {"s3_sensor_dag": "example_s3_sensor"},
         {"redshift_sql_dag": "example_async_redshift_sql"},
         {"redshift_cluster_mgmt_dag": "example_async_redshift_cluster_management"},
-        {"emr_sensor_dag": "example_emr_sensor"},
     ]
     amazon_trigger_tasks, ids = prepare_dag_dependency(amazon_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)
     chain(*amazon_trigger_tasks)
+
+    emr_task_info = [
+        {"emr_sensor_dag": "example_emr_sensor"},
+        {"emr_eks_pi_job_dag", "example_emr_eks_pi_job"},
+    ]
+    emr_trigger_tasks, ids = prepare_dag_dependency(emr_task_info, "{{ ds }}")
+    dag_run_ids.extend(ids)
+    chain(*emr_trigger_tasks)
 
     google_task_info = [
         {"bigquery_dag": "example_async_bigquery_queries"},
@@ -157,6 +164,7 @@ with DAG(
 
     start >> [
         amazon_trigger_tasks[0],
+        emr_trigger_tasks[0],
         google_trigger_tasks[0],
         core_trigger_tasks[0],
         kubernetes_trigger_tasks[0],
@@ -168,6 +176,7 @@ with DAG(
 
     last_task = [
         amazon_trigger_tasks[-1],
+        emr_trigger_tasks[-1],
         google_trigger_tasks[-1],
         core_trigger_tasks[-1],
         kubernetes_trigger_tasks[-1],

--- a/astronomer/providers/amazon/aws/example_dags/example_emr_eks_containers_job.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_eks_containers_job.py
@@ -38,7 +38,7 @@ INSTANCE_TYPE = os.getenv("INSTANCE_TYPE", "m4.large")
 AIRFLOW_HOME = os.getenv("AIRFLOW_HOME", "/usr/local/airflow")
 
 default_args = {
-    "execution_timeout": timedelta(minutes=30),
+    "execution_timeout": timedelta(hours=6),
 }
 
 
@@ -87,12 +87,12 @@ CONFIGURATION_OVERRIDES_ARG = {
 # [END howto_operator_emr_eks_config]
 
 with DAG(
-    dag_id="emr_eks_pi_job",
+    dag_id="example_emr_eks_pi_job",
     start_date=datetime(2022, 1, 1),
     schedule_interval=None,
     catchup=False,
     default_args=default_args,
-    tags=["emr", "example"],
+    tags=["example", "async", "emr"],
 ) as dag:
     # Task steps for DAG to be self-sufficient
     setup_aws_config = BashOperator(

--- a/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
@@ -54,7 +54,7 @@ JOB_FLOW_OVERRIDES = {
 }
 
 DEFAULT_ARGS = {
-    "execution_timeout": timedelta(minutes=30),
+    "execution_timeout": timedelta(hours=6),
 }
 
 

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -30,7 +30,7 @@ AWS_DEFAULT_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
 AWS_CONN_ID = os.environ.get("ASTRO_AWS_CONN_ID", "aws_default")
 
 default_args = {
-    "execution_timeout": timedelta(minutes=30),
+    "execution_timeout": timedelta(hours=6),
 }
 
 

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py
@@ -26,7 +26,7 @@ AWS_DEFAULT_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
 REDSHIFT_CLUSTER_DB_NAME = os.environ.get("REDSHIFT_CLUSTER_DB_NAME", "astro_dev")
 
 default_args = {
-    "execution_timeout": timedelta(minutes=30),
+    "execution_timeout": timedelta(hours=6),
 }
 
 

--- a/astronomer/providers/amazon/aws/example_dags/example_s3.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_s3.py
@@ -29,7 +29,7 @@ AWS_CONN_ID = os.environ.get("ASTRO_AWS_S3_CONN_ID", "aws_s3_default")
 default_args = {
     "retry": 5,
     "retry_delay": timedelta(minutes=1),
-    "execution_timeout": timedelta(minutes=30),
+    "execution_timeout": timedelta(hours=6),
 }
 
 with DAG(

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -6,7 +6,7 @@ using the Java and Python executables provided in the example library.
 import logging
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, List
 
 import boto3
@@ -232,12 +232,17 @@ def get_cluster_details(task_instance: Any) -> None:
     )
 
 
+default_args = {
+    "execution_timeout": timedelta(hours=6),
+}
+
 with DAG(
     dag_id="example_livy_operator",
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
     catchup=False,
-    tags=["example", "async", "deferrable", "LivyOperatorAsync"],
+    default_args=default_args,
+    tags=["example", "async", "livy"],
 ) as dag:
     # [START howto_create_key_pair_file]
     create_key_pair_file = PythonOperator(

--- a/astronomer/providers/cncf/kubernetes/example_dags/example_kubernetes_pod_operator.py
+++ b/astronomer/providers/cncf/kubernetes/example_dags/example_kubernetes_pod_operator.py
@@ -18,7 +18,7 @@ else:
     config_file = None
 
 default_args = {
-    "execution_timeout": timedelta(minutes=30),
+    "execution_timeout": timedelta(hours=6),
 }
 
 with DAG(

--- a/astronomer/providers/core/example_dags/example_external_task.py
+++ b/astronomer/providers/core/example_dags/example_external_task.py
@@ -19,7 +19,7 @@ from airflow.utils.timezone import datetime
 from astronomer.providers.core.sensors.external_task import ExternalTaskSensorAsync
 
 default_args = {
-    "execution_timeout": timedelta(minutes=30),
+    "execution_timeout": timedelta(hours=6),
 }
 
 with DAG(

--- a/astronomer/providers/core/example_dags/example_external_task_wait_for_me.py
+++ b/astronomer/providers/core/example_dags/example_external_task_wait_for_me.py
@@ -4,7 +4,7 @@ from airflow import DAG
 from airflow.sensors.time_sensor import TimeSensorAsync
 
 default_args = {
-    "execution_timeout": timedelta(minutes=30),
+    "execution_timeout": timedelta(hours=6),
 }
 
 with DAG(

--- a/astronomer/providers/core/example_dags/example_file_sensor.py
+++ b/astronomer/providers/core/example_dags/example_file_sensor.py
@@ -9,7 +9,7 @@ from astronomer.providers.core.sensors.filesystem import FileSensorAsync
 FS_CONN_ID = os.environ.get("ASTRO_FS_CONN_ID", "fs_default")
 
 default_args = {
-    "execution_timeout": timedelta(minutes=30),
+    "execution_timeout": timedelta(hours=6),
 }
 
 with DAG(

--- a/astronomer/providers/databricks/example_dags/example_databricks.py
+++ b/astronomer/providers/databricks/example_dags/example_databricks.py
@@ -19,7 +19,7 @@ NOTEBOOK_TASK = json.loads(os.environ.get("DATABRICKS_NOTEBOOK_TASK", notebook_t
 notebook_params: Optional[Dict[str, str]] = {"Variable": "5"}
 
 default_args = {
-    "execution_timeout": timedelta(minutes=10),
+    "execution_timeout": timedelta(hours=6),
 }
 
 new_cluster = {

--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py
@@ -44,7 +44,7 @@ INSERT_ROWS_QUERY = (
 )
 
 default_args = {
-    "execution_timeout": timedelta(minutes=30),
+    "execution_timeout": timedelta(hours=6),
 }
 
 with DAG(

--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_sensors.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_sensors.py
@@ -34,7 +34,7 @@ SCHEMA = [
     {"name": "ds", "type": "DATE", "mode": "NULLABLE"},
 ]
 
-default_args = {"execution_timeout": timedelta(minutes=15), "gcp_conn_id": GCP_CONN_ID}
+default_args = {"execution_timeout": timedelta(hours=6), "gcp_conn_id": GCP_CONN_ID}
 
 with DAG(
     dag_id="example_bigquery_sensors",

--- a/astronomer/providers/google/cloud/example_dags/example_dataproc.py
+++ b/astronomer/providers/google/cloud/example_dags/example_dataproc.py
@@ -143,7 +143,7 @@ WORKFLOW_TEMPLATE = {
 }
 
 default_args = {
-    "execution_timeout": timedelta(minutes=30),
+    "execution_timeout": timedelta(hours=6),
 }
 
 

--- a/astronomer/providers/google/cloud/example_dags/example_gcs.py
+++ b/astronomer/providers/google/cloud/example_dags/example_gcs.py
@@ -27,7 +27,7 @@ PATH_TO_UPLOAD_FILE_PREFIX = "example_"
 BUCKET_FILE_LOCATION = "example_gcs.py"
 
 default_args = {
-    "execution_timeout": timedelta(minutes=30),
+    "execution_timeout": timedelta(hours=6),
 }
 
 with DAG(

--- a/astronomer/providers/http/example_dags/example_http.py
+++ b/astronomer/providers/http/example_dags/example_http.py
@@ -9,7 +9,7 @@ from astronomer.providers.http.sensors.http import HttpSensorAsync
 HTTP_CONN_ID = os.environ.get("ASTRO_HTTP_CONN_ID", "http_default")
 
 default_args = {
-    "execution_timeout": timedelta(minutes=30),
+    "execution_timeout": timedelta(hours=6),
 }
 
 

--- a/astronomer/providers/snowflake/example_dags/example_snowflake.py
+++ b/astronomer/providers/snowflake/example_dags/example_snowflake.py
@@ -23,7 +23,7 @@ SNOWFLAKE_SLACK_MESSAGE = (
     "Results in an ASCII table:\n```{{ results_df | tabulate(tablefmt='pretty', headers='keys') }}```"
 )
 
-default_args = {"execution_timeout": timedelta(minutes=30), "snowflake_conn_id": SNOWFLAKE_CONN_ID}
+default_args = {"execution_timeout": timedelta(hours=6), "snowflake_conn_id": SNOWFLAKE_CONN_ID}
 
 with DAG(
     dag_id="example_snowflake",


### PR DESCRIPTION
- Reverted base docker image i.e airflow somehow 2.2.5 are not healthy on staging 
- increase timeout
- separate emr and other aws dag dependency 
- Add timeout for livy