### PR TITLE
Update ExternalTaskSensorAsync example dag to defer

### DIFF
--- a/astronomer/providers/core/example_dags/example_external_task.py
+++ b/astronomer/providers/core/example_dags/example_external_task.py
@@ -1,20 +1,11 @@
-"""
-Manually testing the async external task sensor requires a separate DAG for it to defer execution
-until the second DAG is complete.
-
-    1. Add this file and "example_external_task_wait_for_me.py" to your local airflow/dags/
-    2. Once airflow is running, select "Trigger Dag w/ Config" for DAG: "test_external_task_async"
-    3. Copy the timestamp and hit the Trigger button
-    4. Select "Trigger DAG w/ Config" for DAG: "test_external_task_async_waits_for_me"
-    5. Paste timestamp and hit trigger button
-    6. Confirm that "test_external_task_async" defers until "test_external_task_async_waits_for_me"
-       successfully completes, then resumes execution and finishes without issue.
-"""
 import os
+import time
 from datetime import timedelta
 
 from airflow import DAG
 from airflow.operators.dummy import DummyOperator
+from airflow.operators.python import PythonOperator
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.utils.timezone import datetime
 
 from astronomer.providers.core.sensors.external_task import ExternalTaskSensorAsync
@@ -26,7 +17,7 @@ default_args = {
 }
 
 with DAG(
-    dag_id="test_external_task_async",
+    dag_id="example_external_task",
     start_date=datetime(2022, 1, 1),
     schedule_interval=None,
     catchup=False,
@@ -36,11 +27,42 @@ with DAG(
     start = DummyOperator(task_id="start")
 
     # [START howto_operator_external_task_sensor_async]
-    ext_task_sensor = ExternalTaskSensorAsync(
-        task_id="external_task_async",
-        external_task_id="start",
-        external_dag_id="test_external_task_async",
+    waiting_for_task = ExternalTaskSensorAsync(
+        task_id="waiting_for_task",
+        external_task_id="wait_for_me",
+        external_dag_id="example_external_task",
     )
     # [END howto_operator_external_task_sensor_async]
 
-    start >> ext_task_sensor
+    wait_for_me = PythonOperator(
+        task_id="wait_for_me",
+        python_callable=lambda: time.sleep(5),
+    )
+
+    # When ``external_task_id`` not provided
+    wait_for_dag = ExternalTaskSensorAsync(
+        task_id="wait_for_dag",
+        external_dag_id="example_external_task_async_waits_for_me",
+    )
+
+    wait_to_defer = PythonOperator(
+        task_id="wait_to_defer",
+        python_callable=lambda: time.sleep(5),
+    )
+
+    external = TriggerDagRunOperator(
+        task_id="external_dag",
+        trigger_dag_id="example_external_task_async_waits_for_me",
+        wait_for_completion=True,
+        reset_dag_run=True,
+        allowed_states=["success", "failed", "skipped"],
+        execution_date="{{execution_date}}",
+        poke_interval=1,
+    )
+
+    end = DummyOperator(task_id="end")
+
+    start >> [waiting_for_task, wait_for_me] >> end
+
+    start >> wait_for_dag >> end
+    start >> wait_to_defer >> external >> end

--- a/astronomer/providers/core/example_dags/example_external_task_wait_for_me.py
+++ b/astronomer/providers/core/example_dags/example_external_task_wait_for_me.py
@@ -11,7 +11,7 @@ default_args = {
 }
 
 with DAG(
-    dag_id="test_external_task_async_waits_for_me",
+    dag_id="example_external_task_async_waits_for_me",
     start_date=datetime(2022, 1, 1),
     schedule_interval=None,
     catchup=False,


### PR DESCRIPTION
Update `ExternalTaskSensorAsync` example DAG so that it correctly defer and run for both scenarios when external_task_id is given and not given.

Closes: #369 