### PR TITLE
Remove unused ``logging.getLogger`` call

### DIFF
--- a/astronomer/providers/amazon/aws/hooks/base_aws_async.py
+++ b/astronomer/providers/amazon/aws/hooks/base_aws_async.py
@@ -1,11 +1,7 @@
-import logging
-
 from aiobotocore.client import AioBaseClient
 from aiobotocore.session import get_session
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook, _parse_s3_config
 from asgiref.sync import sync_to_async
-
-log = logging.getLogger(__name__)
 
 
 class AwsBaseHookAsync(AwsBaseHook):

--- a/astronomer/providers/amazon/aws/hooks/redshift_cluster.py
+++ b/astronomer/providers/amazon/aws/hooks/redshift_cluster.py
@@ -1,12 +1,9 @@
 import asyncio
-import logging
 from typing import Any, Dict
 
 import botocore.exceptions
 
 from astronomer.providers.amazon.aws.hooks.base_aws_async import AwsBaseHookAsync
-
-log = logging.getLogger(__name__)
 
 
 class RedshiftHookAsync(AwsBaseHookAsync):

--- a/astronomer/providers/amazon/aws/hooks/redshift_sql.py
+++ b/astronomer/providers/amazon/aws/hooks/redshift_sql.py
@@ -1,13 +1,10 @@
 import asyncio
-import logging
 from typing import Dict, List, Union
 
 import botocore.exceptions
 from asgiref.sync import sync_to_async
 
 from astronomer.providers.amazon.aws.hooks.redshift_data import RedshiftDataHook
-
-log = logging.getLogger(__name__)
 
 
 class RedshiftSQLHookAsync(RedshiftDataHook):

--- a/astronomer/providers/amazon/aws/hooks/s3.py
+++ b/astronomer/providers/amazon/aws/hooks/s3.py
@@ -1,5 +1,4 @@
 import fnmatch
-import logging
 import os
 import re
 from datetime import datetime
@@ -9,8 +8,6 @@ from aiobotocore.client import AioBaseClient
 from botocore.exceptions import ClientError
 
 from astronomer.providers.amazon.aws.hooks.base_aws_async import AwsBaseHookAsync
-
-log = logging.getLogger(__name__)
 
 
 class S3HookAsync(AwsBaseHookAsync):

--- a/astronomer/providers/amazon/aws/sensors/redshift_cluster.py
+++ b/astronomer/providers/amazon/aws/sensors/redshift_cluster.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, Dict, Optional
 
 from airflow.exceptions import AirflowException
@@ -8,8 +7,6 @@ from airflow.utils.context import Context
 from astronomer.providers.amazon.aws.triggers.redshift_cluster import (
     RedshiftClusterSensorTrigger,
 )
-
-log = logging.getLogger(__name__)
 
 
 class RedshiftClusterSensorAsync(RedshiftClusterSensor):

--- a/astronomer/providers/amazon/aws/sensors/s3.py
+++ b/astronomer/providers/amazon/aws/sensors/s3.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Union, cast
 from urllib.parse import urlparse
@@ -14,8 +13,6 @@ from astronomer.providers.amazon.aws.triggers.s3 import (
     S3KeyTrigger,
     S3PrefixTrigger,
 )
-
-log = logging.getLogger(__name__)
 
 
 class S3KeySensorAsync(BaseOperator):

--- a/astronomer/providers/amazon/aws/triggers/s3.py
+++ b/astronomer/providers/amazon/aws/triggers/s3.py
@@ -1,13 +1,10 @@
 import asyncio
-import logging
 from datetime import datetime
 from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 from astronomer.providers.amazon.aws.hooks.s3 import S3HookAsync
-
-log = logging.getLogger(__name__)
 
 
 class S3KeyTrigger(BaseTrigger):

--- a/astronomer/providers/core/sensors/filesystem.py
+++ b/astronomer/providers/core/sensors/filesystem.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from typing import Any, Dict, Optional
 
@@ -7,8 +6,6 @@ from airflow.sensors.filesystem import FileSensor
 from airflow.utils.context import Context
 
 from astronomer.providers.core.triggers.filesystem import FileTrigger
-
-log = logging.getLogger(__name__)
 
 
 class FileSensorAsync(FileSensor):

--- a/astronomer/providers/core/triggers/filesystem.py
+++ b/astronomer/providers/core/triggers/filesystem.py
@@ -1,14 +1,11 @@
 import asyncio
 import datetime
-import logging
 import os
 import typing
 from glob import glob
 from typing import Any, Dict, Tuple
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
-
-log = logging.getLogger(__name__)
 
 
 class FileTrigger(BaseTrigger):
@@ -52,7 +49,7 @@ class FileTrigger(BaseTrigger):
                 if os.path.isfile(path):
                     mod_time_f = os.path.getmtime(path)
                     mod_time = datetime.datetime.fromtimestamp(mod_time_f).strftime("%Y%m%d%H%M%S")
-                    log.info("Found File %s last modified: %s", str(path), str(mod_time))
+                    self.log.info("Found File %s last modified: %s", str(path), str(mod_time))
                     yield TriggerEvent(True)
                 for _, _, files in os.walk(self.filepath):
                     if len(files) > 0:

--- a/astronomer/providers/google/cloud/triggers/dataproc.py
+++ b/astronomer/providers/google/cloud/triggers/dataproc.py
@@ -1,13 +1,10 @@
 import asyncio
-import logging
 from typing import Any, AsyncIterator, Dict, Optional, Tuple
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from google.cloud.dataproc_v1.types import JobStatus
 
 from astronomer.providers.google.cloud.hooks.dataproc import DataprocHookAsync
-
-log = logging.getLogger(__name__)
 
 
 class DataProcSubmitTrigger(BaseTrigger):

--- a/astronomer/providers/google/cloud/triggers/gcs.py
+++ b/astronomer/providers/google/cloud/triggers/gcs.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import os
 from datetime import datetime
 from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple
@@ -9,8 +8,6 @@ from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils import timezone
 
 from astronomer.providers.google.cloud.hooks.gcs import GCSHookAsync
-
-log = logging.getLogger(__name__)
 
 
 class GCSBlobTrigger(BaseTrigger):


### PR DESCRIPTION
There are some places where we have declared a log variable has the value `logging.getLogger(__name__)`  in this PR I'm removing it because mostly it is unused and it adds an extra attribute log in documentation 

<img width="1219" alt="remove_log" src="https://user-images.githubusercontent.com/98807258/169235514-08cc618d-da29-40c6-a24a-88fb76171cc7.png">
