### PR TITLE
Reraise exceptions caught in except block

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -48,8 +48,9 @@ def get_report(dag_run_ids: List[str]) -> None:
                 channel=SLACK_CHANNEL,
                 username=SLACK_USERNAME,
             ).execute(context=None)
-        except Exception:
+        except Exception as exception:
             logging.exception("Error occur while sending slack alert.")
+            raise exception
 
 
 def prepare_dag_dependency(task_info, execution_time):

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -125,9 +125,9 @@ def delete_redshift_cluster_snapshot() -> None:
             if get_cluster_status() == "available":
                 time.sleep(30)
                 continue
-    except ClientError:
+    except ClientError as exception:
         logging.exception("Error when deleting the cluster")
-        return None
+        raise exception
 
 
 def delete_redshift_cluster() -> None:
@@ -144,9 +144,9 @@ def delete_redshift_cluster() -> None:
             if get_cluster_status() == "deleting":
                 time.sleep(30)
                 continue
-    except ClientError:
+    except ClientError as exception:
         logging.exception("Error when deleting the cluster")
-        return None
+        raise exception
 
 
 with DAG(

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py
@@ -58,9 +58,9 @@ def delete_redshift_cluster() -> None:
             if get_cluster_status() == "deleting":
                 time.sleep(30)
                 continue
-    except ClientError:
+    except ClientError as exception:
         logging.exception("Error deleting redshift cluster")
-        return None
+        raise exception
 
 
 def create_redshift_cluster() -> None:

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -229,18 +229,15 @@ def ssh_and_run_command(task_instance: Any, **kwargs: Any) -> None:
     cluster_response_master_public_dns = task_instance.xcom_pull(
         key="cluster_response_master_public_dns", task_ids=["describe_created_cluster"]
     )[0]
-    try:
-        client.connect(hostname=cluster_response_master_public_dns, username=kwargs["username"], pkey=key)
+    client.connect(hostname=cluster_response_master_public_dns, username=kwargs["username"], pkey=key)
 
-        # Execute a command(cmd) after connecting/ssh to an instance
-        for command in kwargs["command"]:
-            stdin, stdout, stderr = client.exec_command(command)
-            stdout.read()
+    # Execute a command(cmd) after connecting/ssh to an instance
+    for command in kwargs["command"]:
+        stdin, stdout, stderr = client.exec_command(command)
+        stdout.read()
 
-        # close the client connection once the job is done
-        client.close()
-    except Exception as exc:
-        raise Exception("Got an exception as %s.", str(exc))
+    # close the client connection once the job is done
+    client.close()
 
 
 def get_cluster_details(task_instance: Any) -> None:


### PR DESCRIPTION
Currently, we're catching few exceptions in our tasks as part of our example DAGs.
Such exceptions caught do log the exceptions but return None. As a result,
the task is getting marked as success/green and the downstream tasks fail
due to missing resources of this previous task outcome.
Fix such exceptions caught to rightly reflect the status of the tasks.

Closes: #321 