### PR TITLE
CI: Show installed deps before running tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: pip install -U -e .[all,tests]
+      - run: pip freeze
       - run:
           name: Run tests
           command: |
@@ -239,7 +240,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: Deploy to Test PyPI
+          name: Deploy to PyPI
           command: |-
             pip install -U twine
             twine check /tmp/workspace/dist/*


### PR DESCRIPTION
This will help us to debug/check when CI starts failing because a new version of the library was released.