### PR TITLE
Update base Astronomer images to latest release tags

### DIFF
--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/ap-airflow:2.3.0-3 as staging
+FROM quay.io/astronomer/ap-airflow:2.3.0-4 as staging
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0
@@ -76,7 +76,7 @@ RUN cp nuke-config.yml  ${AIRFLOW_HOME}/dags/
 USER astro
 
 # Deploy from astro runtime image
-FROM quay.io/astronomer/astro-runtime:5.0.0-base as astro-cloud
+FROM quay.io/astronomer/astro-runtime:5.0.1-base as astro-cloud
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.0-base"
+ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.1-base"
 FROM ${IMAGE_NAME}
 
 USER root

--- a/dev/Dockerfile.emr_eks_container
+++ b/dev/Dockerfile.emr_eks_container
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.0-base"
+ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.1-base"
 FROM ${IMAGE_NAME}
 
 USER root


### PR DESCRIPTION
Following are the latest releases for base Docker images:
`astro-runtime:5.0.1`
`ap-airflow:2.3.0-4`

Update our builds to the same.