### PR TITLE
Remove IMAGE_NAME args from docker-compose build target

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -6,8 +6,6 @@ x-airflow-common:
   build:
     context: ..
     dockerfile: dev/Dockerfile
-    args:
-      IMAGE_NAME: ${IMAGE_NAME:-quay.io/astronomer/astro-runtime:4.1.0-base}
   environment:
     &airflow-common-env
     DB_BACKEND: postgres


### PR DESCRIPTION
Since we already have the same ARG in the respective Dockerfiles with
updated image tags, it makes sense to remove it from the docker-compose
build target.