### PR TITLE
Fix LivyOperatorAsync example DAG

### DIFF
--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -30,9 +30,9 @@ PEM_FILENAME = os.environ.get("PEM_FILENAME", "providers_team_keypair")
 PRIVATE_KEY = Variable.get("providers_team_keypair")
 
 AWS_S3_CREDS = {
-    "aws_access_key_id": os.environ.get("AWS_ACCESS_KEY", "sample_aws_access_key_id"),
-    "aws_secret_access_key": os.environ.get("AWS_SECRET_KEY", "sample_aws_secret_access_key"),
-    "region_name": os.environ.get("AWS_REGION_NAME", "us-east-2"),
+    "aws_access_key_id": os.environ.get("AWS_ACCESS_KEY_ID", "sample_aws_access_key_id"),
+    "aws_secret_access_key": os.environ.get("AWS_SECRET_ACCESS_KEY", "sample_aws_secret_access_key"),
+    "region_name": os.environ.get("AWS_DEFAULT_REGION", "us-east-2"),
 }
 
 COMMAND_TO_CREATE_PI_FILE: List[str] = [


### PR DESCRIPTION
The LivyOperatorAsync example DAG is failing as part of the integration
tests on staging environment. The reason for the failure is that the DAG is
referring to AWS environment variables different than what has been
configured in the staging deployment. This change renames such AWS 
environment variables to be consistent with other example DAG and the
same have been set in the staging deployment environment.

Closes: https://github.com/astronomer/astronomer-providers/issues/237