### PR TITLE
Fix unclosed client session error for KPOA

### DIFF
--- a/astronomer/providers/cncf/kubernetes/hooks/kubernetes_async.py
+++ b/astronomer/providers/cncf/kubernetes/hooks/kubernetes_async.py
@@ -69,5 +69,7 @@ class KubernetesHookAsync(KubernetesHook):  # noqa: D101
 
     async def get_api_client_async(self) -> client.ApiClient:
         """Create an API Client object to interact with Kubernetes"""
-        await self._load_config()
+        kube_client = await self._load_config()
+        if kube_client is not None:
+            return kube_client
         return client.ApiClient()

--- a/tests/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/cncf/kubernetes/hooks/test_kubernetes.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from kubernetes_asyncio import client
 
 from astronomer.providers.cncf.kubernetes.hooks.kubernetes_async import (
     KubernetesHookAsync,
@@ -15,7 +16,7 @@ from astronomer.providers.cncf.kubernetes.hooks.kubernetes_async import (
         (False, "/path/to/file", "my-context"),
     ],
 )
-@mock.patch("astronomer.providers.cncf.hooks.kubernetes_async.config")
+@mock.patch("astronomer.providers.cncf.kubernetes.hooks.kubernetes_async.config")
 @pytest.mark.xfail
 async def test_kubernetes__load_config(
     mock_config,
@@ -45,3 +46,18 @@ async def test_kubernetes__load_config(
             client_configuration=None,
             context=cluster_context,
         )
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.cncf.kubernetes.hooks.kubernetes_async.KubernetesHookAsync._load_config")
+async def test_get_api_client_async(mock__load_config):
+    mock__load_config.return_value = client.ApiClient()
+
+    hook = KubernetesHookAsync(
+        in_cluster=True,
+        config_file="path/kube/config",
+        cluster_context=None,
+        conn_id=None,
+    )
+    kube_client = await hook.get_api_client_async()
+    assert isinstance(kube_client, client.ApiClient)


### PR DESCRIPTION
This PR should fix `Unclosed client session error`.  
While creating the Kubernetes API client in a couple of scenarios we were calling `client.ApiClient()` twice. As fix, I'm checking if the client already initialised do not call `client.ApiClient()`
Closes: #372 