### PR TITLE
Add `NamedHivePartitionSensorAsync`

### DIFF
--- a/astronomer/providers/apache/hive/sensors/named_hive_partition.py
+++ b/astronomer/providers/apache/hive/sensors/named_hive_partition.py
@@ -1,0 +1,51 @@
+from typing import Dict, Optional
+
+from airflow.exceptions import AirflowException
+from airflow.providers.apache.hive.sensors.named_hive_partition import (
+    NamedHivePartitionSensor,
+)
+from airflow.utils.context import Context
+
+from astronomer.providers.apache.hive.triggers.named_hive_partition import (
+    NamedHivePartitionTrigger,
+)
+
+
+class NamedHivePartitionSensorAsync(NamedHivePartitionSensor):
+    """
+    Waits asynchronously for a set of partitions to show up in Hive.
+
+    :param partition_names: List of fully qualified names of the
+        partitions to wait for. A fully qualified name is of the
+        form ``schema.table/pk1=pv1/pk2=pv2``, for example,
+        default.users/ds=2016-01-01.
+    :param metastore_conn_id: Metastore thrift service connection id.
+    """
+
+    def execute(self, context: "Context") -> None:
+        """Submit a job to Hive and defer"""
+        if not self.partition_names:
+            raise ValueError("Partition array can't be empty")
+        self.defer(
+            timeout=self.execution_timeout,
+            trigger=NamedHivePartitionTrigger(
+                partition_names=self.partition_names,
+                metastore_conn_id=self.metastore_conn_id,
+                polling_interval=self.poke_interval,
+            ),
+            method_name="execute_complete",
+        )
+
+    def execute_complete(self, context: "Context", event: Optional[Dict[str, str]] = None) -> None:
+        """
+        Callback for when the trigger fires - returns immediately.
+        Relies on trigger to throw an exception, otherwise it assumes execution was
+        successful.
+        """
+        if event:
+            if event["status"] == "success":
+                self.log.info(event["message"])
+            else:
+                raise AirflowException(event["message"])
+        else:
+            raise AirflowException("No event received in trigger callback")

--- a/astronomer/providers/apache/hive/triggers/named_hive_partition.py
+++ b/astronomer/providers/apache/hive/triggers/named_hive_partition.py
@@ -1,0 +1,63 @@
+import asyncio
+from typing import Any, AsyncIterator, Dict, List, Tuple
+
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+from astronomer.providers.apache.hive.hooks.hive import HiveCliHookAsync
+
+
+class NamedHivePartitionTrigger(BaseTrigger):
+    """
+    A trigger that fires, and it looks for a partition in the given table
+    in the database or wait for the partition.
+
+    :param partition_names: List of fully qualified names of the
+        partitions to wait for.
+    :param metastore_conn_id: connection string to connect to hive.
+    :param polling_interval: polling period in seconds to check for the partition.
+    """
+
+    def __init__(
+        self,
+        partition_names: List[str],
+        metastore_conn_id: str,
+        polling_interval: float,
+    ):
+        super().__init__()
+        self.partition_names = partition_names
+        self.polling_interval = polling_interval
+        self.metastore_conn_id: str = metastore_conn_id
+
+    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+        """Serializes NamedHivePartitionTrigger arguments and classpath."""
+        return (
+            "astronomer.providers.apache.hive.triggers.named_hive_partition.NamedHivePartitionTrigger",
+            {
+                "partition_names": self.partition_names,
+                "polling_interval": self.polling_interval,
+                "metastore_conn_id": self.metastore_conn_id,
+            },
+        )
+
+    async def run(self) -> AsyncIterator["TriggerEvent"]:  # type: ignore[override]
+        """Run until found all given partition in Hive."""
+        try:
+            hook = HiveCliHookAsync(metastore_conn_id=self.metastore_conn_id)
+            number_of_partitions = len(self.partition_names)
+            res = [False] * number_of_partitions
+            while True:
+                for i in range(number_of_partitions):
+                    if not res[i]:
+                        schema, table, partition = hook.parse_partition_name(self.partition_names[i])
+                        if hook.check_partition_exists(
+                            schema=schema,
+                            table=table,
+                            partition=partition,
+                        ):
+                            self.log.info("Found partition for %s.%s/%s", schema, table, partition)
+                            res[i] = True
+                    if all(res):
+                        yield TriggerEvent({"status": "success", "message": "Named hive partition found."})
+                await asyncio.sleep(self.polling_interval)
+        except Exception as e:
+            yield TriggerEvent({"status": "error", "message": str(e)})

--- a/tests/apache/hive/sensors/test_named_hive_partition.py
+++ b/tests/apache/hive/sensors/test_named_hive_partition.py
@@ -1,0 +1,88 @@
+from unittest import mock
+
+import pytest
+from airflow.exceptions import AirflowException, TaskDeferred
+
+from astronomer.providers.apache.hive.sensors.named_hive_partition import (
+    NamedHivePartitionSensorAsync,
+)
+from astronomer.providers.apache.hive.triggers.named_hive_partition import (
+    NamedHivePartitionTrigger,
+)
+
+TEST_PARTITION = ["user.user_profile/city=delhi"]
+TEST_METASTORE_CONN_ID = "test_metastore_default"
+
+
+@pytest.fixture()
+def context():
+    """Creates an empty context."""
+    context = {}
+    yield context
+
+
+def test_named_hive_partition_sensor_async():
+    """
+    Asserts that a task is deferred and a NamedHivePartitionTrigger will be fired
+    when the NamedHivePartitionSensorAsync is executed.
+    """
+    task = NamedHivePartitionSensorAsync(
+        task_id="task-id",
+        partition_names=TEST_PARTITION,
+        metastore_conn_id=TEST_METASTORE_CONN_ID,
+    )
+    with pytest.raises(TaskDeferred) as exc:
+        task.execute(context)
+    assert isinstance(
+        exc.value.trigger, NamedHivePartitionTrigger
+    ), "Trigger is not a NamedHivePartitionTrigger"
+
+
+def test_named_hive_partition_sensor_async_exception():
+    """
+    Asserts that a task is deferred and a NamedHivePartitionTrigger will be fired
+    when the NamedHivePartitionSensorAsync is executed.
+    """
+    task = NamedHivePartitionSensorAsync(
+        task_id="task-id",
+        partition_names=[],
+        metastore_conn_id=TEST_METASTORE_CONN_ID,
+    )
+    with pytest.raises(ValueError):
+        task.execute(context)
+
+
+def test_named_hive_partition_sensor_async_execute_failure(context):
+    """Tests that an AirflowException is raised in case of error event"""
+    task = NamedHivePartitionSensorAsync(
+        task_id="task-id",
+        partition_names=[],
+        metastore_conn_id=TEST_METASTORE_CONN_ID,
+    )
+    with pytest.raises(AirflowException):
+        task.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
+
+
+def test_named_hive_partition_sensor_async_execute_complete():
+    """Asserts that logging occurs as expected"""
+    task = NamedHivePartitionSensorAsync(
+        task_id="task-id",
+        partition_names=TEST_PARTITION,
+        metastore_conn_id=TEST_METASTORE_CONN_ID,
+    )
+    with mock.patch.object(task.log, "info") as mock_log_info:
+        task.execute_complete(
+            context=None, event={"status": "success", "message": "Named hive partition found"}
+        )
+    mock_log_info.assert_called_with("Named hive partition found")
+
+
+def test_named_hive_partition_sensor_async_execute_failure_no_event(context):
+    """Assert that an AirflowException is raised in case of no event"""
+    task = NamedHivePartitionSensorAsync(
+        task_id="task-id",
+        partition_names=TEST_PARTITION,
+        metastore_conn_id=TEST_METASTORE_CONN_ID,
+    )
+    with pytest.raises(AirflowException):
+        task.execute_complete(context=None, event=None)

--- a/tests/apache/hive/triggers/test_named_hive_partition.py
+++ b/tests/apache/hive/triggers/test_named_hive_partition.py
@@ -1,0 +1,89 @@
+import asyncio
+from unittest import mock
+
+import pytest
+from airflow.triggers.base import TriggerEvent
+
+from astronomer.providers.apache.hive.triggers.named_hive_partition import (
+    NamedHivePartitionTrigger,
+)
+
+TEST_POLLING_INTERVAL = 5
+TEST_PARTITION_NAMES = ["user.user_profile/city=delhi"]
+TEST_METASTORE_CONN_ID = "test_conn_id"
+
+
+def test_hive_partition_trigger_serialization():
+    """
+    Asserts that the NamedHivePartitionTrigger correctly serializes its arguments
+    and classpath.
+    """
+    trigger = NamedHivePartitionTrigger(
+        partition_names=TEST_PARTITION_NAMES,
+        polling_interval=TEST_POLLING_INTERVAL,
+        metastore_conn_id=TEST_METASTORE_CONN_ID,
+    )
+    classpath, kwargs = trigger.serialize()
+    assert (
+        classpath
+        == "astronomer.providers.apache.hive.triggers.named_hive_partition.NamedHivePartitionTrigger"
+    )
+    assert kwargs == {
+        "partition_names": TEST_PARTITION_NAMES,
+        "polling_interval": TEST_POLLING_INTERVAL,
+        "metastore_conn_id": TEST_METASTORE_CONN_ID,
+    }
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.apache.hive.hooks.hive.HiveCliHookAsync.check_partition_exists")
+@mock.patch("astronomer.providers.apache.hive.hooks.hive.HiveCliHookAsync.get_connection")
+async def test_hive_partition_trigger_success(mock_get_connection, mock_check_partition_exists):
+    """Tests that the HivePartitionTrigger is success case when a partition exists in the given table"""
+    mock_check_partition_exists.return_value = True
+
+    trigger = NamedHivePartitionTrigger(
+        partition_names=TEST_PARTITION_NAMES,
+        polling_interval=TEST_POLLING_INTERVAL,
+        metastore_conn_id=TEST_METASTORE_CONN_ID,
+    )
+
+    generator = trigger.run()
+    response = await generator.asend(None)
+    assert TriggerEvent({"status": "success", "message": "Named hive partition found."}) == response
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.apache.hive.hooks.hive.HiveCliHookAsync.check_partition_exists")
+@mock.patch("astronomer.providers.apache.hive.hooks.hive.HiveCliHookAsync.get_connection")
+async def test_hive_partition_trigger_pending(mock_get_connection, mock_check_partition_exists):
+    """Test that HivePartitionTrigger is in loop if partition isn't found."""
+    mock_check_partition_exists.return_value = False
+
+    trigger = NamedHivePartitionTrigger(
+        partition_names=TEST_PARTITION_NAMES,
+        polling_interval=TEST_POLLING_INTERVAL,
+        metastore_conn_id=TEST_METASTORE_CONN_ID,
+    )
+    task = asyncio.create_task(trigger.run().__anext__())
+    await asyncio.sleep(0.5)
+
+    # TriggerEvent was not returned
+    assert task.done() is False
+    asyncio.get_event_loop().stop()
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.apache.hive.hooks.hive.HiveCliHookAsync.check_partition_exists")
+@mock.patch("astronomer.providers.apache.hive.hooks.hive.HiveCliHookAsync.get_connection")
+async def test_hive_partition_trigger_exception(mock_get_connection, mock_check_partition_exists):
+    """Tests the HivePartitionTrigger does fire if there is an exception."""
+    mock_check_partition_exists.side_effect = Exception("Test exception")
+    trigger = NamedHivePartitionTrigger(
+        partition_names=TEST_PARTITION_NAMES,
+        polling_interval=TEST_POLLING_INTERVAL,
+        metastore_conn_id=TEST_METASTORE_CONN_ID,
+    )
+    task = [i async for i in trigger.run()]
+    assert len(task) == 1
+    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task


### PR DESCRIPTION
Support for NamedHivePartitionSensorAsync. It currently only works with a plain auth mechanism.
 - Add Sensor/Trigger 
 - Add unit test 
 - Add example
 
Sync Version sensor [NamedHivePartitionSensor](https://github.com/apache/airflow/blob/main/airflow/sensors/named_hive_partition_sensor.py)

Closes: #277 