### PR TITLE
Fix failing Databricks tests

### DIFF
--- a/tests/databricks/operators/test_databricks.py
+++ b/tests/databricks/operators/test_databricks.py
@@ -56,7 +56,7 @@ def test_databricks_submit_run_operator_async(
     )
 
     with pytest.raises(TaskDeferred) as exc:
-        operator.execute(context)
+        operator.execute(context=create_context(operator))
 
     assert isinstance(exc.value.trigger, DatabricksTrigger), "Trigger is not a DatabricksTrigger"
 
@@ -80,7 +80,7 @@ def test_databricks_run_now_operator_async(
     )
 
     with pytest.raises(TaskDeferred) as exc:
-        operator.execute(context)
+        operator.execute(context=create_context(operator))
 
     assert isinstance(exc.value.trigger, DatabricksTrigger), "Trigger is not a DatabricksTrigger"
 


### PR DESCRIPTION
Following tests for Databricks are failing and observed in a non-related PR: #290

1. test_databricks_submit_run_operator_async
2. test_databricks_run_now_operator_async

The reason for failure is that the execute method called in these
tests is trying to push an XCOM against task instance 'ti' of
the context. Previously, context was an empty dictionary missing
the 'ti' key. We now are using the create_context utility to
generate a context object which includes the 'ti' key against which
the XCOM is getting pushed.