### PR TITLE
Remove test_external_task_async_waits_for_me from master DAG

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -122,7 +122,6 @@ with DAG(
 
     # Core DAG
     core_task_info = [
-        {"external_task_wait_dag": "test_external_task_async_waits_for_me"},
         {"external_task_dag": "test_external_task_async"},
         {"file_sensor_dag": "example_async_file_sensor"},
     ]


### PR DESCRIPTION
Removed `test_external_task_async_waits_for_me_dag_from_master_dag` from `master_dag` since this dag does not test any of our async implantations but the purpose of this was to run `ExternalTaskSensorAsync` example DAG so no need to trigger this via master DAG. 

Now, [astronomer/providers/core/example_dags/example_external_task.py](https://github.com/astronomer/astronomer-providers/pull/370/files#diff-b9ba255046aec454155394e74f499084ba8ed2683b77f7316331b201da786656) trigger this instead of master DAG

related to: https://github.com/astronomer/astronomer-providers/issues/369