### PR TITLE
Enable `aws-nuke` to delete specified AWS resources

### DIFF
--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -23,9 +23,10 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 RUN apt-get update && apt-get install -y wget
 
 # install AWS nuke
-RUN wget --quiet  "https://github.com/rebuy-de/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz"
-RUN tar -xzvf aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz -C /usr/local/bin
-RUN mv /usr/local/bin/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64 /usr/local/bin/aws-nuke
+RUN wget --quiet  \
+    "https://github.com/rebuy-de/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz" \
+    && tar -xzvf aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz -C /usr/local/bin \
+    && mv /usr/local/bin/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64 /usr/local/bin/aws-nuke
 
 # install eksctl
 RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp \
@@ -71,12 +72,13 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     && unzip awscliv2.zip \
     && ./aws/install;
 
-RUN apt-get update && apt-get install -y vim wget
+RUN apt-get update && apt-get install -y wget
 
 # install AWS nuke
-RUN wget --quiet  "https://github.com/rebuy-de/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz"
-RUN tar -xzvf aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz -C /usr/local/bin
-RUN mv /usr/local/bin/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64 /usr/local/bin/aws-nuke
+RUN wget --quiet  \
+    "https://github.com/rebuy-de/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz" \
+    && tar -xzvf aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz -C /usr/local/bin \
+    && mv /usr/local/bin/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64 /usr/local/bin/aws-nuke
 
 # install eksctl
 RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp \

--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -1,6 +1,7 @@
 FROM quay.io/astronomer/ap-airflow:2.2.5 as staging
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
+ENV AWS_NUKE_VERSION=v2.17.0
 
 USER root
 RUN apt-get update -y \
@@ -17,7 +18,14 @@ RUN apt-get update -y \
 # install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \
-    && ./aws/install
+    && ./aws/install;
+
+RUN apt-get update && apt-get install -y wget
+
+# install AWS nuke
+RUN wget --quiet  "https://github.com/rebuy-de/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz"
+RUN tar -xzvf aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz -C /usr/local/bin
+RUN mv /usr/local/bin/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64 /usr/local/bin/aws-nuke
 
 # install eksctl
 RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp \
@@ -37,6 +45,7 @@ RUN mkdir -p ${AIRFLOW_HOME}/dags
 COPY . .
 RUN cp -r example_* ${AIRFLOW_HOME}/dags
 RUN cp master_dag.py  ${AIRFLOW_HOME}/dags/
+RUN cp nuke-config.yml  ${AIRFLOW_HOME}/dags/
 
 USER astro
 
@@ -60,7 +69,14 @@ RUN apt-get update -y \
 # install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \
-    && ./aws/install
+    && ./aws/install;
+
+RUN apt-get update && apt-get install -y vim wget
+
+# install AWS nuke
+RUN wget --quiet  "https://github.com/rebuy-de/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz"
+RUN tar -xzvf aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz -C /usr/local/bin
+RUN mv /usr/local/bin/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64 /usr/local/bin/aws-nuke
 
 # install eksctl
 RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp \
@@ -80,5 +96,6 @@ RUN mkdir -p ${AIRFLOW_HOME}/dags
 COPY . .
 RUN cp -r example_* ${AIRFLOW_HOME}/dags
 RUN cp master_dag.py  ${AIRFLOW_HOME}/dags/
+RUN cp nuke-config.yml  ${AIRFLOW_HOME}/dags/
 
 USER astro

--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -34,8 +34,6 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     && unzip awscliv2.zip \
     && ./aws/install;
 
-RUN apt-get update && apt-get install -y wget
-
 # install AWS nuke
 RUN wget --quiet  \
     "https://github.com/rebuy-de/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz" \
@@ -112,8 +110,6 @@ ENV HADOOP_LIBRARY_VERSION=hadoop-2.10.1
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \
     && ./aws/install;
-
-RUN apt-get update && apt-get install -y wget
 
 # install AWS nuke
 RUN wget --quiet  \

--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -94,6 +94,7 @@ with DAG(
         {"s3_sensor_dag": "example_s3_sensor"},
         {"redshift_sql_dag": "example_async_redshift_sql"},
         {"redshift_cluster_mgmt_dag": "example_async_redshift_cluster_management"},
+        {"aws_nuke_dag": "example_aws_nuke"},
     ]
     amazon_trigger_tasks, ids = prepare_dag_dependency(amazon_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)

--- a/.circleci/integration-tests/nuke-config.yml
+++ b/.circleci/integration-tests/nuke-config.yml
@@ -4,9 +4,6 @@ regions:
   - us-east-1
   - us-west-1
   - us-west-2
-  - af-south-1
-  - ap-east-1
-  - ap-southeast-3
   - ap-south-1
   - ap-northeast-2
   - ap-northeast-3
@@ -17,10 +14,8 @@ regions:
   - eu-central-1
   - eu-west-1
   - eu-west-2
-  - eu-south-1
   - eu-west-3
   - eu-north-1
-  - me-south-1
   - sa-east-1
 account-blocklist:
   - '999999999999'
@@ -32,4 +27,4 @@ resource-types:
     - S3MultipartUpload
     - RedshiftCluster
 accounts:
-  '475538383708':  # aws-nuke-example
+  '475538383708':  # aws-oss-main

--- a/.circleci/integration-tests/nuke-config.yml
+++ b/.circleci/integration-tests/nuke-config.yml
@@ -1,6 +1,27 @@
 ---
 regions:
   - us-east-2
+  - us-east-1
+  - us-west-1
+  - us-west-2
+  - af-south-1
+  - ap-east-1
+  - ap-southeast-3
+  - ap-south-1
+  - ap-northeast-2
+  - ap-northeast-3
+  - ap-southeast-1
+  - ap-southeast-2
+  - ap-northeast-1
+  - ca-central-1
+  - eu-central-1
+  - eu-west-1
+  - eu-west-2
+  - eu-south-1
+  - eu-west-3
+  - eu-north-1
+  - me-south-1
+  - sa-east-1
 account-blocklist:
   - '999999999999'
 resource-types:
@@ -9,5 +30,6 @@ resource-types:
     - EC2Instance
     - EKSCluster
     - S3MultipartUpload
+    - RedshiftCluster
 accounts:
   '475538383708':  # aws-nuke-example

--- a/.circleci/integration-tests/nuke-config.yml
+++ b/.circleci/integration-tests/nuke-config.yml
@@ -1,0 +1,13 @@
+---
+regions:
+  - us-east-2
+account-blocklist:
+  - '999999999999'
+resource-types:
+  targets:
+    - EMRCluster
+    - EC2Instance
+    - EKSCluster
+    - S3MultipartUpload
+accounts:
+  '475538383708':  # aws-nuke-example

--- a/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
@@ -1,0 +1,42 @@
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.operators.dummy import DummyOperator
+
+AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "**********")
+AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "***********")
+AWS_DEFAULT_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-2")
+AWS_CONN_ID = os.environ.get("ASTRO_AWS_CONN_ID", "aws_default")
+EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
+
+default_args = {
+    "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+}
+
+with DAG(
+    dag_id="example_aws_nuke",
+    start_date=datetime(2022, 1, 1),
+    schedule_interval=timedelta(hours=1),
+    catchup=False,
+    default_args=default_args,
+    tags=["example", "async", "aws-nuke"],
+) as dag:
+    start = DummyOperator(task_id="start")
+
+    set_aws_config = BashOperator(
+        task_id="aws_config",
+        bash_command=f"aws configure set aws_access_key_id {AWS_ACCESS_KEY_ID}; "
+        f"aws configure set aws_secret_access_key {AWS_SECRET_ACCESS_KEY}; "
+        f"aws configure set default.region {AWS_DEFAULT_REGION}; ",
+    )
+
+    execute_aws_nuke = BashOperator(
+        task_id="execute_aws_nuke",
+        bash_command="aws-nuke -c /usr/local/airflow/dags/nuke-config.yml --profile default --force --no-dry-run; ",
+    )
+
+    end = DummyOperator(task_id="end")
+
+    start >> set_aws_config >> execute_aws_nuke >> end

--- a/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
@@ -18,7 +18,7 @@ default_args = {
 with DAG(
     dag_id="example_aws_nuke",
     start_date=datetime(2022, 1, 1),
-    schedule_interval=timedelta(hours=1),
+    schedule_interval="30 20 * * *",
     catchup=False,
     default_args=default_args,
     tags=["example", "aws-nuke"],

--- a/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
@@ -21,7 +21,7 @@ with DAG(
     schedule_interval=timedelta(hours=1),
     catchup=False,
     default_args=default_args,
-    tags=["example", "async", "aws-nuke"],
+    tags=["example", "aws-nuke"],
 ) as dag:
     start = DummyOperator(task_id="start")
 

--- a/astronomer/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
+++ b/astronomer/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
+from azure.core.exceptions import HttpResponseError
 from azure.identity import ClientSecretCredential
 from azure.mgmt.datafactory import DataFactoryManagementClient
 from azure.mgmt.datafactory.models import (
@@ -71,8 +72,8 @@ def create_adf_storage_pipeline() -> None:
     resource_group_exist = None
     try:
         resource_group_exist = resource_client.resource_groups.get(RESOURCE_GROUP_NAME)
-    except Exception:
-        logging.info("Resource group not found, so creating one")
+    except HttpResponseError as e:
+        logging.exception("Resource group not found, so creating one %s", e.__str__())
     if not resource_group_exist:
         resource_client.resource_groups.create_or_update(RESOURCE_GROUP_NAME, rg_params)
 


### PR DESCRIPTION
This PR introduces aws-nuke utility into the integration workflow so that we can clean our aws resources at a specified time of each day.

Fixes part of #44 