### PR TITLE
Bump image tags to latest Airflow releases

### DIFF
--- a/.circleci/integration-tests/Dockerfile
+++ b/.circleci/integration-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/ap-airflow:2.3.0-4 as staging
+FROM quay.io/astronomer/ap-airflow:2.3.1-1 as staging
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0
@@ -76,7 +76,7 @@ RUN cp nuke-config.yml  ${AIRFLOW_HOME}/dags/
 USER astro
 
 # Deploy from astro runtime image
-FROM quay.io/astronomer/astro-runtime:5.0.1-base as astro-cloud
+FROM quay.io/astronomer/astro-runtime:5.0.2 as astro-cloud
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0

--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -103,7 +103,9 @@ with DAG(
     # AWS EMR DAG
     emr_task_info = [
         {"emr_sensor_dag": "example_emr_sensor"},
-        {"emr_eks_pi_job_dag": "example_emr_eks_pi_job"},
+        # Comment out `example_emr_eks_pi_job` to skip running from master_dag trigger until the DAG run issue is
+        # resolved.
+        # {"emr_eks_pi_job_dag": "example_emr_eks_pi_job"},
     ]
     emr_trigger_tasks, ids = prepare_dag_dependency(emr_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.1-base"
+ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.2"
 FROM ${IMAGE_NAME}
 
 USER root

--- a/dev/Dockerfile.emr_eks_container
+++ b/dev/Dockerfile.emr_eks_container
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.1-base"
+ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.2"
 FROM ${IMAGE_NAME}
 
 USER root


### PR DESCRIPTION
Bump to the following versions
Staging image -> quay.io/astronomer/ap-airflow:2.3.1-1
Astro Cloud image -> quay.io/astronomer/astro-runtime:5.0.2

Additionally, disable run of `example_emr_eks_pi_job` DAG as part
of `master_dag` run to not make it run until the issue is fixed
for the DAG.