### PR TITLE
Add missing await on aysncio.sleep coroutine in Hive hook

### DIFF
--- a/astronomer/providers/apache/hive/hooks/hive.py
+++ b/astronomer/providers/apache/hive/hooks/hive.py
@@ -43,7 +43,7 @@ class HiveCliHookAsync(BaseHook):
         query = f"show partitions {schema}.{table} partition({partition})"
         cursor.execute_async(query)
         while cursor.is_executing():
-            asyncio.sleep(polling_interval)
+            await asyncio.sleep(polling_interval)
         results = cursor.fetchall()
         if len(results) == 0:
             return "failure"

--- a/tests/apache/hive/hooks/test_hive.py
+++ b/tests/apache/hive/hooks/test_hive.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from unittest.mock import PropertyMock
 
 import pytest
 from airflow import models
@@ -51,7 +52,7 @@ async def test_partition_exists(mock_get_client, mock_get_connection, result, re
     mock_get_client.return_value = hiveserver_connection
     cursor = mock.AsyncMock(HiveServer2Cursor)
     hiveserver_connection.cursor.return_value = cursor
-    cursor.is_executing.return_value = False
+    cursor.is_executing = PropertyMock(side_effect=[True, False])
     cursor.fetchall.return_value = result
     res = await hook.partition_exists(TEST_TABLE, TEST_SCHEMA, TEST_PARTITION, TEST_POLLING_INTERVAL)
     assert res == response


### PR DESCRIPTION
MyPY release a new version recently 0.950 which has rightly pointed
out that we're missing an await on asyncio.sleep coroutine in our
Hive connection hook module.
The fix adds an await for the same.

Closes: #295 