### PR TITLE
Remove Flask from requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,11 +75,10 @@ apache.hive =
     impyla
 microsoft.azure =
     apache-airflow-providers-microsoft-azure
+
+# If in future we move Openlineage extractors out of the repo, this dependency should be removed
 openlineage =
     openlineage-airflow==0.6.2
-# Library to run a flask based local Lineage server to dump events to.
-flask =
-    Flask==1.1.4
 docs =
     sphinx
     sphinx-autoapi
@@ -133,7 +132,6 @@ all =
     paramiko
     impyla
     openlineage-airflow==0.6.2
-    Flask==1.1.4
 
 [options.packages.find]
 include =


### PR DESCRIPTION
Flask is a dev onoly requirement and is also a core requirement for Airflow.