### PR TITLE
Fix Example ExternalTaskSensorAsync DAG name mismatch 

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -122,7 +122,7 @@ with DAG(
 
     # Core DAG
     core_task_info = [
-        {"external_task_dag": "test_external_task_async"},
+        {"external_task_dag": "example_external_task"},
         {"file_sensor_dag": "example_async_file_sensor"},
     ]
     core_trigger_tasks, ids = prepare_dag_dependency(core_task_info, "{{ ds }}")


### PR DESCRIPTION
Fix external_task DAG name mismatch in example dag in master dag

Related PR: https://github.com/astronomer/astronomer-providers/pull/370