### PR TITLE
Delay import of libraries to task scope

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_emr_eks_containers_job.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_eks_containers_job.py
@@ -3,11 +3,9 @@ import os
 from datetime import datetime, timedelta
 from typing import Any
 
-import boto3
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
-from botocore.exceptions import ClientError
 
 from astronomer.providers.amazon.aws.operators.emr import EmrContainerOperatorAsync
 from astronomer.providers.amazon.aws.sensors.emr import EmrContainerSensorAsync
@@ -42,6 +40,9 @@ default_args = {
 
 def create_emr_virtual_cluster_func(task_instance: Any) -> None:
     """Create EMR virtual cluster in container"""
+    import boto3
+    from botocore.exceptions import ClientError
+
     client = boto3.client("emr-containers")
     try:
         response = client.create_virtual_cluster(

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -9,8 +9,6 @@ import time
 from datetime import datetime, timedelta
 from typing import Any, List
 
-import boto3
-import paramiko
 from airflow import DAG, settings
 from airflow.models import Connection, Variable
 from airflow.operators.python import PythonOperator
@@ -114,6 +112,8 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
     Sets the inbound rule for the aws security group, based on
     current ip address of the system.
     """
+    import boto3
+
     current_docker_ip = get("https://api.ipify.org").text
     logging.info("Current ip address is: %s", str(current_docker_ip))
     client = boto3.client("ec2", **AWS_S3_CREDS)
@@ -190,6 +190,8 @@ def ssh_and_run_command(task_instance: Any, **kwargs: Any) -> None:
     SSH into the machine and execute the bash script from the list
     of commands.
     """
+    import paramiko
+
     key = paramiko.RSAKey.from_private_key_file(kwargs["path_to_pem_file"])
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -216,6 +218,8 @@ def get_cluster_details(task_instance: Any) -> None:
     Fetches the cluster details and stores EmrManagedMasterSecurityGroup and
     MasterPublicDnsName in the XCOM.
     """
+    import boto3
+
     client = boto3.client("emr", **AWS_S3_CREDS)
     response = client.describe_cluster(
         ClusterId=str(task_instance.xcom_pull(key="return_value", task_ids=["cluster_creator"])[0])

--- a/astronomer/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
+++ b/astronomer/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
@@ -5,24 +5,6 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
-from azure.core.exceptions import HttpResponseError
-from azure.identity import ClientSecretCredential
-from azure.mgmt.datafactory import DataFactoryManagementClient
-from azure.mgmt.datafactory.models import (
-    AzureBlobDataset,
-    AzureStorageLinkedService,
-    BlobSink,
-    BlobSource,
-    CopyActivity,
-    DatasetReference,
-    DatasetResource,
-    Factory,
-    LinkedServiceReference,
-    LinkedServiceResource,
-    PipelineResource,
-    SecureString,
-)
-from azure.mgmt.resource import ResourceManagementClient
 
 from astronomer.providers.microsoft.azure.operators.data_factory import (
     AzureDataFactoryRunPipelineOperatorAsync,
@@ -65,6 +47,25 @@ def create_adf_storage_pipeline() -> None:
     Creates Azure resource if not present, Azure Data factory, Azure Storage linked service,
     Azure blob dataset both input and output and Data factory pipeline
     """
+    from azure.core.exceptions import HttpResponseError
+    from azure.identity import ClientSecretCredential
+    from azure.mgmt.datafactory import DataFactoryManagementClient
+    from azure.mgmt.datafactory.models import (
+        AzureBlobDataset,
+        AzureStorageLinkedService,
+        BlobSink,
+        BlobSource,
+        CopyActivity,
+        DatasetReference,
+        DatasetResource,
+        Factory,
+        LinkedServiceReference,
+        LinkedServiceResource,
+        PipelineResource,
+        SecureString,
+    )
+    from azure.mgmt.resource import ResourceManagementClient
+
     credentials = ClientSecretCredential(
         client_id=CLIENT_ID, client_secret=CLIENT_SECRET, tenant_id=TENANT_ID
     )
@@ -132,6 +133,10 @@ def create_adf_storage_pipeline() -> None:
 
 def delete_azure_data_factory_storage_pipeline() -> None:
     """Delete data factory, storage linked service pipeline, dataset"""
+    from azure.identity import ClientSecretCredential
+    from azure.mgmt.datafactory import DataFactoryManagementClient
+    from azure.mgmt.resource import ResourceManagementClient
+
     credentials = ClientSecretCredential(
         client_id=CLIENT_ID, client_secret=CLIENT_SECRET, tenant_id=TENANT_ID
     )


### PR DESCRIPTION
DAGs processing might timeout due to import of heavy libraries
at top module level. Since, the DAGs are refreshed often, we want
to avoid such timeouts in processing. Hence, delay the import of
heavy libraries to task definition scope.
Reference: https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html#top-level-python-code

part of: #351 