### PR TITLE
Follow similar naming convention across EMR clusters

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
@@ -33,7 +33,7 @@ SPARK_STEPS = [
 ]
 
 JOB_FLOW_OVERRIDES = {
-    "Name": "PiCalc",
+    "Name": "example_emr_sensor_cluster",
     "ReleaseLabel": "emr-5.29.0",
     "Applications": [{"Name": "Spark"}],
     "Instances": {

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -50,7 +50,7 @@ main/astronomer/providers/apache/hive/example_dags/zipcodes.csv \
 # If you would like to use a different version of the EMR cluster, then we need to
 # match the hive and hadoop versions same as specified in the integration tests `Dockefile`.
 JOB_FLOW_OVERRIDES = {
-    "Name": "team-provider-example-dag-hive-test",
+    "Name": "example_hive_sensor_cluster",
     "ReleaseLabel": "emr-5.34.0",
     "Applications": [
         {"Name": "Spark"},

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -42,7 +42,7 @@ COMMAND_TO_CREATE_PI_FILE: List[str] = [
 ]
 
 JOB_FLOW_OVERRIDES = {
-    "Name": "team-provider-example-dag-livy-test",
+    "Name": "example_livy_operator_cluster",
     "ReleaseLabel": "emr-5.35.0",
     "Applications": [
         {"Name": "Spark"},


### PR DESCRIPTION
This PR will standardize the EMR cluster names used in the integration testing, so that we can identify the example DAG which creates them, instead of using random names like "PiCalc"

Closes #299 