### PR TITLE
Add implementation for OpenLineage custom extractor for BigQueryInsertJobOperatorAsync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ coverage.xml
 
 # Mypy Cache
 .mypy_cache
+
+# Lineage server dumps
+dumps

--- a/Makefile
+++ b/Makefile
@@ -58,5 +58,8 @@ run-mypy: ## Run MyPy in Container
 		--rm -it astronomer-providers-dev \
 		-- mypy --install-types --cache-dir /home/astro/.cache/.mypy_cache $(RUN_ARGS)
 
+run-local-lineage-server: ## Run flask based local Lineage server
+	FLASK_APP=dev/local_flask_lineage_server.py flask run --host 0.0.0.0 --port 5050
+
 help: ## Prints this message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/astronomer/providers/google/cloud/extractors/bigquery_async_extractor.py
+++ b/astronomer/providers/google/cloud/extractors/bigquery_async_extractor.py
@@ -13,7 +13,7 @@ from astronomer.providers.google.cloud.operators.bigquery import (
 )
 
 
-class BigQueryInsertJobOperatorAsyncExtractor(BaseExtractor, LoggingMixin):
+class BigQueryAsyncExtractor(BaseExtractor, LoggingMixin):
     """
     This extractor provides visibility on the metadata of a BigQuery Insert Job
     including ``billedBytes``, ``rowCount``, ``size``, etc. submitted from a

--- a/astronomer/providers/google/cloud/extractors/bigquery_insertjoboperatorasync_extractor.py
+++ b/astronomer/providers/google/cloud/extractors/bigquery_insertjoboperatorasync_extractor.py
@@ -1,0 +1,97 @@
+import logging
+from typing import Any, List, Optional
+
+from airflow.exceptions import AirflowException
+from airflow.models.taskinstance import TaskInstance
+from airflow.version import version as AIRFLOW_VERSION
+from google.cloud.bigquery import Client
+from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
+from openlineage.airflow.utils import get_job_name, try_import_from_string
+from openlineage.common.provider.bigquery import BigQueryDatasetsProvider
+from pkg_resources import parse_version
+
+from astronomer.providers.google.cloud.operators.bigquery import (
+    BigQueryInsertJobOperatorAsync,
+)
+
+log = logging.getLogger(__name__)
+
+
+class BigQueryInsertJobOperatorAsyncExtractor(BaseExtractor):
+    """
+    This extractor provides visibility on the metadata of a BigQuery Insert Job
+    including ``billedBytes``, ``rowCount``, ``size``, etc. submitted from a
+    ``BigQueryInsertJobOperatorAsync`` operator.
+    """
+
+    def __init__(self, operator: BigQueryInsertJobOperatorAsync):
+        super().__init__(operator)
+        self._big_query_client = self._get_big_query_client()
+
+    def _get_big_query_client(self) -> Client:
+        """
+        Gets the BigQuery client to fetch job metadata.
+        The method checks whether a connection hook is available with the Airflow configuration for the operator, and
+        if yes, returns the same connection. Otherwise, returns the Client instance of``google.cloud.bigquery``.
+        """
+        if hasattr(self.operator, "hook") and self.operator.hook:
+            hook = self.operator.hook
+            return hook.get_client(project_id=hook.project_id, location=hook.location)
+        elif parse_version(AIRFLOW_VERSION) >= parse_version("2.0.0"):
+            BigQueryHook = try_import_from_string(
+                "airflow.providers.google.cloud.operators.bigquery.BigQueryHook"
+            )
+            if BigQueryHook is not None:
+                hook = BigQueryHook(
+                    gcp_conn_id=self.operator.gcp_conn_id,
+                    delegate_to=self.operator.delegate_to,
+                    location=self.operator.location,
+                    impersonation_chain=self.operator.impersonation_chain,
+                )
+                return hook.get_client(project_id=hook.project_id, location=hook.location)
+        return Client()
+
+    @staticmethod
+    def _get_xcom_bigquery_job_id(task_instance: TaskInstance) -> Any:
+        """
+        Pulls the BigQuery Job ID from XCOM for the task instance whose metadata needs to be extracted.
+
+        :param task_instance: Instance of the Airflow task whose BigQuery ``job_id`` needs to be pulled from XCOM.
+        """
+        bigquery_job_id = task_instance.xcom_pull(task_ids=task_instance.task_id, key="job_id")
+        log.debug("Big Query Job Id %s", bigquery_job_id)
+        return bigquery_job_id
+
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        """Returns the list of operators this extractor works on."""
+        return ["BigQueryInsertJobOperatorAsync"]
+
+    def extract(self) -> Optional[TaskMetadata]:
+        """Empty extract implementation for the abstractmethod of the ``BaseExtractor`` class."""
+        return None
+
+    def extract_on_complete(self, task_instance: TaskInstance) -> Optional[TaskMetadata]:
+        """
+        Callback on task completion to fetch metadata extraction details that are to be pushed to the Lineage server.
+
+        :param task_instance: Instance of the Airflow task whose metadata needs to be extracted.
+        """
+        try:
+            bigquery_job_id = self._get_xcom_bigquery_job_id(task_instance)
+            if bigquery_job_id is None:
+                raise AirflowException("Xcom could not resolve BigQuery job id." + "Job may have failed.")
+        except AirflowException:
+            log.exception("Cannot retrieve job details from BigQuery Client.")
+            return TaskMetadata(name=get_job_name(task=self.operator))
+        stats = BigQueryDatasetsProvider(client=self._big_query_client).get_facets(bigquery_job_id)
+        inputs = stats.inputs
+        output = stats.output
+        run_facets = stats.run_facets
+
+        return TaskMetadata(
+            name=get_job_name(task=self.operator),
+            inputs=[ds.to_openlineage_dataset() for ds in inputs],
+            outputs=[output.to_openlineage_dataset()] if output else [],
+            run_facets=run_facets,
+        )

--- a/astronomer/providers/google/cloud/extractors/bigquery_insertjoboperatorasync_extractor.py
+++ b/astronomer/providers/google/cloud/extractors/bigquery_insertjoboperatorasync_extractor.py
@@ -3,12 +3,10 @@ from typing import Any, List, Optional
 
 from airflow.exceptions import AirflowException
 from airflow.models.taskinstance import TaskInstance
-from airflow.version import version as AIRFLOW_VERSION
 from google.cloud.bigquery import Client
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
-from openlineage.airflow.utils import get_job_name, try_import_from_string
+from openlineage.airflow.utils import get_job_name
 from openlineage.common.provider.bigquery import BigQueryDatasetsProvider
-from pkg_resources import parse_version
 
 from astronomer.providers.google.cloud.operators.bigquery import (
     BigQueryInsertJobOperatorAsync,
@@ -37,18 +35,6 @@ class BigQueryInsertJobOperatorAsyncExtractor(BaseExtractor):
         if hasattr(self.operator, "hook") and self.operator.hook:
             hook = self.operator.hook
             return hook.get_client(project_id=hook.project_id, location=hook.location)
-        elif parse_version(AIRFLOW_VERSION) >= parse_version("2.0.0"):
-            BigQueryHook = try_import_from_string(
-                "airflow.providers.google.cloud.operators.bigquery.BigQueryHook"
-            )
-            if BigQueryHook is not None:
-                hook = BigQueryHook(
-                    gcp_conn_id=self.operator.gcp_conn_id,
-                    delegate_to=self.operator.delegate_to,
-                    location=self.operator.location,
-                    impersonation_chain=self.operator.impersonation_chain,
-                )
-                return hook.get_client(project_id=hook.project_id, location=hook.location)
         return Client()
 
     @staticmethod

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -140,7 +140,7 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
             event["message"],
         )
 
-        context["ti"].xcom_push(key="job_id", value=event["jobId"])
+        context["ti"].xcom_push(key="job_id", value=event["job_id"])
 
 
 class BigQueryCheckOperatorAsync(BigQueryCheckOperator):

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -140,6 +140,8 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
             event["message"],
         )
 
+        context["ti"].xcom_push(key="job_id", value=event["jobId"])
+
 
 class BigQueryCheckOperatorAsync(BigQueryCheckOperator):
     """

--- a/astronomer/providers/google/cloud/triggers/bigquery.py
+++ b/astronomer/providers/google/cloud/triggers/bigquery.py
@@ -68,6 +68,7 @@ class BigQueryInsertJobTrigger(BaseTrigger):
                 if response_from_hook == "success":
                     yield TriggerEvent(
                         {
+                            "jobId": self.job_id,
                             "status": "success",
                             "message": "Job completed",
                         }

--- a/astronomer/providers/google/cloud/triggers/bigquery.py
+++ b/astronomer/providers/google/cloud/triggers/bigquery.py
@@ -68,7 +68,7 @@ class BigQueryInsertJobTrigger(BaseTrigger):
                 if response_from_hook == "success":
                     yield TriggerEvent(
                         {
-                            "jobId": self.job_id,
+                            "job_id": self.job_id,
                             "status": "success",
                             "message": "Job completed",
                         }

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -20,6 +20,12 @@ x-airflow-common:
     AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "True"
     AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL: "5"
     ASTRONOMER_ENVIRONMENT: local
+    AIRFLOW__LINEAGE__BACKEND: openlineage.lineage_backend.OpenLineageBackend
+    OPENLINEAGE_URL: http://host.docker.internal:5050/
+    OPENLINEAGE_API_KEY: <YOUR_OPENLINEAGE_API_KEY>
+    OPENLINEAGE_NAMESPACE: dev
+    # yamllint disable-line rule:line-length
+    OPENLINEAGE_EXTRACTOR_BigQueryInsertJobOperatorAsync: astronomer.providers.google.cloud.extractors.bigquery_insertjoboperatorasync_extractor.BigQueryInsertJobOperatorAsyncExtractor
   volumes:
     - ./dags:/usr/local/airflow/dags
     - ./logs:/usr/local/airflow/logs

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -25,7 +25,7 @@ x-airflow-common:
     OPENLINEAGE_API_KEY: <YOUR_OPENLINEAGE_API_KEY>
     OPENLINEAGE_NAMESPACE: dev
     # yamllint disable-line rule:line-length
-    OPENLINEAGE_EXTRACTOR_BigQueryInsertJobOperatorAsync: astronomer.providers.google.cloud.extractors.bigquery_insertjoboperatorasync_extractor.BigQueryInsertJobOperatorAsyncExtractor
+    OPENLINEAGE_EXTRACTOR_BigQueryAsync: astronomer.providers.google.cloud.extractors.bigquery_async_extractor.BigQueryAsyncExtractor
   volumes:
     - ./dags:/usr/local/airflow/dags
     - ./logs:/usr/local/airflow/logs

--- a/dev/local_flask_lineage_server.py
+++ b/dev/local_flask_lineage_server.py
@@ -1,0 +1,33 @@
+import json
+import logging
+import os
+
+from dateutil.parser import parse
+from flask import Flask, request
+
+APP = Flask(__name__)
+logger = logging.getLogger(__name__)
+
+DUMPS_DIR = "dumps"
+os.makedirs(DUMPS_DIR, exist_ok=True)
+
+
+@APP.route("/api/v1/lineage", methods=["POST"])
+def dump():
+    """Endpoint to dump lineage event to a local file system directory."""
+    event_name = "default"
+    try:
+        js = json.loads(request.data)
+        content = json.dumps(js, sort_keys=True, indent=4)
+
+        date = parse(js["eventTime"]).date()
+        job_name = js["job"]["name"]
+        event_name = f"{date}-{job_name}"
+    except Exception:
+        content = str(request.data, "UTF-8")
+    file_path = f"{DUMPS_DIR}/{event_name}.json"
+
+    logger.info("Written event %s to file %s", event_name, file_path)
+    with open(file_path, "a") as f:
+        f.write(content)
+    return "", 200

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,11 @@ apache.hive =
     impyla
 microsoft.azure =
     apache-airflow-providers-microsoft-azure
+openlineage =
+    openlineage-airflow==0.6.2
+# Library to run a flask based local Lineage server to dump events to.
+flask =
+    Flask==1.1.4
 docs =
     sphinx
     sphinx-autoapi
@@ -127,6 +132,8 @@ all =
     kubernetes_asyncio
     paramiko
     impyla
+    openlineage-airflow==0.6.2
+    Flask==1.1.4
 
 [options.packages.find]
 include =

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,7 +92,7 @@ tests =
     pytest-cov
     pre-commit
 mypy =
-    mypy>=0.800
+    mypy==0.942
     types-aiofiles
     types-boto
     types-certifi

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,7 +92,7 @@ tests =
     pytest-cov
     pre-commit
 mypy =
-    mypy==0.942
+    mypy>=0.800
     types-aiofiles
     types-boto
     types-certifi

--- a/tests/google/cloud/extractors/job_details.json
+++ b/tests/google/cloud/extractors/job_details.json
@@ -1,0 +1,56 @@
+{
+  "kind": "bigquery#job",
+  "id": "astronomer-airflow-providers:US.airflow_example_async_bigquery_queries_insert_query_job_2022_04_28T18_32_32_169270_00_00_9dad4c2a5b6b4be168a3d32a14476144",
+  "selfLink": "https://bigquery.googleapis.com/bigquery/v2/projects/astronomer-airflow-providers/jobs/airflow_example_async_bigquery_queries_insert_query_job_2022_04_28T18_32_32_169270_00_00_9dad4c2a5b6b4be168a3d32a14476144?location=US",
+  "user_email": "user@email.com",
+  "jobReference": {
+    "projectId": "astronomer-airflow-providers",
+    "jobId": "airflow_example_async_bigquery_queries_insert_query_job_2022_04_28T18_32_32_169270_00_00_9dad4c2a5b6b4be168a3d32a14476144",
+    "location": "US"
+  },
+  "statistics": {
+    "creationTime": 1651170770441.0,
+    "startTime": 1651170770591.0,
+    "endTime": 1651170772087.0,
+    "totalBytesProcessed": "0",
+    "query": {
+      "queryPlan": [
+        {
+          "recordsRead": "0",
+          "recordsWritten": "2",
+          "status": "COMPLETE"
+        }
+      ],
+      "estimatedBytesProcessed": "0",
+      "totalPartitionsProcessed": "0",
+      "totalBytesProcessed": "0",
+      "totalBytesBilled": "0",
+      "referencedTables": [
+        {
+          "projectId": "astronomer-airflow-providers",
+          "datasetId": "astro_dataset",
+          "tableId": "table1"
+        }
+      ],
+      "numDmlAffectedRows": "2",
+      "statementType": "INSERT",
+      "dmlStats": {
+        "insertedRowCount": "2"
+      }
+    }
+  },
+  "status": {
+    "state": "DONE"
+  },
+  "configuration": {
+    "query": {
+      "query": "INSERT test-dataset.test-table VALUES (42, 'monthy python', '2022-01-01'), (42, 'fishy fish', '2022-01-01');",
+      "destinationTable": {
+        "projectId": "astronomer-airflow-providers",
+        "datasetId": "astro_dataset",
+        "tableId": "table1"
+      }
+    },
+    "jobType": "QUERY"
+  }
+}

--- a/tests/google/cloud/extractors/test_bigquery_async_extractor.py
+++ b/tests/google/cloud/extractors/test_bigquery_async_extractor.py
@@ -14,8 +14,8 @@ from openlineage.common.provider.bigquery import (
     BigQueryStatisticsDatasetFacet,
 )
 
-from astronomer.providers.google.cloud.extractors.bigquery_insertjoboperatorasync_extractor import (
-    BigQueryInsertJobOperatorAsyncExtractor,
+from astronomer.providers.google.cloud.extractors.bigquery_async_extractor import (
+    BigQueryAsyncExtractor,
 )
 from astronomer.providers.google.cloud.operators.bigquery import (
     BigQueryInsertJobOperatorAsync,
@@ -103,7 +103,7 @@ def test_extract_on_complete(mock_bg_dataset_provider, mock_xcom_pull, mock_hook
     with pytest.raises(TaskDeferred):
         operator.execute(context)
 
-    bq_extractor = BigQueryInsertJobOperatorAsyncExtractor(operator)
+    bq_extractor = BigQueryAsyncExtractor(operator)
     task_meta_extract = bq_extractor.extract()
     assert task_meta_extract is None
 
@@ -129,7 +129,7 @@ def test_extractor_works_on_operator():
     """Tests that the custom extractor implementation is available for the BigQueryInsertJobOperatorAsync Operator."""
     task_id = "insert_query_job"
     operator = BigQueryInsertJobOperatorAsync(task_id=task_id, configuration={})
-    assert type(operator).__name__ in BigQueryInsertJobOperatorAsyncExtractor.get_operator_classnames()
+    assert type(operator).__name__ in BigQueryAsyncExtractor.get_operator_classnames()
 
 
 @mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
@@ -160,7 +160,7 @@ def test_unavailable_xcom_raises_exception(mock_hook):
     with pytest.raises(TaskDeferred):
         operator.execute(context)
 
-    bq_extractor = BigQueryInsertJobOperatorAsyncExtractor(operator)
+    bq_extractor = BigQueryAsyncExtractor(operator)
     with mock.patch.object(bq_extractor.log, "exception") as mock_log_exception:
         task_meta = bq_extractor.extract_on_complete(task_instance)
 

--- a/tests/google/cloud/extractors/test_bigquery_async_extractor.py
+++ b/tests/google/cloud/extractors/test_bigquery_async_extractor.py
@@ -167,5 +167,5 @@ def test_unavailable_xcom_raises_exception(mock_hook):
     with mock.patch.object(bq_extractor.log, "exception") as mock_log_exception:
         task_meta = bq_extractor.extract_on_complete(task_instance)
 
-    mock_log_exception.assert_called_with("Could not pull relevant BigQuery job ID from XCOM")
+    mock_log_exception.assert_called_with("%s", "Could not pull relevant BigQuery job ID from XCOM")
     assert task_meta.name == f"adhoc_airflow.{task_id}"

--- a/tests/google/cloud/extractors/test_bigquery_insertjoboperatorasync_extractor.py
+++ b/tests/google/cloud/extractors/test_bigquery_insertjoboperatorasync_extractor.py
@@ -74,6 +74,10 @@ def context():
 @mock.patch("airflow.models.TaskInstance.xcom_pull")
 @mock.patch("openlineage.common.provider.bigquery.BigQueryDatasetsProvider.get_facets")
 def test_extract_on_complete(mock_bg_dataset_provider, mock_xcom_pull, mock_hook):
+    """
+    Tests that  the custom extractor's implementation for the BigQueryInsertJobOperatorAsync is able to process the
+    operator's metadata that needs to be extracted as per OpenLineage.
+    """
     configuration = {
         "query": {
             "query": INSERT_ROWS_QUERY,
@@ -122,6 +126,7 @@ def test_extract_on_complete(mock_bg_dataset_provider, mock_xcom_pull, mock_hook
 
 
 def test_extractor_works_on_operator():
+    """Tests that the custom extractor implementation is available for the BigQueryInsertJobOperatorAsync Operator."""
     task_id = "insert_query_job"
     operator = BigQueryInsertJobOperatorAsync(task_id=task_id, configuration={})
     assert type(operator).__name__ in BigQueryInsertJobOperatorAsyncExtractor.get_operator_classnames()
@@ -129,6 +134,10 @@ def test_extractor_works_on_operator():
 
 @mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
 def test_unavailable_xcom_raises_exception(mock_hook):
+    """
+    Tests that an exception is raised when the custom extractor is not available to retrieve required XCOM for the
+    BigQueryInsertJobOperatorAsync Operator.
+    """
     configuration = {
         "query": {
             "query": INSERT_ROWS_QUERY,

--- a/tests/google/cloud/extractors/test_bigquery_insertjoboperatorasync_extractor.py
+++ b/tests/google/cloud/extractors/test_bigquery_insertjoboperatorasync_extractor.py
@@ -119,3 +119,9 @@ def test_extract_on_complete(mock_bg_dataset_provider, mock_xcom_pull, mock_hook
     assert task_meta.run_facets["bigQuery_job"].billedBytes == 0
     run_facet_properties = json.loads(task_meta.run_facets["bigQuery_job"].properties)
     assert run_facet_properties == JOB_PROPERTIES
+
+
+def test_extractor_works_on_operator():
+    task_id = "insert_query_job"
+    operator = BigQueryInsertJobOperatorAsync(task_id=task_id, configuration={})
+    assert type(operator).__name__ in BigQueryInsertJobOperatorAsyncExtractor.get_operator_classnames()

--- a/tests/google/cloud/extractors/test_bigquery_insertjoboperatorasync_extractor.py
+++ b/tests/google/cloud/extractors/test_bigquery_insertjoboperatorasync_extractor.py
@@ -1,0 +1,121 @@
+import json
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+from airflow.exceptions import TaskDeferred
+from airflow.models.taskinstance import TaskInstance
+from airflow.utils.timezone import datetime
+from openlineage.client.facet import OutputStatisticsOutputDatasetFacet
+from openlineage.common.dataset import Dataset, Source
+from openlineage.common.provider.bigquery import (
+    BigQueryFacets,
+    BigQueryJobRunFacet,
+    BigQueryStatisticsDatasetFacet,
+)
+
+from astronomer.providers.google.cloud.extractors.bigquery_insertjoboperatorasync_extractor import (
+    BigQueryInsertJobOperatorAsyncExtractor,
+)
+from astronomer.providers.google.cloud.operators.bigquery import (
+    BigQueryInsertJobOperatorAsync,
+)
+
+TEST_DATASET_LOCATION = "EU"
+TEST_GCP_PROJECT_ID = "test-project"
+TEST_DATASET = "test-dataset"
+TEST_TABLE = "test-table"
+EXECUTION_DATE = datetime(2022, 1, 1, 0, 0, 0)
+INSERT_DATE = EXECUTION_DATE.strftime("%Y-%m-%d")
+INSERT_ROWS_QUERY = (
+    f"INSERT {TEST_DATASET}.{TEST_TABLE} VALUES "
+    f"(42, 'monthy python', '{INSERT_DATE}'), "
+    f"(42, 'fishy fish', '{INSERT_DATE}');"
+)
+
+INPUT_STATS = [
+    Dataset(
+        source=Source(scheme="bigquery"),
+        name=f"astronomer-airflow-providers.{TEST_DATASET}.{TEST_TABLE}",
+        fields=[],
+        custom_facets={},
+        input_facets={},
+        output_facets={},
+    )
+]
+
+OUTPUT_STATS = Dataset(
+    source=Source(scheme="bigquery"),
+    name=f"astronomer-airflow-providers.{TEST_DATASET}.{TEST_TABLE}",
+    fields=[],
+    custom_facets={"stats": BigQueryStatisticsDatasetFacet(rowCount=2, size=0)},
+    input_facets={},
+    output_facets={"outputStatistics": OutputStatisticsOutputDatasetFacet(rowCount=2, size=0)},
+)
+
+with open("tests/google/cloud/extractors/job_details.json") as jd_json:
+    JOB_PROPERTIES = json.load(jd_json)
+
+RUN_FACETS = {
+    "bigQuery_job": BigQueryJobRunFacet(billedBytes=0, cached=False, properties=json.dumps(JOB_PROPERTIES))
+}
+
+
+@pytest.fixture
+def context():
+    """
+    Creates an empty context.
+    """
+    context = {}
+    yield context
+
+
+@mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
+@mock.patch("airflow.models.TaskInstance.xcom_pull")
+@mock.patch("openlineage.common.provider.bigquery.BigQueryDatasetsProvider.get_facets")
+def test_extract_on_complete(mock_bg_dataset_provider, mock_xcom_pull, mock_hook):
+    configuration = {
+        "query": {
+            "query": INSERT_ROWS_QUERY,
+            "useLegacySql": False,
+        }
+    }
+    job_id = "123456"
+    mock_hook.return_value.insert_job.return_value = MagicMock(job_id=job_id, error_result=False)
+    mock_bg_dataset_provider.return_value = BigQueryFacets(
+        run_facets=RUN_FACETS, inputs=INPUT_STATS, output=OUTPUT_STATS
+    )
+
+    task_id = "insert_query_job"
+    operator = BigQueryInsertJobOperatorAsync(
+        task_id=task_id,
+        configuration=configuration,
+        location=TEST_DATASET_LOCATION,
+        job_id=job_id,
+        project_id=TEST_GCP_PROJECT_ID,
+    )
+
+    task_instance = TaskInstance(task=operator)
+    with pytest.raises(TaskDeferred):
+        operator.execute(context)
+
+    bq_extractor = BigQueryInsertJobOperatorAsyncExtractor(operator)
+    task_meta_extract = bq_extractor.extract()
+    assert task_meta_extract is None
+
+    task_meta = bq_extractor.extract_on_complete(task_instance)
+
+    mock_xcom_pull.assert_called_once_with(task_ids=task_instance.task_id, key="job_id")
+
+    assert task_meta.name == f"adhoc_airflow.{task_id}"
+
+    assert task_meta.inputs[0].facets["dataSource"].name == INPUT_STATS[0].source.scheme
+    assert task_meta.inputs[0].name == INPUT_STATS[0].name
+
+    assert task_meta.outputs[0].name == OUTPUT_STATS.name
+    assert task_meta.outputs[0].facets["stats"].rowCount == 2
+    assert task_meta.outputs[0].facets["stats"].size == 0
+
+    assert task_meta.run_facets["bigQuery_job"].billedBytes == 0
+    run_facet_properties = json.loads(task_meta.run_facets["bigQuery_job"].properties)
+    assert run_facet_properties == JOB_PROPERTIES

--- a/tests/google/cloud/operators/test_bigquery.py
+++ b/tests/google/cloud/operators/test_bigquery.py
@@ -137,7 +137,7 @@ def test_bigquery_insert_job_operator_execute_complete():
     with mock.patch.object(operator.log, "info") as mock_log_info:
         operator.execute_complete(
             context=create_context(operator),
-            event={"status": "success", "message": "Job completed", "jobId": job_id},
+            event={"status": "success", "message": "Job completed", "job_id": job_id},
         )
     mock_log_info.assert_called_with("%s completed with response %s ", "insert_query_job", "Job completed")
 

--- a/tests/google/cloud/operators/test_bigquery.py
+++ b/tests/google/cloud/operators/test_bigquery.py
@@ -4,7 +4,10 @@ from unittest.mock import MagicMock
 import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.models import DAG
+from airflow.models.dagrun import DagRun
+from airflow.models.taskinstance import TaskInstance
 from airflow.utils.timezone import datetime
+from airflow.utils.types import DagRunType
 from google.cloud.exceptions import Conflict
 
 from astronomer.providers.google.cloud.operators.bigquery import (
@@ -93,6 +96,27 @@ def test_bigquery_insert_job_operator_execute_failure(context):
         operator.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
 
 
+def create_context(task):
+    dag = DAG(dag_id="dag")
+    execution_date = datetime(2022, 1, 1, 0, 0, 0)
+    dag_run = DagRun(
+        dag_id=dag.dag_id,
+        execution_date=execution_date,
+        run_id=DagRun.generate_run_id(DagRunType.MANUAL, execution_date),
+    )
+    task_instance = TaskInstance(task=task)
+    task_instance.dag_run = dag_run
+    task_instance.dag_id = dag.dag_id
+    task_instance.xcom_push = mock.Mock()
+    return {
+        "dag": dag,
+        "run_id": dag_run.run_id,
+        "task": task,
+        "ti": task_instance,
+        "task_instance": task_instance,
+    }
+
+
 def test_bigquery_insert_job_operator_execute_complete():
     """Asserts that logging occurs as expected"""
     configuration = {
@@ -111,7 +135,10 @@ def test_bigquery_insert_job_operator_execute_complete():
         project_id=TEST_GCP_PROJECT_ID,
     )
     with mock.patch.object(operator.log, "info") as mock_log_info:
-        operator.execute_complete(context=None, event={"status": "success", "message": "Job completed"})
+        operator.execute_complete(
+            context=create_context(operator),
+            event={"status": "success", "message": "Job completed", "jobId": job_id},
+        )
     mock_log_info.assert_called_with("%s completed with response %s ", "insert_query_job", "Job completed")
 
 

--- a/tests/google/cloud/triggers/test_bigquery.py
+++ b/tests/google/cloud/triggers/test_bigquery.py
@@ -92,7 +92,7 @@ async def test_bigquery_insert_job_op_trigger_success(mock_job_status):
     # so we validate for length of task to be 1
     assert len(task) == 1
 
-    assert TriggerEvent({"status": "success", "message": "Job completed", "jobId": TEST_JOB_ID}) in task
+    assert TriggerEvent({"status": "success", "message": "Job completed", "job_id": TEST_JOB_ID}) in task
 
 
 @pytest.mark.parametrize(

--- a/tests/google/cloud/triggers/test_bigquery.py
+++ b/tests/google/cloud/triggers/test_bigquery.py
@@ -92,7 +92,7 @@ async def test_bigquery_insert_job_op_trigger_success(mock_job_status):
     # so we validate for length of task to be 1
     assert len(task) == 1
 
-    assert TriggerEvent({"status": "success", "message": "Job completed"}) in task
+    assert TriggerEvent({"status": "success", "message": "Job completed", "jobId": TEST_JOB_ID}) in task
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Export job_id as XCOM for the BigQueryInsertJobOperatorAsync operator
and add an OpenLineage custom extractor for the same.

The custom extractor is an extension of OpenLineage BigQuery extractor to include
BigQueryInsertJobOperatorAsync.
The OpenLineage extractor has a common implementation to fetch statistics for
big query with the given job_id which is fetched from XCOM in the case of Airflow tasks.
So, I believe, all we need to do is push the job_id as XCOM for the task
which is pulled by OpenLineage and the metadata is fetched & extracted
by the common implementation.

Some additional OpenLineage specific environment variables need to be set
which are included as part of the docker-compose.yaml file change in the commit.

Also, adding a flask based local Lineage server where we can forward extraction
events for local development.