### PR TITLE
Update staging image to ap-airflow:2.3.0-3

### DIFF
--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/ap-airflow:2.3.0-1 as staging
+FROM quay.io/astronomer/ap-airflow:2.3.0-3 as staging
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0


### PR DESCRIPTION
Image `ap-airflow:2.3.0-1 `was not coming up on staging.
Use image `ap-airflow:2.3.0-3` as per latest update on the issue.

Closes: #300 