### PR TITLE
Add limitations for the AwsBaseHookAsync in doc-strings

### DIFF
--- a/astronomer/providers/amazon/aws/hooks/base_aws_async.py
+++ b/astronomer/providers/amazon/aws/hooks/base_aws_async.py
@@ -10,7 +10,7 @@ class AwsBaseHookAsync(AwsBaseHook):
 
     .. note::
         AwsBaseHookAsync uses aiobotocore to create asynchronous S3 hooks. Hence, AwsBaseHookAsync
-        supports all the authentication mechanism which aiobotocore supports. The ability to assume
+        only supports the authentication mechanism that aiobotocore supports. The ability to assume
         roles provided in the Airflow connection extra args via aiobotocore is not supported by the
         library yet.
     """

--- a/astronomer/providers/amazon/aws/hooks/base_aws_async.py
+++ b/astronomer/providers/amazon/aws/hooks/base_aws_async.py
@@ -5,7 +5,14 @@ from asgiref.sync import sync_to_async
 
 
 class AwsBaseHookAsync(AwsBaseHook):
-    """Interacts with AWS using aiobotocore asynchronously."""
+    """
+    Interacts with AWS using aiobotocore asynchronously.
+
+    Limitations: AwsBaseHookAsync uses aiobotocore to create asynchronous S3 hooks. Hence,
+    AwsBaseHookAsync supports all the authentication mechanism which aiobotocore supports.
+    The ability to assume roles provided in the Airflow connection extra args via aiobotocore
+    is not supported by the library yet.
+    """
 
     async def get_client_async(self) -> AioBaseClient:
         """Create an Async Client object to communicate with AWS services."""

--- a/astronomer/providers/amazon/aws/hooks/base_aws_async.py
+++ b/astronomer/providers/amazon/aws/hooks/base_aws_async.py
@@ -8,10 +8,11 @@ class AwsBaseHookAsync(AwsBaseHook):
     """
     Interacts with AWS using aiobotocore asynchronously.
 
-    Limitations: AwsBaseHookAsync uses aiobotocore to create asynchronous S3 hooks. Hence,
-    AwsBaseHookAsync supports all the authentication mechanism which aiobotocore supports.
-    The ability to assume roles provided in the Airflow connection extra args via aiobotocore
-    is not supported by the library yet.
+    .. note::
+       AwsBaseHookAsync uses aiobotocore to create asynchronous S3 hooks. Hence, AwsBaseHookAsync
+       supports all the authentication mechanism which aiobotocore supports. The ability to assume
+       roles provided in the Airflow connection extra args via aiobotocore is not supported by the
+       library yet.
     """
 
     async def get_client_async(self) -> AioBaseClient:


### PR DESCRIPTION
- Add limitations of using [aiobotocore](https://aiobotocore.readthedocs.io/en/latest/tutorial.html#using-botocore) in doc-strings