### PR TITLE
Fix ingress port authorizations for Livy & Hive example DAGs

### DIFF
--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -15,6 +15,7 @@ from airflow.providers.amazon.aws.operators.emr import (
     EmrTerminateJobFlowOperator,
 )
 from airflow.providers.apache.hive.operators.hive import HiveOperator
+from botocore.exceptions import ClientError
 from requests import get
 
 from astronomer.providers.apache.hive.sensors.hive_partition import (
@@ -29,9 +30,10 @@ AWS_S3_CREDS = {
     "aws_secret_access_key": os.getenv("AWS_SECRET_ACCESS_KEY", "aws_secret_key"),
     "region_name": os.getenv("AWS_DEFAULT_REGION", "us-east-2"),
 }
-
+BOTO_DUPLICATE_PERMISSION_ERROR = "InvalidPermission.Duplicate"
 PEM_FILENAME = os.getenv("PEM_FILENAME", "providers_team_keypair")
 PRIVATE_KEY = Variable.get("providers_team_keypair")
+HIVE_OPERATOR_INGRESS_PORT = int(os.getenv("HIVE_OPERATOR_INGRESS_PORT", 10000))
 HIVE_SCHEMA = os.getenv("HIVE_SCHEMA", "default")
 HIVE_TABLE = os.getenv("HIVE_TABLE", "zipcode")
 HIVE_PARTITION = os.getenv("HIVE_PARTITION", "state='FL'")
@@ -94,7 +96,7 @@ def create_airflow_connection_for_hive_metastore_(task_instance: Any) -> None:
         )[0],
         login="hive",
         password="password",
-        port=10000,
+        port=HIVE_OPERATOR_INGRESS_PORT,
         schema="default",
     )  # create a connection object
 
@@ -125,7 +127,7 @@ def create_airflow_connection_for_hive_cli(task_instance: Any) -> None:
         )[0],
         login="hive",
         password="password",
-        port=10000,
+        port=HIVE_OPERATOR_INGRESS_PORT,
         schema="default",
         extra={"use_beeline": True, "auth": "none"},
     )  # create a connection object
@@ -153,23 +155,8 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
     logging.info("Current ip address is: %s", str(current_docker_ip))
     client = boto3.client("ec2", **AWS_S3_CREDS)
 
-    response = client.describe_security_groups(
-        GroupIds=[
-            task_instance.xcom_pull(
-                key="cluster_response_master_security_group", task_ids=["describe_created_cluster"]
-            )[0]
-        ]
-    )
-    current_ip_permissions = response["SecurityGroups"][0]["IpPermissions"]
-    ip_exists = False
-    for current_ip in current_ip_permissions:
-        ip_ranges = current_ip["IpRanges"]
-        for ip in ip_ranges:
-            if ip["CidrIp"] == str(current_docker_ip) + "/32":
-                ip_exists = True
-
-    if not ip_exists:
-        # Port 10000 need to be open for Impyla connectivity to Hive
+    # Port HIVE_OPERATOR_INGRESS_PORT needs to be open for Impyla connectivity to Hive.
+    try:
         client.authorize_security_group_ingress(
             GroupId=task_instance.xcom_pull(
                 key="cluster_response_master_security_group", task_ids=["describe_created_cluster"]
@@ -177,14 +164,20 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 10000,
-                    "ToPort": 10000,
+                    "FromPort": HIVE_OPERATOR_INGRESS_PORT,
+                    "ToPort": HIVE_OPERATOR_INGRESS_PORT,
                     "IpRanges": [{"CidrIp": str(current_docker_ip) + "/32"}],
                 }
             ],
         )
+    except ClientError as error:
+        if error.response.get("Error", {}).get("Code", "") == BOTO_DUPLICATE_PERMISSION_ERROR:
+            logging.info("Ingress for port %s already authorized", HIVE_OPERATOR_INGRESS_PORT)
+        else:
+            raise error
 
-        # Allow SSH traffic on port 22 and copy file to HDFS
+    # Allow SSH traffic on port 22 and copy file to HDFS.
+    try:
         client.authorize_security_group_ingress(
             GroupId=task_instance.xcom_pull(
                 key="cluster_response_master_security_group", task_ids=["describe_created_cluster"]
@@ -198,6 +191,11 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
                 }
             ],
         )
+    except ClientError as error:
+        if error.response.get("Error", {}).get("Code", "") == BOTO_DUPLICATE_PERMISSION_ERROR:
+            logging.info("Ingress for port 22 already authorized")
+        else:
+            raise error
 
 
 def create_key_pair() -> None:

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -172,7 +172,11 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
         )
     except ClientError as error:
         if error.response.get("Error", {}).get("Code", "") == BOTO_DUPLICATE_PERMISSION_ERROR:
-            logging.error("Ingress for port %s already authorized", HIVE_OPERATOR_INGRESS_PORT)
+            logging.error(
+                "Ingress for port %s already authorized. Error Message is: %s",
+                HIVE_OPERATOR_INGRESS_PORT,
+                error.response["Error"]["Message"],
+            )
         else:
             raise error
 
@@ -193,7 +197,10 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
         )
     except ClientError as error:
         if error.response.get("Error", {}).get("Code", "") == BOTO_DUPLICATE_PERMISSION_ERROR:
-            logging.error("Ingress for port 22 already authorized")
+            logging.error(
+                "Ingress for port 22 already authorized. Error message is: %s",
+                error.response["Error"]["Message"],
+            )
         else:
             raise error
 

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -172,7 +172,7 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
         )
     except ClientError as error:
         if error.response.get("Error", {}).get("Code", "") == BOTO_DUPLICATE_PERMISSION_ERROR:
-            logging.info("Ingress for port %s already authorized", HIVE_OPERATOR_INGRESS_PORT)
+            logging.error("Ingress for port %s already authorized", HIVE_OPERATOR_INGRESS_PORT)
         else:
             raise error
 
@@ -193,7 +193,7 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
         )
     except ClientError as error:
         if error.response.get("Error", {}).get("Code", "") == BOTO_DUPLICATE_PERMISSION_ERROR:
-            logging.info("Ingress for port 22 already authorized")
+            logging.error("Ingress for port 22 already authorized")
         else:
             raise error
 

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -135,7 +135,7 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
         )
     except ClientError as error:
         if error.response.get("Error", {}).get("Code", "") == BOTO_DUPLICATE_PERMISSION_ERROR:
-            logging.info("Ingress for port %s already authorized", LIVY_OPERATOR_INGRESS_PORT)
+            logging.error("Ingress for port %s already authorized", LIVY_OPERATOR_INGRESS_PORT)
         else:
             raise error
 
@@ -156,7 +156,7 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
         )
     except ClientError as error:
         if error.response.get("Error", {}).get("Code", "") == BOTO_DUPLICATE_PERMISSION_ERROR:
-            logging.info("Ingress for port 22 already authorized")
+            logging.error("Ingress for port 22 already authorized")
         else:
             raise error
 

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -135,7 +135,11 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
         )
     except ClientError as error:
         if error.response.get("Error", {}).get("Code", "") == BOTO_DUPLICATE_PERMISSION_ERROR:
-            logging.error("Ingress for port %s already authorized", LIVY_OPERATOR_INGRESS_PORT)
+            logging.error(
+                "Ingress for port %s already authorized. Error Message is: %s",
+                LIVY_OPERATOR_INGRESS_PORT,
+                error.response["Error"]["Message"],
+            )
         else:
             raise error
 
@@ -156,7 +160,10 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
         )
     except ClientError as error:
         if error.response.get("Error", {}).get("Code", "") == BOTO_DUPLICATE_PERMISSION_ERROR:
-            logging.error("Ingress for port 22 already authorized")
+            logging.error(
+                "Ingress for port 22 already authorized. Error message is: %s",
+                error.response["Error"]["Message"],
+            )
         else:
             raise error
 

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -18,11 +18,14 @@ from airflow.providers.amazon.aws.operators.emr import (
     EmrCreateJobFlowOperator,
     EmrTerminateJobFlowOperator,
 )
+from botocore.exceptions import ClientError
 from requests import get
 
 from astronomer.providers.apache.livy.operators.livy import LivyOperatorAsync
 
+BOTO_DUPLICATE_PERMISSION_ERROR = "InvalidPermission.Duplicate"
 LIVY_JAVA_FILE = os.getenv("LIVY_JAVA_FILE", "/spark-examples.jar")
+LIVY_OPERATOR_INGRESS_PORT = int(os.getenv("LIVY_OPERATOR_INGRESS_PORT", 8998))
 LIVY_PYTHON_FILE = os.getenv("LIVY_PYTHON_FILE", "/user/hadoop/pi.py")
 JOB_FLOW_ROLE = os.getenv("EMR_JOB_FLOW_ROLE", "EMR_EC2_DefaultRole")
 SERVICE_ROLE = os.getenv("EMR_SERVICE_ROLE", "EMR_DefaultRole")
@@ -89,7 +92,7 @@ def create_airflow_connection(task_instance: Any) -> None:
         )[0],
         login="",
         password="",
-        port=8998,
+        port=LIVY_OPERATOR_INGRESS_PORT,
     )  # create a connection object
 
     session = settings.Session()
@@ -115,23 +118,8 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
     logging.info("Current ip address is: %s", str(current_docker_ip))
     client = boto3.client("ec2", **AWS_S3_CREDS)
 
-    response = client.describe_security_groups(
-        GroupIds=[
-            task_instance.xcom_pull(
-                key="cluster_response_master_security_group", task_ids=["describe_created_cluster"]
-            )[0]
-        ]
-    )
-    current_ip_permissions = response["SecurityGroups"][0]["IpPermissions"]
-    ip_exists = False
-    for current_ip in current_ip_permissions:
-        ip_ranges = current_ip["IpRanges"]
-        for ip in ip_ranges:
-            if ip["CidrIp"] == str(current_docker_ip) + "/32":
-                ip_exists = True
-
-    if not ip_exists:
-        # open port for port 8998
+    # Open port 'LIVY_OPERATOR_INGRESS_PORT'.
+    try:
         client.authorize_security_group_ingress(
             GroupId=task_instance.xcom_pull(
                 key="cluster_response_master_security_group", task_ids=["describe_created_cluster"]
@@ -139,14 +127,20 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 8998,
-                    "ToPort": 8998,
+                    "FromPort": LIVY_OPERATOR_INGRESS_PORT,
+                    "ToPort": LIVY_OPERATOR_INGRESS_PORT,
                     "IpRanges": [{"CidrIp": str(current_docker_ip) + "/32"}],
                 }
             ],
         )
+    except ClientError as error:
+        if error.response.get("Error", {}).get("Code", "") == BOTO_DUPLICATE_PERMISSION_ERROR:
+            logging.info("Ingress for port %s already authorized", LIVY_OPERATOR_INGRESS_PORT)
+        else:
+            raise error
 
-        # open port for port 22 for ssh and copy file for hdfs
+    # Open port 22 for downstream task 'ssh_and_copy_pifile_to_hdfs'.
+    try:
         client.authorize_security_group_ingress(
             GroupId=task_instance.xcom_pull(
                 key="cluster_response_master_security_group", task_ids=["describe_created_cluster"]
@@ -160,6 +154,11 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
                 }
             ],
         )
+    except ClientError as error:
+        if error.response.get("Error", {}).get("Code", "") == BOTO_DUPLICATE_PERMISSION_ERROR:
+            logging.info("Ingress for port 22 already authorized")
+        else:
+            raise error
 
 
 def create_key_pair() -> None:


### PR DESCRIPTION
The previous implementation was checking only for the presence
of the machine's IP address for existence of ALLOW permission
in the security group. As a result, when both Livy and Hive example
DAGs run concurrently, one of them adds the machine's IP along with
its ports to be authorized, but the second DAG sees that the IP
is already added and then skips authorizing its port. To elaborate
with an example, let's suppose the Hive example DAG runs first. It
will authorize and open port '22' and '10000' for the machine's IP.
When the Livy operator runs, it will see that rules against the
machine's IP already exist in the security group and as a result
it will skip authorizing its required port '8998' in the security
group.

To fix this, the commit removes the check on IP in the security
group and instead tries authorising the ports directly. In case,
the rule already exists, boto will throw a duplicate permission error
which we catch. Other errors are reported back to ensure that the
task is marked failed. Previously, since, the port was getting
skipped to be open, we were getting the error mentioned in issue #298 

Closes: #298 