### PR TITLE
Reconstruct hook using connection ID in the extractor

### DIFF
--- a/astronomer/providers/google/cloud/extractors/bigquery_async_extractor.py
+++ b/astronomer/providers/google/cloud/extractors/bigquery_async_extractor.py
@@ -10,6 +10,7 @@ from openlineage.common.provider.bigquery import BigQueryDatasetsProvider
 
 from astronomer.providers.google.cloud.operators.bigquery import (
     BigQueryInsertJobOperatorAsync,
+    _BigQueryHook,
 )
 
 
@@ -29,7 +30,7 @@ class BigQueryAsyncExtractor(BaseExtractor, LoggingMixin):
         The method checks whether a connection hook is available with the Airflow configuration for the operator, and
         if yes, returns the same connection. Otherwise, returns the Client instance of``google.cloud.bigquery``.
         """
-        hook = self.operator.hook
+        hook = _BigQueryHook(gcp_conn_id=self.operator.gcp_conn_id)
         return hook.get_client(project_id=hook.project_id, location=hook.location)
 
     def _get_xcom_bigquery_job_id(self, task_instance: TaskInstance) -> Any:

--- a/tests/google/cloud/extractors/test_bigquery_async_extractor.py
+++ b/tests/google/cloud/extractors/test_bigquery_async_extractor.py
@@ -72,10 +72,11 @@ def context():
     yield context
 
 
+@mock.patch("astronomer.providers.google.cloud.extractors.bigquery_async_extractor._BigQueryHook")
 @mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
 @mock.patch("airflow.models.TaskInstance.xcom_pull")
 @mock.patch("openlineage.common.provider.bigquery.BigQueryDatasetsProvider.get_facets")
-def test_extract_on_complete(mock_bg_dataset_provider, mock_xcom_pull, mock_hook):
+def test_extract_on_complete(mock_bg_dataset_provider, mock_xcom_pull, mock_hook, mock_extractor_hook):
     """
     Tests that  the custom extractor's implementation for the BigQueryInsertJobOperatorAsync is able to process the
     operator's metadata that needs to be extracted as per OpenLineage.
@@ -88,6 +89,7 @@ def test_extract_on_complete(mock_bg_dataset_provider, mock_xcom_pull, mock_hook
     }
     job_id = "123456"
     mock_hook.return_value.insert_job.return_value = MagicMock(job_id=job_id, error_result=False)
+    mock_extractor_hook.return_value.insert_job.return_value = MagicMock(job_id=job_id, error_result=False)
     mock_bg_dataset_provider.return_value = BigQueryFacets(
         run_facets=RUN_FACETS, inputs=INPUT_STATS, output=OUTPUT_STATS
     )


### PR DESCRIPTION
I observed that the hook that we attach in `execute` method
https://github.com/astronomer/astronomer-providers/blob/main/astronomer/providers/google/cloud/operators/bigquery.py#L92
is not available in `execute_complete` https://github.com/astronomer/astronomer-providers/blob/main/astronomer/providers/google/cloud/operators/bigquery.py#L129
I tried to attach this hook in `execute_complete`; it does get
attached, however, it no longer remains attached to the operator
outside its scope. Previously, the hook attached in `execute` was
available throughout (even in the extractor), but this no longer
seems to be the case. Something has changed internally which is
wiping out the hook from the operator that we manually attach to it.
To make the connection available in the extractor, I am reconstructing
it using the hook utility and this fixes the issue.

I am creating this commit to fix the current issue and
what has change internally needs to be looked into for understanding
purpose.

closes: #350