### PR TITLE
Make `HivePartitionSensorAsync` example dag self-sufficient.

### DIFF
--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -6,12 +6,12 @@ USER root
 
 RUN apt-get update -y \
     && apt-get install -y software-properties-common \
-    && apt-get install -y wget procps gnupg2 \
-    && wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
+    && apt-get install -y wget procps gnupg2
 
-RUN add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/de
-RUN apt-get update -y && apt-get install -y adoptopenjdk-8-hotspot
-ENV JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
+# Install openjdk-8
+RUN apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main'
+RUN apt-get update && apt-get install -y openjdk-8-jdk
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 
 RUN apt-get update -y \
     && apt-get install -y git \
@@ -45,14 +45,14 @@ ENV HIVE_HOME=/usr/local/apache-hive-2.3.9-bin
 
 #install Apache Hadoop 2.10.1 (Download same version of library to match EMR hadopp version created by DAG)
 RUN curl "https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz" -o "/tmp/hadoop-2.10.1.tar.gz" \
-    && tar -xf /tmp/hadoop-2.10.1.tar.gz -C /usr/local/
+    && tar -xf /tmp/hadoop-2.10.1.tar.gz -C /usr/local
 ENV HADOOP_HOME=/usr/local/hadoop-2.10.1
 ENV HADOOP_CONF_DIR=$HADOOP_HOME/conf
 
 RUN curl "https://raw.githubusercontent.com/apache/hive/master/data/conf/hive-site.xml" -o "/tmp/hive-site.xml" \
-    && mv /tmp/hive-site.xml $HADOOP_HOME/conf
+    && mkdir $HADOOP_HOME/conf && mv /tmp/hive-site.xml $HADOOP_HOME/conf/hive-site.xml
 
-ENV PATH $PATH:$JAVA_HOME/bin:$HIVE_HOME:$HIVE_HOME/bin:$HADOOP_HOME:$HADOOP_HOME/bin:$SPARK_HOME:$SPARK_HOME/bin:$HADOOP_CONF_DIR
+ENV PATH $PATH:$JAVA_HOME/bin:$HIVE_HOME:$HIVE_HOME/bin:$HADOOP_HOME:$HADOOP_HOME/bin
 
 COPY astronomer-providers /tmp/astronomer-providers
 RUN pip install /tmp/astronomer-providers[all]
@@ -75,12 +75,12 @@ USER root
 
 RUN apt-get update -y \
     && apt-get install -y software-properties-common \
-    && apt-get install -y wget procps gnupg2 \
-    && wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
+    && apt-get install -y wget procps gnupg2
 
-RUN add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
-RUN apt-get update && apt-get install -y adoptopenjdk-8-hotspot
-ENV JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
+# Install openjdk-8
+RUN apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main'
+RUN apt-get update && apt-get install -y openjdk-8-jdk
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 
 RUN apt-get update -y \
     && apt-get install -y git \
@@ -114,14 +114,14 @@ ENV HIVE_HOME=/usr/local/apache-hive-2.3.9-bin
 
 #install Apache Hadoop 2.10.1 (Download same version of library to match EMR hadopp version created by DAG)
 RUN curl "https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz" -o "/tmp/hadoop-2.10.1.tar.gz" \
-    && tar -xf /tmp/hadoop-2.10.1.tar.gz -C /usr/local/
+    && tar -xf /tmp/hadoop-2.10.1.tar.gz -C /usr/local
 ENV HADOOP_HOME=/usr/local/hadoop-2.10.1
 ENV HADOOP_CONF_DIR=$HADOOP_HOME/conf
 
 RUN curl "https://raw.githubusercontent.com/apache/hive/master/data/conf/hive-site.xml" -o "/tmp/hive-site.xml" \
-    && mv /tmp/hive-site.xml $HADOOP_HOME/conf
+    && mkdir $HADOOP_HOME/conf && mv /tmp/hive-site.xml $HADOOP_HOME/conf/hive-site.xml
 
-ENV PATH $PATH:$JAVA_HOME/bin:$HIVE_HOME:$HIVE_HOME/bin:$HADOOP_HOME:$HADOOP_HOME/bin:$SPARK_HOME:$SPARK_HOME/bin:$HADOOP_CONF_DIR
+ENV PATH $PATH:$JAVA_HOME/bin:$HIVE_HOME:$HIVE_HOME/bin:$HADOOP_HOME:$HADOOP_HOME/bin
 
 COPY astronomer-providers /tmp/astronomer-providers
 RUN pip install /tmp/astronomer-providers[all]

--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -24,6 +24,10 @@ RUN apt-get update -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Set Hive and hadoop versions.
+ENV HIVE_LIBRARY_VERSION=hive-2.3.9
+ENV HADOOP_LIBRARY_VERSION=hadoop-2.10.1
+
 # install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \
@@ -38,19 +42,16 @@ RUN curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin
 
-#install Apache Hive 2.3.9 (Download same version of library to match EMR hive version created by DAG)
-RUN curl "https://downloads.apache.org/hive/hive-2.3.9/apache-hive-2.3.9-bin.tar.gz" -o  "/tmp/apache-hive-2.3.9-bin.tar.gz"  \
-    && tar -xf /tmp/apache-hive-2.3.9-bin.tar.gz -C /usr/local
-ENV HIVE_HOME=/usr/local/apache-hive-2.3.9-bin
+#install Apache Hive (Download same version of library to match EMR hive version created by DAG)
+RUN curl "https://downloads.apache.org/hive/$HIVE_LIBRARY_VERSION/apache-$HIVE_LIBRARY_VERSION-bin.tar.gz" -o  "/tmp/apache-$HIVE_LIBRARY_VERSION-bin.tar.gz"  \
+    && tar -xf /tmp/apache-$HIVE_LIBRARY_VERSION-bin.tar.gz -C /usr/local
+ENV HIVE_HOME=/usr/local/apache-$HIVE_LIBRARY_VERSION-bin
 
-#install Apache Hadoop 2.10.1 (Download same version of library to match EMR hadopp version created by DAG)
-RUN curl "https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz" -o "/tmp/hadoop-2.10.1.tar.gz" \
-    && tar -xf /tmp/hadoop-2.10.1.tar.gz -C /usr/local
-ENV HADOOP_HOME=/usr/local/hadoop-2.10.1
+#install Apache Hadoop (Download same version of library to match EMR hadopp version created by DAG)
+RUN curl "https://archive.apache.org/dist/hadoop/common/$HADOOP_LIBRARY_VERSION/$HADOOP_LIBRARY_VERSION.tar.gz" -o "/tmp/$HADOOP_LIBRARY_VERSION.tar.gz" \
+    && tar -xf /tmp/$HADOOP_LIBRARY_VERSION.tar.gz -C /usr/local
+ENV HADOOP_HOME=/usr/local/$HADOOP_LIBRARY_VERSION
 ENV HADOOP_CONF_DIR=$HADOOP_HOME/conf
-
-RUN curl "https://raw.githubusercontent.com/apache/hive/master/data/conf/hive-site.xml" -o "/tmp/hive-site.xml" \
-    && mkdir $HADOOP_HOME/conf && mv /tmp/hive-site.xml $HADOOP_HOME/conf/hive-site.xml
 
 ENV PATH $PATH:$JAVA_HOME/bin:$HIVE_HOME:$HIVE_HOME/bin:$HADOOP_HOME:$HADOOP_HOME/bin
 
@@ -93,6 +94,10 @@ RUN apt-get update -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Set Hive and hadoop versions.
+ENV HIVE_LIBRARY_VERSION=hive-2.3.9
+ENV HADOOP_LIBRARY_VERSION=hadoop-2.10.1
+
 # install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \
@@ -107,19 +112,16 @@ RUN curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin
 
-#install Apache Hive 2.3.9 (Download same version of library to match EMR hive version created by DAG)
-RUN curl "https://downloads.apache.org/hive/hive-2.3.9/apache-hive-2.3.9-bin.tar.gz" -o  "/tmp/apache-hive-2.3.9-bin.tar.gz"  \
-    && tar -xf /tmp/apache-hive-2.3.9-bin.tar.gz -C /usr/local
-ENV HIVE_HOME=/usr/local/apache-hive-2.3.9-bin
+#install Apache Hive (Download same version of library to match EMR hive version created by DAG)
+RUN curl "https://downloads.apache.org/hive/$HIVE_LIBRARY_VERSION/apache-$HIVE_LIBRARY_VERSION-bin.tar.gz" -o  "/tmp/apache-$HIVE_LIBRARY_VERSION-bin.tar.gz"  \
+    && tar -xf /tmp/apache-$HIVE_LIBRARY_VERSION-bin.tar.gz -C /usr/local
+ENV HIVE_HOME=/usr/local/apache-$HIVE_LIBRARY_VERSION-bin
 
-#install Apache Hadoop 2.10.1 (Download same version of library to match EMR hadopp version created by DAG)
-RUN curl "https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz" -o "/tmp/hadoop-2.10.1.tar.gz" \
-    && tar -xf /tmp/hadoop-2.10.1.tar.gz -C /usr/local
-ENV HADOOP_HOME=/usr/local/hadoop-2.10.1
+#install Apache Hadoop (Download same version of library to match EMR hadopp version created by DAG)
+RUN curl "https://archive.apache.org/dist/hadoop/common/$HADOOP_LIBRARY_VERSION/$HADOOP_LIBRARY_VERSION.tar.gz" -o "/tmp/$HADOOP_LIBRARY_VERSION.tar.gz" \
+    && tar -xf /tmp/$HADOOP_LIBRARY_VERSION.tar.gz -C /usr/local
+ENV HADOOP_HOME=/usr/local/$HADOOP_LIBRARY_VERSION
 ENV HADOOP_CONF_DIR=$HADOOP_HOME/conf
-
-RUN curl "https://raw.githubusercontent.com/apache/hive/master/data/conf/hive-site.xml" -o "/tmp/hive-site.xml" \
-    && mkdir $HADOOP_HOME/conf && mv /tmp/hive-site.xml $HADOOP_HOME/conf/hive-site.xml
 
 ENV PATH $PATH:$JAVA_HOME/bin:$HIVE_HOME:$HIVE_HOME/bin:$HADOOP_HOME:$HADOOP_HOME/bin
 

--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -3,6 +3,16 @@ FROM quay.io/astronomer/ap-airflow:2.2.5 as staging
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 
 USER root
+
+RUN apt-get update -y \
+    && apt-get install -y software-properties-common \
+    && apt-get install -y wget procps gnupg2 \
+    && wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
+
+RUN add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/de
+RUN apt-get update -y && apt-get install -y adoptopenjdk-8-hotspot
+ENV JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
+
 RUN apt-get update -y \
     && apt-get install -y git \
     && apt-get install -y unzip \
@@ -28,12 +38,28 @@ RUN curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin
 
+#install Apache Hive 2.3.9 (Download same version of library to match EMR hive version created by DAG)
+RUN curl "https://downloads.apache.org/hive/hive-2.3.9/apache-hive-2.3.9-bin.tar.gz" -o  "/tmp/apache-hive-2.3.9-bin.tar.gz"  \
+    && tar -xf /tmp/apache-hive-2.3.9-bin.tar.gz -C /usr/local
+ENV HIVE_HOME=/usr/local/apache-hive-2.3.9-bin
+
+#install Apache Hadoop 2.10.1 (Download same version of library to match EMR hadopp version created by DAG)
+RUN curl "https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz" -o "/tmp/hadoop-2.10.1.tar.gz" \
+    && tar -xf /tmp/hadoop-2.10.1.tar.gz -C /usr/local/
+ENV HADOOP_HOME=/usr/local/hadoop-2.10.1
+ENV HADOOP_CONF_DIR=$HADOOP_HOME/conf
+
+RUN curl "https://raw.githubusercontent.com/apache/hive/master/data/conf/hive-site.xml" -o "/tmp/hive-site.xml" \
+    && mv /tmp/hive-site.xml $HADOOP_HOME/conf
+
+ENV PATH $PATH:$JAVA_HOME/bin:$HIVE_HOME:$HIVE_HOME/bin:$HADOOP_HOME:$HADOOP_HOME/bin:$SPARK_HOME:$SPARK_HOME/bin:$HADOOP_CONF_DIR
+
 COPY astronomer-providers /tmp/astronomer-providers
 RUN pip install /tmp/astronomer-providers[all]
 RUN pip install apache-airflow[slack]
 
-
 RUN mkdir -p ${AIRFLOW_HOME}/dags
+
 COPY . .
 RUN cp -r example_* ${AIRFLOW_HOME}/dags
 RUN cp master_dag.py  ${AIRFLOW_HOME}/dags/
@@ -46,6 +72,16 @@ FROM quay.io/astronomer/astro-runtime:4.2.4-base as astro-cloud
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 
 USER root
+
+RUN apt-get update -y \
+    && apt-get install -y software-properties-common \
+    && apt-get install -y wget procps gnupg2 \
+    && wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
+
+RUN add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+RUN apt-get update && apt-get install -y adoptopenjdk-8-hotspot
+ENV JAVA_HOME=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
+
 RUN apt-get update -y \
     && apt-get install -y git \
     && apt-get install -y unzip \
@@ -70,6 +106,22 @@ RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/late
 RUN curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03-09/bin/linux/amd64/kubectl \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin
+
+#install Apache Hive 2.3.9 (Download same version of library to match EMR hive version created by DAG)
+RUN curl "https://downloads.apache.org/hive/hive-2.3.9/apache-hive-2.3.9-bin.tar.gz" -o  "/tmp/apache-hive-2.3.9-bin.tar.gz"  \
+    && tar -xf /tmp/apache-hive-2.3.9-bin.tar.gz -C /usr/local
+ENV HIVE_HOME=/usr/local/apache-hive-2.3.9-bin
+
+#install Apache Hadoop 2.10.1 (Download same version of library to match EMR hadopp version created by DAG)
+RUN curl "https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz" -o "/tmp/hadoop-2.10.1.tar.gz" \
+    && tar -xf /tmp/hadoop-2.10.1.tar.gz -C /usr/local/
+ENV HADOOP_HOME=/usr/local/hadoop-2.10.1
+ENV HADOOP_CONF_DIR=$HADOOP_HOME/conf
+
+RUN curl "https://raw.githubusercontent.com/apache/hive/master/data/conf/hive-site.xml" -o "/tmp/hive-site.xml" \
+    && mv /tmp/hive-site.xml $HADOOP_HOME/conf
+
+ENV PATH $PATH:$JAVA_HOME/bin:$HIVE_HOME:$HIVE_HOME/bin:$HADOOP_HOME:$HADOOP_HOME/bin:$SPARK_HOME:$SPARK_HOME/bin:$HADOOP_CONF_DIR
 
 COPY astronomer-providers /tmp/astronomer-providers
 RUN pip install /tmp/astronomer-providers[all]

--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -47,7 +47,7 @@ RUN curl "https://downloads.apache.org/hive/$HIVE_LIBRARY_VERSION/apache-$HIVE_L
     && tar -xf /tmp/apache-$HIVE_LIBRARY_VERSION-bin.tar.gz -C /usr/local
 ENV HIVE_HOME=/usr/local/apache-$HIVE_LIBRARY_VERSION-bin
 
-#install Apache Hadoop (Download same version of library to match EMR hadopp version created by DAG)
+#install Apache Hadoop (Download same version of library to match EMR hadoop version created by DAG)
 RUN curl "https://archive.apache.org/dist/hadoop/common/$HADOOP_LIBRARY_VERSION/$HADOOP_LIBRARY_VERSION.tar.gz" -o "/tmp/$HADOOP_LIBRARY_VERSION.tar.gz" \
     && tar -xf /tmp/$HADOOP_LIBRARY_VERSION.tar.gz -C /usr/local
 ENV HADOOP_HOME=/usr/local/$HADOOP_LIBRARY_VERSION
@@ -117,7 +117,7 @@ RUN curl "https://downloads.apache.org/hive/$HIVE_LIBRARY_VERSION/apache-$HIVE_L
     && tar -xf /tmp/apache-$HIVE_LIBRARY_VERSION-bin.tar.gz -C /usr/local
 ENV HIVE_HOME=/usr/local/apache-$HIVE_LIBRARY_VERSION-bin
 
-#install Apache Hadoop (Download same version of library to match EMR hadopp version created by DAG)
+#install Apache Hadoop (Download same version of library to match EMR hadoop version created by DAG)
 RUN curl "https://archive.apache.org/dist/hadoop/common/$HADOOP_LIBRARY_VERSION/$HADOOP_LIBRARY_VERSION.tar.gz" -o "/tmp/$HADOOP_LIBRARY_VERSION.tar.gz" \
     && tar -xf /tmp/$HADOOP_LIBRARY_VERSION.tar.gz -C /usr/local
 ENV HADOOP_HOME=/usr/local/$HADOOP_LIBRARY_VERSION

--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update -y \
     && apt-get install -y wget procps gnupg2
 
 # Install openjdk-8
-RUN apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main'
-RUN apt-get update && apt-get install -y openjdk-8-jdk
+RUN apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main' \
+    && apt-get update && apt-get install -y openjdk-8-jdk
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 
 RUN apt-get update -y \
@@ -24,7 +24,7 @@ RUN apt-get update -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Set Hive and hadoop versions.
+# Set Hive and Hadoop versions.
 ENV HIVE_LIBRARY_VERSION=hive-2.3.9
 ENV HADOOP_LIBRARY_VERSION=hadoop-2.10.1
 
@@ -42,18 +42,18 @@ RUN curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin
 
-#install Apache Hive (Download same version of library to match EMR hive version created by DAG)
+# Install Apache Hive (Download same version of library to match EMR Hive version created by DAG).
 RUN curl "https://downloads.apache.org/hive/$HIVE_LIBRARY_VERSION/apache-$HIVE_LIBRARY_VERSION-bin.tar.gz" -o  "/tmp/apache-$HIVE_LIBRARY_VERSION-bin.tar.gz"  \
     && tar -xf /tmp/apache-$HIVE_LIBRARY_VERSION-bin.tar.gz -C /usr/local
 ENV HIVE_HOME=/usr/local/apache-$HIVE_LIBRARY_VERSION-bin
 
-#install Apache Hadoop (Download same version of library to match EMR hadoop version created by DAG)
+# Install Apache Hadoop (Download same version of library to match EMR Hadoop version created by DAG).
 RUN curl "https://archive.apache.org/dist/hadoop/common/$HADOOP_LIBRARY_VERSION/$HADOOP_LIBRARY_VERSION.tar.gz" -o "/tmp/$HADOOP_LIBRARY_VERSION.tar.gz" \
     && tar -xf /tmp/$HADOOP_LIBRARY_VERSION.tar.gz -C /usr/local
 ENV HADOOP_HOME=/usr/local/$HADOOP_LIBRARY_VERSION
 ENV HADOOP_CONF_DIR=$HADOOP_HOME/conf
 
-ENV PATH $PATH:$JAVA_HOME/bin:$HIVE_HOME:$HIVE_HOME/bin:$HADOOP_HOME:$HADOOP_HOME/bin
+ENV PATH $PATH:$JAVA_HOME/bin:$HIVE_HOME/bin:$HADOOP_HOME/bin
 
 COPY astronomer-providers /tmp/astronomer-providers
 RUN pip install /tmp/astronomer-providers[all]
@@ -79,8 +79,8 @@ RUN apt-get update -y \
     && apt-get install -y wget procps gnupg2
 
 # Install openjdk-8
-RUN apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main'
-RUN apt-get update && apt-get install -y openjdk-8-jdk
+RUN apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main' \
+    && apt-get update && apt-get install -y openjdk-8-jdk
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 
 RUN apt-get update -y \
@@ -94,7 +94,7 @@ RUN apt-get update -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Set Hive and hadoop versions.
+# Set Hive and Hadoop versions.
 ENV HIVE_LIBRARY_VERSION=hive-2.3.9
 ENV HADOOP_LIBRARY_VERSION=hadoop-2.10.1
 
@@ -112,18 +112,18 @@ RUN curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin
 
-#install Apache Hive (Download same version of library to match EMR hive version created by DAG)
+# Install Apache Hive (Download same version of library to match EMR Hive version created by DAG)
 RUN curl "https://downloads.apache.org/hive/$HIVE_LIBRARY_VERSION/apache-$HIVE_LIBRARY_VERSION-bin.tar.gz" -o  "/tmp/apache-$HIVE_LIBRARY_VERSION-bin.tar.gz"  \
     && tar -xf /tmp/apache-$HIVE_LIBRARY_VERSION-bin.tar.gz -C /usr/local
 ENV HIVE_HOME=/usr/local/apache-$HIVE_LIBRARY_VERSION-bin
 
-#install Apache Hadoop (Download same version of library to match EMR hadoop version created by DAG)
+# Install Apache Hadoop (Download same version of library to match EMR Hadoop version created by DAG)
 RUN curl "https://archive.apache.org/dist/hadoop/common/$HADOOP_LIBRARY_VERSION/$HADOOP_LIBRARY_VERSION.tar.gz" -o "/tmp/$HADOOP_LIBRARY_VERSION.tar.gz" \
     && tar -xf /tmp/$HADOOP_LIBRARY_VERSION.tar.gz -C /usr/local
 ENV HADOOP_HOME=/usr/local/$HADOOP_LIBRARY_VERSION
 ENV HADOOP_CONF_DIR=$HADOOP_HOME/conf
 
-ENV PATH $PATH:$JAVA_HOME/bin:$HIVE_HOME:$HIVE_HOME/bin:$HADOOP_HOME:$HADOOP_HOME/bin
+ENV PATH $PATH:$JAVA_HOME/bin::$HIVE_HOME/bin:$HADOOP_HOME/bin
 
 COPY astronomer-providers /tmp/astronomer-providers
 RUN pip install /tmp/astronomer-providers[all]

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -165,7 +165,7 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
                 ip_exists = True
 
     if not ip_exists:
-        # open port for port 10000
+        # Port 10000 need to be open for Impyla connectivity to Hive
         client.authorize_security_group_ingress(
             GroupId=task_instance.xcom_pull(
                 key="cluster_response_master_security_group", task_ids=["describe_created_cluster"]
@@ -180,7 +180,7 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
             ],
         )
 
-        # open port for port 22 for ssh and copy file for hdfs
+        # Allow SSH traffic on port 22 and copy file to hdfs
         client.authorize_security_group_ingress(
             GroupId=task_instance.xcom_pull(
                 key="cluster_response_master_security_group", task_ids=["describe_created_cluster"]

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -42,9 +42,9 @@ main/astronomer/providers/apache/hive/example_dags/zipcodes.csv \
     "hdfs dfs -put zipcodes.csv /user/root",
 ]
 
-# emr-5.34.0 cluster has been used and apache-hive-2.3.9-bin and hadoop-2.10.1
-# has been used for integration testing. If the versions of emr cluster changes then we need to
-# update and match the hive and hadoop libraries versions in the integration tests `Dockefile`.
+# This example uses an emr-5.34.0 cluster,apache-hive-2.3.9-bin and hadoop-2.10.1.
+# If you would like to use a different version of the EMR cluster, then we need to
+# match the hive and hadoop versions same as specified in the integration tests `Dockefile`.
 JOB_FLOW_OVERRIDES = {
     "Name": "team-provider-example-dag-hive-test",
     "ReleaseLabel": "emr-5.34.0",

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -42,7 +42,7 @@ main/astronomer/providers/apache/hive/example_dags/zipcodes.csv \
     "hdfs dfs -put zipcodes.csv /user/root",
 ]
 
-# This example uses an emr-5.34.0 cluster,apache-hive-2.3.9-bin and hadoop-2.10.1.
+# This example uses an emr-5.34.0 cluster, apache-hive-2.3.9 and hadoop-2.10.1.
 # If you would like to use a different version of the EMR cluster, then we need to
 # match the hive and hadoop versions same as specified in the integration tests `Dockefile`.
 JOB_FLOW_OVERRIDES = {

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -180,7 +180,7 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
             ],
         )
 
-        # Allow SSH traffic on port 22 and copy file to hdfs
+        # Allow SSH traffic on port 22 and copy file to HDFS
         client.authorize_security_group_ingress(
             GroupId=task_instance.xcom_pull(
                 key="cluster_response_master_security_group", task_ids=["describe_created_cluster"]

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -42,6 +42,9 @@ main/astronomer/providers/apache/hive/example_dags/zipcodes.csv \
     "hdfs dfs -put zipcodes.csv /user/root",
 ]
 
+# emr-5.34.0 cluster has been used and same versions of hive and hadoop binaries
+# has been used for integration testing. If the versions of emr cluster changes then we need to
+# update and match the hive and hadoop libraries versions in the integration tests `Dockefile`.
 JOB_FLOW_OVERRIDES = {
     "Name": "team-provider-example-dag-hive-test",
     "ReleaseLabel": "emr-5.34.0",

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -42,7 +42,7 @@ main/astronomer/providers/apache/hive/example_dags/zipcodes.csv \
     "hdfs dfs -put zipcodes.csv /user/root",
 ]
 
-# emr-5.34.0 cluster has been used and same versions of hive and hadoop binaries
+# emr-5.34.0 cluster has been used and apache-hive-2.3.9-bin and hadoop-2.10.1
 # has been used for integration testing. If the versions of emr cluster changes then we need to
 # update and match the hive and hadoop libraries versions in the integration tests `Dockefile`.
 JOB_FLOW_OVERRIDES = {
@@ -165,7 +165,7 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
                 ip_exists = True
 
     if not ip_exists:
-        # open port for port 8998
+        # open port for port 10000
         client.authorize_security_group_ingress(
             GroupId=task_instance.xcom_pull(
                 key="cluster_response_master_security_group", task_ids=["describe_created_cluster"]
@@ -179,6 +179,7 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
                 }
             ],
         )
+
         # open port for port 22 for ssh and copy file for hdfs
         client.authorize_security_group_ingress(
             GroupId=task_instance.xcom_pull(

--- a/astronomer/providers/apache/hive/sensors/hive_partition.py
+++ b/astronomer/providers/apache/hive/sensors/hive_partition.py
@@ -10,7 +10,7 @@ from astronomer.providers.apache.hive.triggers.hive_partition import (
 
 class HivePartitionSensorAsync(HivePartitionSensor):
     """
-    Waits for a given partition to show up in Hive table.
+    Waits for a given partition to show up in Hive table asynchronously.
 
     .. note::
        HivePartitionSensorAsync uses implya library instead of pyhive.

--- a/astronomer/providers/apache/hive/sensors/hive_partition.py
+++ b/astronomer/providers/apache/hive/sensors/hive_partition.py
@@ -12,10 +12,10 @@ class HivePartitionSensorAsync(HivePartitionSensor):
     """
     Waits for a given partition to show up in Hive.
     Note: HivePartitionSensorAsync uses implya library instead of pyhive
-    since pyhive is currently unsupported. Refer https://github.com/dropbox/PyHive.
-    Since we use implya library, please set the connection to use the port 10000 instead of 9083
-    The sensor currently supports `auth_mechansim='PLAIN'` only.
-    The library version of hive and hadoop in `Dockerfile` should match the remote cluster where the
+    since pyhive is currently `unsupported <https://github.com/dropbox/PyHive>`_.
+    Since we use implya library, please set the connection to use the port ``10000`` instead of ``9083``
+    The sensor currently supports ``auth_mechansim='PLAIN'`` only.
+    The library version of hive and hadoop in ``Dockerfile`` should match the remote cluster where the
     hadoop and hive is running.
 
     :param table: the table where the partition is present.

--- a/astronomer/providers/apache/hive/sensors/hive_partition.py
+++ b/astronomer/providers/apache/hive/sensors/hive_partition.py
@@ -21,8 +21,8 @@ class HivePartitionSensorAsync(HivePartitionSensor):
        please set the connection to use the port ``10000`` instead of ``9083``.
        This sensor currently supports ``auth_mechansim='PLAIN'`` only.
 
-       The library version of hive and hadoop in ``Dockerfile`` should match the remote cluster where the
-       hadoop and hive is running.
+       The library version of hive and hadoop in ``Dockerfile`` should match the remote
+       cluster where they are running.
 
     :param table: the table where the partition is present.
     :param partition: The partition clause to wait for. This is passed as

--- a/astronomer/providers/apache/hive/sensors/hive_partition.py
+++ b/astronomer/providers/apache/hive/sensors/hive_partition.py
@@ -14,7 +14,9 @@ class HivePartitionSensorAsync(HivePartitionSensor):
     Note: HivePartitionSensorAsync uses implya library instead of pyhive
     since pyhive is currently unsupported. Refer https://github.com/dropbox/PyHive.
     Since we use implya library, please set the connection to use the port 10000 instead of 9083
-    The sensor currently supports auth_mechansim='PLAIN' only.
+    The sensor currently supports `auth_mechansim='PLAIN'` only.
+    The library version of hive and hadoop in `Dockerfile` should match the remote cluster where the
+    hadoop and hive is running.
 
     :param table: the table where the partition is present.
     :param partition: The partition clause to wait for. This is passed as

--- a/astronomer/providers/apache/hive/sensors/hive_partition.py
+++ b/astronomer/providers/apache/hive/sensors/hive_partition.py
@@ -10,13 +10,16 @@ from astronomer.providers.apache.hive.triggers.hive_partition import (
 
 class HivePartitionSensorAsync(HivePartitionSensor):
     """
-    Waits for a given partition to show up in Hive.
-    Note: HivePartitionSensorAsync uses implya library instead of pyhive
-    since pyhive is currently `unsupported <https://github.com/dropbox/PyHive>`_.
-    Since we use implya library, please set the connection to use the port ``10000`` instead of ``9083``
-    The sensor currently supports ``auth_mechansim='PLAIN'`` only.
-    The library version of hive and hadoop in ``Dockerfile`` should match the remote cluster where the
-    hadoop and hive is running.
+    .. note:: HivePartitionSensorAsync uses implya library instead of pyhive
+       since pyhive is currently `unsupported <https://github.com/dropbox/PyHive>`_.
+
+       Since we use implya library, please set the connection to use the port ``10000`` instead of ``9083``
+       The sensor currently supports ``auth_mechansim='PLAIN'`` only.
+
+       The library version of hive and hadoop in ``Dockerfile`` should match the remote cluster where the
+       hadoop and hive is running.
+
+    Waits for a given partition to show up in Hive table.
 
     :param table: the table where the partition is present.
     :param partition: The partition clause to wait for. This is passed as

--- a/astronomer/providers/apache/hive/sensors/hive_partition.py
+++ b/astronomer/providers/apache/hive/sensors/hive_partition.py
@@ -12,7 +12,8 @@ class HivePartitionSensorAsync(HivePartitionSensor):
     """
     Waits for a given partition to show up in Hive table.
 
-    .. note:: HivePartitionSensorAsync uses implya library instead of pyhive.
+    .. note::
+       HivePartitionSensorAsync uses implya library instead of pyhive.
        Note that pyhive is currently `unsupported <https://github.com/dropbox/PyHive>`_.
 
        Since we use implya library, please set the connection to use the port ``10000`` instead of ``9083``

--- a/astronomer/providers/apache/hive/sensors/hive_partition.py
+++ b/astronomer/providers/apache/hive/sensors/hive_partition.py
@@ -10,16 +10,16 @@ from astronomer.providers.apache.hive.triggers.hive_partition import (
 
 class HivePartitionSensorAsync(HivePartitionSensor):
     """
-    .. note:: HivePartitionSensorAsync uses implya library instead of pyhive
-       since pyhive is currently `unsupported <https://github.com/dropbox/PyHive>`_.
+    Waits for a given partition to show up in Hive table.
+
+    .. note:: HivePartitionSensorAsync uses implya library instead of pyhive.
+       Note that pyhive is currently `unsupported <https://github.com/dropbox/PyHive>`_.
 
        Since we use implya library, please set the connection to use the port ``10000`` instead of ``9083``
        The sensor currently supports ``auth_mechansim='PLAIN'`` only.
 
        The library version of hive and hadoop in ``Dockerfile`` should match the remote cluster where the
        hadoop and hive is running.
-
-    Waits for a given partition to show up in Hive table.
 
     :param table: the table where the partition is present.
     :param partition: The partition clause to wait for. This is passed as

--- a/astronomer/providers/apache/hive/sensors/hive_partition.py
+++ b/astronomer/providers/apache/hive/sensors/hive_partition.py
@@ -14,10 +14,12 @@ class HivePartitionSensorAsync(HivePartitionSensor):
 
     .. note::
        HivePartitionSensorAsync uses implya library instead of pyhive.
-       Note that pyhive is currently `unsupported <https://github.com/dropbox/PyHive>`_.
+       The sync version of this sensor uses `pyhive <https://github.com/dropbox/PyHive>`_,
+       but `pyhive <https://github.com/dropbox/PyHive>`_ is currently unsupported.
 
-       Since we use implya library, please set the connection to use the port ``10000`` instead of ``9083``
-       The sensor currently supports ``auth_mechansim='PLAIN'`` only.
+       Since we use `implya <https://github.com/cloudera/impyla>`_ library,
+       please set the connection to use the port ``10000`` instead of ``9083``.
+       This sensor currently supports ``auth_mechansim='PLAIN'`` only.
 
        The library version of hive and hadoop in ``Dockerfile`` should match the remote cluster where the
        hadoop and hive is running.


### PR DESCRIPTION
- Make example dag of `HivePartitionSensorAsync` self-sufficient for integration testing.
- Update sphinx docs and doc-strings to `HivePartitionSensorAsync`.
- The library version of hive and Hadoop in ``Dockerfile`` should match the remote cluster where the
     Hadoop and hive are running.

Closes #265 