### PR TITLE
Upgrade base Airflow images to latest version

### DIFF
--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/ap-airflow:2.3.0 as staging
+FROM quay.io/astronomer/ap-airflow:2.3.0-1 as staging
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0

--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/ap-airflow:2.2.5 as staging
+FROM quay.io/astronomer/ap-airflow:2.3.0 as staging
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:4.2.4-base"
+ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.0-base"
 FROM ${IMAGE_NAME}
 
 USER root


### PR DESCRIPTION
With respect to the recent Airflow release:
https://github.com/astronomer/astro-runtime/blob/main/CHANGELOG.md#500-2022-04-30
and https://airflow.apache.org/docs/apache-airflow/2.3.0/release_notes.html#airflow-2-3-0-2022-04-30,
upgrade the base image in Dockerfiles to the following versions:

ap-airflow:2.2.5 -> ap-airflow:2.3.0
astro-runtime:4.2.4-base, astro-runtime:4.2.6-base -> astro-runtime:5.0.0-base

Closed: #300 