### PR TITLE
Replace `os.environ.get` to `os.getenv`

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -13,9 +13,9 @@ from airflow.operators.python import PythonOperator
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.utils.session import create_session
 
-SLACK_CHANNEL = os.environ.get("SLACK_CHANNEL", "#provider-alert")
-SLACK_WEBHOOK_CONN = os.environ.get("SLACK_WEBHOOK_CONN", "http_slack")
-SLACK_USERNAME = os.environ.get("SLACK_USERNAME", "airflow_app")
+SLACK_CHANNEL = os.getenv("SLACK_CHANNEL", "#provider-alert")
+SLACK_WEBHOOK_CONN = os.getenv("SLACK_WEBHOOK_CONN", "http_slack")
+SLACK_USERNAME = os.getenv("SLACK_USERNAME", "airflow_app")
 
 
 def get_report(dag_run_ids: List[str]) -> None:

--- a/.circleci/scripts/verify_tag_and_version.py
+++ b/.circleci/scripts/verify_tag_and_version.py
@@ -10,7 +10,7 @@ config = configparser.ConfigParser(strict=False)
 config.read(repo_dir / "setup.cfg")
 
 version_in_setup_cfg = config["metadata"]["version"]
-git_tag = os.environ.get("CIRCLE_TAG")
+git_tag = os.getenv("CIRCLE_TAG")
 
 if git_tag is not None:
     if version_in_setup_cfg != git_tag:

--- a/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
@@ -5,10 +5,10 @@ from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator
 
-AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "**********")
-AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "***********")
-AWS_DEFAULT_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-2")
-AWS_CONN_ID = os.environ.get("ASTRO_AWS_CONN_ID", "aws_default")
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "**********")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "***********")
+AWS_DEFAULT_REGION = os.getenv("AWS_DEFAULT_REGION", "us-east-2")
+AWS_CONN_ID = os.getenv("ASTRO_AWS_CONN_ID", "aws_default")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -18,16 +18,16 @@ from astronomer.providers.amazon.aws.sensors.redshift_cluster import (
     RedshiftClusterSensorAsync,
 )
 
-REDSHIFT_CLUSTER_IDENTIFIER = os.environ.get("REDSHIFT_CLUSTER_IDENTIFIER", "astro-providers-cluster")
-REDSHIFT_CLUSTER_MASTER_USER = os.environ.get("REDSHIFT_CLUSTER_MASTER_USER", "awsuser")
-REDSHIFT_CLUSTER_MASTER_PASSWORD = os.environ.get("REDSHIFT_CLUSTER_MASTER_PASSWORD", "********")
-REDSHIFT_CLUSTER_DB_NAME = os.environ.get("REDSHIFT_CLUSTER_DB_NAME", "astro_dev")
-REDSHIFT_CLUSTER_TYPE = os.environ.get("REDSHIFT_CLUSTER_TYPE", "single-node")
-REDSHIFT_CLUSTER_NODE_TYPE = os.environ.get("REDSHIFT_CLUSTER_NODE_TYPE", "dc2.large")
-AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "**********")
-AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "***********")
-AWS_DEFAULT_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-2")
-AWS_CONN_ID = os.environ.get("ASTRO_AWS_CONN_ID", "aws_default")
+REDSHIFT_CLUSTER_IDENTIFIER = os.getenv("REDSHIFT_CLUSTER_IDENTIFIER", "astro-providers-cluster")
+REDSHIFT_CLUSTER_MASTER_USER = os.getenv("REDSHIFT_CLUSTER_MASTER_USER", "awsuser")
+REDSHIFT_CLUSTER_MASTER_PASSWORD = os.getenv("REDSHIFT_CLUSTER_MASTER_PASSWORD", "********")
+REDSHIFT_CLUSTER_DB_NAME = os.getenv("REDSHIFT_CLUSTER_DB_NAME", "astro_dev")
+REDSHIFT_CLUSTER_TYPE = os.getenv("REDSHIFT_CLUSTER_TYPE", "single-node")
+REDSHIFT_CLUSTER_NODE_TYPE = os.getenv("REDSHIFT_CLUSTER_NODE_TYPE", "dc2.large")
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "**********")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "***********")
+AWS_DEFAULT_REGION = os.getenv("AWS_DEFAULT_REGION", "us-east-2")
+AWS_CONN_ID = os.getenv("ASTRO_AWS_CONN_ID", "aws_default")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py
@@ -14,16 +14,16 @@ from astronomer.providers.amazon.aws.operators.redshift_sql import (
     RedshiftSQLOperatorAsync,
 )
 
-REDSHIFT_CONN_ID = os.environ.get("ASTRO_REDSHIFT_CONN_ID", "redshift_default")
-REDSHIFT_CLUSTER_IDENTIFIER = os.environ.get("REDSHIFT_CLUSTER_IDENTIFIER", "astro-providers-cluster")
-REDSHIFT_CLUSTER_MASTER_USER = os.environ.get("REDSHIFT_CLUSTER_MASTER_USER", "awsuser")
-REDSHIFT_CLUSTER_MASTER_PASSWORD = os.environ.get("REDSHIFT_CLUSTER_MASTER_PASSWORD", "********")
-REDSHIFT_CLUSTER_TYPE = os.environ.get("REDSHIFT_CLUSTER_TYPE", "single-node")
-REDSHIFT_CLUSTER_NODE_TYPE = os.environ.get("REDSHIFT_CLUSTER_NODE_TYPE", "dc2.large")
-AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "**********")
-AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "***********")
-AWS_DEFAULT_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-2")
-REDSHIFT_CLUSTER_DB_NAME = os.environ.get("REDSHIFT_CLUSTER_DB_NAME", "astro_dev")
+REDSHIFT_CONN_ID = os.getenv("ASTRO_REDSHIFT_CONN_ID", "redshift_default")
+REDSHIFT_CLUSTER_IDENTIFIER = os.getenv("REDSHIFT_CLUSTER_IDENTIFIER", "astro-providers-cluster")
+REDSHIFT_CLUSTER_MASTER_USER = os.getenv("REDSHIFT_CLUSTER_MASTER_USER", "awsuser")
+REDSHIFT_CLUSTER_MASTER_PASSWORD = os.getenv("REDSHIFT_CLUSTER_MASTER_PASSWORD", "********")
+REDSHIFT_CLUSTER_TYPE = os.getenv("REDSHIFT_CLUSTER_TYPE", "single-node")
+REDSHIFT_CLUSTER_NODE_TYPE = os.getenv("REDSHIFT_CLUSTER_NODE_TYPE", "dc2.large")
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "**********")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "***********")
+AWS_DEFAULT_REGION = os.getenv("AWS_DEFAULT_REGION", "us-east-2")
+REDSHIFT_CLUSTER_DB_NAME = os.getenv("REDSHIFT_CLUSTER_DB_NAME", "astro_dev")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {

--- a/astronomer/providers/amazon/aws/example_dags/example_s3.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_s3.py
@@ -17,14 +17,14 @@ from astronomer.providers.amazon.aws.sensors.s3 import (
     S3PrefixSensorAsync,
 )
 
-S3_BUCKET_NAME = os.environ.get("S3_BUCKET_NAME", "test-bucket-astronomer-providers")
-S3_BUCKET_KEY = os.environ.get("S3_BUCKET_KEY", "test/example_s3_test_file.txt")
-S3_BUCKET_WILDCARD_KEY = os.environ.get("S3_BUCKET_WILDCARD_KEY", "test*")
-PREFIX = os.environ.get("S3_PREFIX", "test")
-INACTIVITY_PERIOD = float(os.environ.get("INACTIVITY_PERIOD", 5))
-AWS_DEFAULT_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-2")
-LOCAL_FILE_PATH = os.environ.get("LOCAL_FILE_PATH", "/usr/local/airflow/dags/example_s3_test_file.txt")
-AWS_CONN_ID = os.environ.get("ASTRO_AWS_S3_CONN_ID", "aws_s3_default")
+S3_BUCKET_NAME = os.getenv("S3_BUCKET_NAME", "test-bucket-astronomer-providers")
+S3_BUCKET_KEY = os.getenv("S3_BUCKET_KEY", "test/example_s3_test_file.txt")
+S3_BUCKET_WILDCARD_KEY = os.getenv("S3_BUCKET_WILDCARD_KEY", "test*")
+PREFIX = os.getenv("S3_PREFIX", "test")
+INACTIVITY_PERIOD = float(os.getenv("INACTIVITY_PERIOD", 5))
+AWS_DEFAULT_REGION = os.getenv("AWS_DEFAULT_REGION", "us-east-2")
+LOCAL_FILE_PATH = os.getenv("LOCAL_FILE_PATH", "/usr/local/airflow/dags/example_s3_test_file.txt")
+AWS_CONN_ID = os.getenv("ASTRO_AWS_S3_CONN_ID", "aws_s3_default")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -22,17 +22,17 @@ from astronomer.providers.apache.hive.sensors.hive_partition import (
 )
 
 AWS_S3_CREDS = {
-    "aws_access_key_id": os.environ.get("AWS_ACCESS_KEY_ID", "aws_access_key"),
-    "aws_secret_access_key": os.environ.get("AWS_SECRET_ACCESS_KEY", "aws_secret_key"),
-    "region_name": os.environ.get("AWS_DEFAULT_REGION", "us-east-2"),
+    "aws_access_key_id": os.getenv("AWS_ACCESS_KEY_ID", "aws_access_key"),
+    "aws_secret_access_key": os.getenv("AWS_SECRET_ACCESS_KEY", "aws_secret_key"),
+    "region_name": os.getenv("AWS_DEFAULT_REGION", "us-east-2"),
 }
 
-PEM_FILENAME = os.environ.get("PEM_FILENAME", "providers_team_keypair")
+PEM_FILENAME = os.getenv("PEM_FILENAME", "providers_team_keypair")
 PRIVATE_KEY = Variable.get("providers_team_keypair")
-HIVE_TABLE = os.environ.get("HIVE_TABLE", "zipcode")
-HIVE_PARTITION = os.environ.get("HIVE_PARTITION", "state='FL'")
-JOB_FLOW_ROLE = os.environ.get("EMR_JOB_FLOW_ROLE", "EMR_EC2_DefaultRole")
-SERVICE_ROLE = os.environ.get("EMR_SERVICE_ROLE", "EMR_DefaultRole")
+HIVE_TABLE = os.getenv("HIVE_TABLE", "zipcode")
+HIVE_PARTITION = os.getenv("HIVE_PARTITION", "state='FL'")
+JOB_FLOW_ROLE = os.getenv("EMR_JOB_FLOW_ROLE", "EMR_EC2_DefaultRole")
+SERVICE_ROLE = os.getenv("EMR_SERVICE_ROLE", "EMR_DefaultRole")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 COMMAND_TO_CREATE_TABLE_DATA_FILE: List[str] = [

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -22,18 +22,18 @@ from requests import get
 
 from astronomer.providers.apache.livy.operators.livy import LivyOperatorAsync
 
-LIVY_JAVA_FILE = os.environ.get("LIVY_JAVA_FILE", "/spark-examples.jar")
-LIVY_PYTHON_FILE = os.environ.get("LIVY_PYTHON_FILE", "/user/hadoop/pi.py")
-JOB_FLOW_ROLE = os.environ.get("EMR_JOB_FLOW_ROLE", "EMR_EC2_DefaultRole")
-SERVICE_ROLE = os.environ.get("EMR_SERVICE_ROLE", "EMR_DefaultRole")
-PEM_FILENAME = os.environ.get("PEM_FILENAME", "providers_team_keypair")
+LIVY_JAVA_FILE = os.getenv("LIVY_JAVA_FILE", "/spark-examples.jar")
+LIVY_PYTHON_FILE = os.getenv("LIVY_PYTHON_FILE", "/user/hadoop/pi.py")
+JOB_FLOW_ROLE = os.getenv("EMR_JOB_FLOW_ROLE", "EMR_EC2_DefaultRole")
+SERVICE_ROLE = os.getenv("EMR_SERVICE_ROLE", "EMR_DefaultRole")
+PEM_FILENAME = os.getenv("PEM_FILENAME", "providers_team_keypair")
 PRIVATE_KEY = Variable.get("providers_team_keypair")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 AWS_S3_CREDS = {
-    "aws_access_key_id": os.environ.get("AWS_ACCESS_KEY_ID", "sample_aws_access_key_id"),
-    "aws_secret_access_key": os.environ.get("AWS_SECRET_ACCESS_KEY", "sample_aws_secret_access_key"),
-    "region_name": os.environ.get("AWS_DEFAULT_REGION", "us-east-2"),
+    "aws_access_key_id": os.getenv("AWS_ACCESS_KEY_ID", "sample_aws_access_key_id"),
+    "aws_secret_access_key": os.getenv("AWS_SECRET_ACCESS_KEY", "sample_aws_secret_access_key"),
+    "region_name": os.getenv("AWS_DEFAULT_REGION", "us-east-2"),
 }
 
 COMMAND_TO_CREATE_PI_FILE: List[str] = [

--- a/astronomer/providers/core/example_dags/example_file_sensor.py
+++ b/astronomer/providers/core/example_dags/example_file_sensor.py
@@ -6,7 +6,7 @@ from airflow.utils.timezone import datetime
 
 from astronomer.providers.core.sensors.filesystem import FileSensorAsync
 
-FS_CONN_ID = os.environ.get("ASTRO_FS_CONN_ID", "fs_default")
+FS_CONN_ID = os.getenv("ASTRO_FS_CONN_ID", "fs_default")
 
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 

--- a/astronomer/providers/databricks/example_dags/example_databricks.py
+++ b/astronomer/providers/databricks/example_dags/example_databricks.py
@@ -11,10 +11,10 @@ from astronomer.providers.databricks.operators.databricks import (
     DatabricksSubmitRunOperatorAsync,
 )
 
-DATABRICKS_CONN_ID = os.environ.get("ASTRO_DATABRICKS_CONN_ID", "databricks_default")
+DATABRICKS_CONN_ID = os.getenv("ASTRO_DATABRICKS_CONN_ID", "databricks_default")
 # Notebook path as a Json object
 notebook_task = '{"notebook_path": "/Users/phani.kumar@astronomer.io/quick_start"}'
-NOTEBOOK_TASK = json.loads(os.environ.get("DATABRICKS_NOTEBOOK_TASK", notebook_task))
+NOTEBOOK_TASK = json.loads(os.getenv("DATABRICKS_NOTEBOOK_TASK", notebook_task))
 notebook_params: Optional[Dict[str, str]] = {"Variable": "5"}
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 

--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py
@@ -21,10 +21,10 @@ from astronomer.providers.google.cloud.operators.bigquery import (
     BigQueryValueCheckOperatorAsync,
 )
 
-PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "astronomer-airflow-providers")
-DATASET_NAME = os.environ.get("GCP_BIGQUERY_DATASET_NAME", "astro_dataset")
-GCP_CONN_ID = os.environ.get("GCP_CONN_ID", "google_cloud_default")
-LOCATION = os.environ.get("GCP_LOCATION", "us")
+PROJECT_ID = os.getenv("GCP_PROJECT_ID", "astronomer-airflow-providers")
+DATASET_NAME = os.getenv("GCP_BIGQUERY_DATASET_NAME", "astro_dataset")
+GCP_CONN_ID = os.getenv("GCP_CONN_ID", "google_cloud_default")
+LOCATION = os.getenv("GCP_LOCATION", "us")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 TABLE_1 = "table1"

--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_sensors.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_sensors.py
@@ -17,13 +17,13 @@ from astronomer.providers.google.cloud.sensors.bigquery import (
     BigQueryTableExistenceSensorAsync,
 )
 
-PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "astronomer-airflow-providers")
-DATASET_NAME = os.environ.get("GCP_BIGQUERY_DATASET_NAME", "astro_dataset")
-GCP_CONN_ID = os.environ.get("GCP_CONN_ID", "google_cloud_default")
-LOCATION = os.environ.get("GCP_LOCATION", "us")
+PROJECT_ID = os.getenv("GCP_PROJECT_ID", "astronomer-airflow-providers")
+DATASET_NAME = os.getenv("GCP_BIGQUERY_DATASET_NAME", "astro_dataset")
+GCP_CONN_ID = os.getenv("GCP_CONN_ID", "google_cloud_default")
+LOCATION = os.getenv("GCP_LOCATION", "us")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
-TABLE_NAME = os.environ.get("TABLE_NAME", "partitioned_table")
+TABLE_NAME = os.getenv("TABLE_NAME", "partitioned_table")
 INSERT_DATE = datetime.now().strftime("%Y-%m-%d")
 
 PARTITION_NAME = "{{ ds_nodash }}"

--- a/astronomer/providers/google/cloud/example_dags/example_dataproc.py
+++ b/astronomer/providers/google/cloud/example_dags/example_dataproc.py
@@ -22,11 +22,11 @@ from astronomer.providers.google.cloud.operators.dataproc import (
     DataprocSubmitJobOperatorAsync,
 )
 
-PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "astronomer-airflow-providers")
-CLUSTER_NAME = os.environ.get("GCP_DATAPROC_CLUSTER_NAME", "example-cluster-astronomer-providers")
-REGION = os.environ.get("GCP_LOCATION", "us-central1")
-ZONE = os.environ.get("GCP_REGION", "us-central1-a")
-BUCKET = os.environ.get("GCP_DATAPROC_BUCKET", "dataproc-system-tests-astronomer-providers")
+PROJECT_ID = os.getenv("GCP_PROJECT_ID", "astronomer-airflow-providers")
+CLUSTER_NAME = os.getenv("GCP_DATAPROC_CLUSTER_NAME", "example-cluster-astronomer-providers")
+REGION = os.getenv("GCP_LOCATION", "us-central1")
+ZONE = os.getenv("GCP_REGION", "us-central1-a")
+BUCKET = os.getenv("GCP_DATAPROC_BUCKET", "dataproc-system-tests-astronomer-providers")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 OUTPUT_FOLDER = "wordcount"
 OUTPUT_PATH = f"gs://{BUCKET}/{OUTPUT_FOLDER}/"

--- a/astronomer/providers/google/cloud/example_dags/example_gcs.py
+++ b/astronomer/providers/google/cloud/example_dags/example_gcs.py
@@ -19,9 +19,9 @@ from astronomer.providers.google.cloud.sensors.gcs import (
     GCSUploadSessionCompleteSensorAsync,
 )
 
-PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "astronomer-airflow-providers")
-BUCKET_1 = os.environ.get("GCP_TEST_BUCKET", "test-gcs-bucket-astronomer-providers")
-GCP_CONN_ID = os.environ.get("GCP_CONN_ID", "google_cloud_default")
+PROJECT_ID = os.getenv("GCP_PROJECT_ID", "astronomer-airflow-providers")
+BUCKET_1 = os.getenv("GCP_TEST_BUCKET", "test-gcs-bucket-astronomer-providers")
+GCP_CONN_ID = os.getenv("GCP_CONN_ID", "google_cloud_default")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 PATH_TO_UPLOAD_FILE = "dags/example_gcs.py"
 PATH_TO_UPLOAD_FILE_PREFIX = "example_"

--- a/astronomer/providers/http/example_dags/example_http.py
+++ b/astronomer/providers/http/example_dags/example_http.py
@@ -6,7 +6,7 @@ from airflow.utils.timezone import datetime
 
 from astronomer.providers.http.sensors.http import HttpSensorAsync
 
-HTTP_CONN_ID = os.environ.get("ASTRO_HTTP_CONN_ID", "http_default")
+HTTP_CONN_ID = os.getenv("ASTRO_HTTP_CONN_ID", "http_default")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {

--- a/astronomer/providers/snowflake/example_dags/example_snowflake.py
+++ b/astronomer/providers/snowflake/example_dags/example_snowflake.py
@@ -8,8 +8,8 @@ from airflow.utils.timezone import datetime
 
 from astronomer.providers.snowflake.operators.snowflake import SnowflakeOperatorAsync
 
-SNOWFLAKE_CONN_ID = os.environ.get("ASTRO_SNOWFLAKE_CONN_ID", "snowflake_default")
-SNOWFLAKE_SAMPLE_TABLE = os.environ.get("SNOWFLAKE_SAMPLE_TABLE", "sample_table")
+SNOWFLAKE_CONN_ID = os.getenv("ASTRO_SNOWFLAKE_CONN_ID", "snowflake_default")
+SNOWFLAKE_SAMPLE_TABLE = os.getenv("SNOWFLAKE_SAMPLE_TABLE", "sample_table")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 # SQL commands


### PR DESCRIPTION
This PR will update `os.environ.get` to `os.getenv` so that fetching env will be consistent across the reop.

Closes: https://github.com/astronomer/astronomer-providers/issues/307