### PR TITLE
Fixes for deploying integration tests on Astro Cloud

### DIFF
--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -76,7 +76,7 @@ RUN cp nuke-config.yml  ${AIRFLOW_HOME}/dags/
 USER astro
 
 # Deploy from astro runtime image
-FROM quay.io/astronomer/astro-runtime:4.2.4-base as astro-cloud
+FROM quay.io/astronomer/astro-runtime:4.2.6-base as astro-cloud
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 

--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -76,7 +76,7 @@ RUN cp nuke-config.yml  ${AIRFLOW_HOME}/dags/
 USER astro
 
 # Deploy from astro runtime image
-FROM quay.io/astronomer/astro-runtime:4.2.6-base as astro-cloud
+FROM quay.io/astronomer/astro-runtime:5.0.0-base as astro-cloud
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 

--- a/.circleci/integration-tests/script.sh
+++ b/.circleci/integration-tests/script.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# Make the script exit with the status if one of the commands fails. Without this, the Airflow task calling this script
+# will be marked as 'success' and the DAG will proceed on to the subsequent tasks.
+set -e
+
 # This script use to update a staging Astro staging and cloud Airflow deployment.
 # It currently does not support creating a new deployment.
 # To deploy on 'staging' execute the script with below positional params


### PR DESCRIPTION
The commit includes the following fixes:
1. Report failure of any of the commands of the deployment script
and exit the script with status code.
2. Upgrade runtime image to 4.2.6 to be compatible with Astro
Cloud environment

Closed #274 