### PR TITLE
Loosen Airflow version pin to >=2.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages = find_namespace:
 include_package_data = true
 namespace_packages = astronomer,astronomer.providers
 install_requires =
-    apache-airflow>=2.3.0
+    apache-airflow>=2.2.0
     apache-airflow-providers-http
     aiohttp
     aiofiles


### PR DESCRIPTION
Apparently, there was some db upgrade issue on my setup which
I thought is due to version mismatch in base Docker image and
the airflow dependency version. That however is not the case
as it works fine with `>=2.2.0` and we do not need to pin it to `>=2.3.0`.
Pinning it to `>=2.3.0` would mean users on `<2.3` won't be able to use
the providers packages. Hence, reverting it to `>=2.2.0`