### PR TITLE
Address Kaxil's comments on PR #290

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -25,7 +25,7 @@ x-airflow-common:
     OPENLINEAGE_API_KEY: <YOUR_OPENLINEAGE_API_KEY>
     OPENLINEAGE_NAMESPACE: dev
     # yamllint disable-line rule:line-length
-    OPENLINEAGE_EXTRACTOR_BigQueryAsync: astronomer.providers.google.cloud.extractors.bigquery_async_extractor.BigQueryAsyncExtractor
+    OPENLINEAGE_EXTRACTORS: astronomer.providers.google.cloud.extractors.bigquery_async_extractor.BigQueryAsyncExtractor
   volumes:
     - ./dags:/usr/local/airflow/dags
     - ./logs:/usr/local/airflow/logs

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages = find_namespace:
 include_package_data = true
 namespace_packages = astronomer,astronomer.providers
 install_requires =
-    apache-airflow>=2.2.0
+    apache-airflow>=2.3.0
     aiohttp
     aiofiles
     asgiref
@@ -79,7 +79,7 @@ microsoft.azure =
 
 # If in future we move Openlineage extractors out of the repo, this dependency should be removed
 openlineage =
-    openlineage-airflow==0.6.2
+    openlineage-airflow>=0.8.1
 docs =
     sphinx
     sphinx-autoapi
@@ -132,7 +132,7 @@ all =
     kubernetes_asyncio
     paramiko
     impyla
-    openlineage-airflow==0.6.2
+    openlineage-airflow>=0.8.1
 
 [options.packages.find]
 include =


### PR DESCRIPTION
The commit addresses Kaxil's comments on PR #290 
The changes are:
1. Unpin openlineage-airflow version
2. Upgrade apache-airflow to >= 2.3.0


However, upon local testing, I am observing an issue with OpenLineage 
https://github.com/OpenLineage/OpenLineage/issues/736 which makes version 0.8.1 unstable 
for us and hence will keep the PR in draft mode.
Edit: The above issue is resolved by delaying referencing of the hook's client.