### PR TITLE
Correct module name for DagStateTrigger

### DIFF
--- a/astronomer/providers/core/triggers/external_task.py
+++ b/astronomer/providers/core/triggers/external_task.py
@@ -111,7 +111,7 @@ class DagStateTrigger(BaseTrigger):
     def serialize(self) -> Tuple[str, Dict[str, Any]]:
         """Serializes DagStateTrigger arguments and classpath."""
         return (
-            "astronomer.providers.core.triggers.external_dag.DagStateTrigger",
+            "astronomer.providers.core.triggers.external_task.DagStateTrigger",
             {
                 "dag_id": self.dag_id,
                 "states": self.states,

--- a/tests/core/triggers/test_external_dag.py
+++ b/tests/core/triggers/test_external_dag.py
@@ -65,7 +65,7 @@ def test_task_dag_trigger_serialization():
         TEST_POLL_INTERVAL,
     )
     classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.core.triggers.external_dag.DagStateTrigger"
+    assert classpath == "astronomer.providers.core.triggers.external_task.DagStateTrigger"
     assert kwargs == {
         "dag_id": TEST_DAG_ID,
         "states": TEST_STATES,


### PR DESCRIPTION
`DagStateTrigger` has wrong module name.

The trigger fails with:
```
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)

  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import

  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load

  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked

ModuleNotFoundError: No module named 'astronomer.providers.core.triggers.external_dag'
```