### PR TITLE
Add `libsasl` to ReadTheDocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,9 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.9"
+  apt_packages:
+    - build-essential
+    - libsasl2-dev
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
https://readthedocs.org/projects/astronomer-providers/builds/16816473/ is failing,
this will fix it.