### PR TITLE
Nuke `CloudFormation` resource before `EKSCluster`

### DIFF
--- a/.circleci/integration-tests/nuke-config.yml
+++ b/.circleci/integration-tests/nuke-config.yml
@@ -21,6 +21,7 @@ account-blocklist:
   - '999999999999'
 resource-types:
   targets:
+    - CloudFormationStack
     - EMRCluster
     - EC2Instance
     - EKSCluster
@@ -28,3 +29,6 @@ resource-types:
     - RedshiftCluster
 accounts:
   '396807896376':  # aws-airflow-providers-main
+    filters:       # won't delete the filtered resources
+      CloudFormationStack:
+        - 'databricks-workspace-stack'


### PR DESCRIPTION
This change to the nuke config will ensure that any left over EKS cluster is terminated to save costs. Note that since we should not delete databricks-workspace-stack, it is included in the filters so that `aws-nuke` would not delete it

Closes #337

Below are the logs of the run with this change.

```
us-east-2 - EC2Instance - i-0b0fff6220c1aaf69 - [Identifier: "i-0b0fff6220c1aaf69", ImageIdentifier: "ami-0410b1b829bec36f6", InstanceState: "running", InstanceType: "m5.large", LaunchTime: "2022-05-11T20:34:58Z", tag:Name: "providers-team-eks-cluster-ng-2c554d24-Node", tag:alpha.eksctl.io/nodegroup-name: "ng-2c554d24", tag:alpha.eksctl.io/nodegroup-type: "managed", tag:aws:autoscaling:groupName: "eks-ng-2c554d24-eec057c8-e1cc-86f3-d6b2-a740bb8d905c", tag:aws:ec2:fleet-id: "fleet-4c758bfd-d4a8-c47c-0432-a9a846411362", tag:aws:ec2launchtemplate:id: "lt-0d91352a1e6fb5411", tag:aws:ec2launchtemplate:version: "1", tag:eks:cluster-name: "providers-team-eks-cluster", tag:eks:nodegroup-name: "ng-2c554d24", tag:k8s.io/cluster-autoscaler/enabled: "true", tag:k8s.io/cluster-autoscaler/providers-team-eks-cluster: "owned", tag:kubernetes.io/cluster/providers-team-eks-cluster: "owned"] - removed
us-east-2 - EC2Instance - i-075d710346df2feff - [Identifier: "i-075d710346df2feff", ImageIdentifier: "ami-0410b1b829bec36f6", InstanceState: "running", InstanceType: "m5.large", LaunchTime: "2022-05-11T20:32:55Z", tag:Name: "providers-team-eks-cluster-ng-2c554d24-Node", tag:alpha.eksctl.io/nodegroup-name: "ng-2c554d24", tag:alpha.eksctl.io/nodegroup-type: "managed", tag:aws:autoscaling:groupName: "eks-ng-2c554d24-eec057c8-e1cc-86f3-d6b2-a740bb8d905c", tag:aws:ec2:fleet-id: "fleet-645f0357-76a0-4cde-8c12-8b28f3f46640", tag:aws:ec2launchtemplate:id: "lt-0d91352a1e6fb5411", tag:aws:ec2launchtemplate:version: "1", tag:eks:cluster-name: "providers-team-eks-cluster", tag:eks:nodegroup-name: "ng-2c554d24", tag:k8s.io/cluster-autoscaler/enabled: "true", tag:k8s.io/cluster-autoscaler/providers-team-eks-cluster: "owned", tag:kubernetes.io/cluster/providers-team-eks-cluster: "owned"] - removed
us-east-2 - CloudFormationStack - eksctl-providers-team-eks-cluster-nodegroup-ng-2c554d24 - [CreationTime: "2022-05-10T20:03:06Z", LastUpdatedTime: "2022-05-10T20:03:06Z", Name: "eksctl-providers-team-eks-cluster-nodegroup-ng-2c554d24", tag:alpha.eksctl.io/cluster-name: "providers-team-eks-cluster", tag:alpha.eksctl.io/eksctl-version: "0.96.0", tag:alpha.eksctl.io/nodegroup-name: "ng-2c554d24", tag:alpha.eksctl.io/nodegroup-type: "managed", tag:eksctl.cluster.k8s.io/v1alpha1/cluster-name: "providers-team-eks-cluster"] - removed
us-east-2 - CloudFormationStack - eksctl-providers-team-eks-cluster-addon-iamserviceaccount-kube-system-aws-node - [CreationTime: "2022-05-10T20:02:35Z", LastUpdatedTime: "2022-05-10T20:02:35Z", Name: "eksctl-providers-team-eks-cluster-addon-iamserviceaccount-kube-system-aws-node", tag:alpha.eksctl.io/cluster-name: "providers-team-eks-cluster", tag:alpha.eksctl.io/eksctl-version: "0.96.0", tag:alpha.eksctl.io/iamserviceaccount-name: "kube-system/aws-node", tag:eksctl.cluster.k8s.io/v1alpha1/cluster-name: "providers-team-eks-cluster"] - removed
us-east-2 - CloudFormationStack - eksctl-providers-team-eks-cluster-cluster - [CreationTime: "2022-05-10T19:49:32Z", LastUpdatedTime: "2022-05-10T19:49:32Z", Name: "eksctl-providers-team-eks-cluster-cluster", tag:alpha.eksctl.io/cluster-name: "providers-team-eks-cluster", tag:alpha.eksctl.io/eksctl-version: "0.96.0", tag:eksctl.cluster.k8s.io/v1alpha1/cluster-name: "providers-team-eks-cluster"] - removed
us-east-2 - CloudFormationStack - databricks-workspace-stack - [CreationTime: "2022-04-27T02:39:16Z", LastUpdatedTime: "2022-04-27T02:39:16Z", Name: "databricks-workspace-stack"] - filtered by config```

 