### PR TITLE
Replace parameter for operator post removal of deprecated param

### DIFF
--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py
@@ -61,7 +61,7 @@ with DAG(
         task_id="create_dataset",
         dataset_id=DATASET,
         location=LOCATION,
-        bigquery_conn_id=GCP_CONN_ID,
+        gcp_conn_id=GCP_CONN_ID,
     )
 
     create_table_1 = BigQueryCreateEmptyTableOperator(


### PR DESCRIPTION
The deprecated param `bigquery_conn_id` of
`BigQueryCreateEmptyDatasetOperator` has been removed as part of
PR https://github.com/apache/airflow/pull/23326 . Hence, update the
operator task to use the new param `gcp_conn_id`.

Attaching the DAG import error screenshot.
<img width="1713" alt="Screenshot 2022-05-26 at 4 41 19 PM" src="https://user-images.githubusercontent.com/10206082/170476979-b457b9de-6551-42fc-8338-d7a774b68197.png">
