### PR TITLE
Officially Support Python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ workflows:
           name: test-python<< matrix.python_version >>
           matrix:
             parameters:
-              python_version: ["3.8", "3.9"]
+              python_version: ["3.8", "3.9", "3.10"]
           <<: *all_branches_and_version_tag
           requires:
             - static-checks

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 project_urls =
     Source Code=https://github.com/astronomer/astronomer-providers/
     Homepage=https://astronomer.io/


### PR DESCRIPTION
closes https://github.com/astronomer/astronomer-providers/issues/180

Airflow 2.3 now supports Python 3.10 and so we should be able to officially support Python 3.10 too.

This PR runs all the unit tests with Python 3.10 too