### PR TITLE
Add `retries` arg in the default params for example DAGs

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
@@ -13,6 +13,8 @@ EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 with DAG(

--- a/astronomer/providers/amazon/aws/example_dags/example_emr_eks_containers_job.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_eks_containers_job.py
@@ -35,6 +35,8 @@ EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 

--- a/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
@@ -55,6 +55,8 @@ JOB_FLOW_OVERRIDES = {
 
 DEFAULT_ARGS = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -30,6 +30,8 @@ EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py
@@ -26,6 +26,8 @@ EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 

--- a/astronomer/providers/amazon/aws/example_dags/example_s3.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_s3.py
@@ -28,9 +28,9 @@ AWS_CONN_ID = os.getenv("ASTRO_AWS_S3_CONN_ID", "aws_s3_default")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {
-    "retry": 5,
-    "retry_delay": timedelta(minutes=1),
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 with DAG(

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -279,6 +279,8 @@ def get_cluster_details(task_instance: Any) -> None:
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 with DAG(

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -245,6 +245,8 @@ def get_cluster_details(task_instance: Any) -> None:
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 with DAG(

--- a/astronomer/providers/cncf/kubernetes/example_dags/example_kubernetes_pod_operator.py
+++ b/astronomer/providers/cncf/kubernetes/example_dags/example_kubernetes_pod_operator.py
@@ -20,6 +20,8 @@ else:
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 with DAG(

--- a/astronomer/providers/core/example_dags/example_external_task.py
+++ b/astronomer/providers/core/example_dags/example_external_task.py
@@ -14,6 +14,8 @@ EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 with DAG(

--- a/astronomer/providers/core/example_dags/example_external_task_wait_for_me.py
+++ b/astronomer/providers/core/example_dags/example_external_task_wait_for_me.py
@@ -8,6 +8,8 @@ EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 with DAG(

--- a/astronomer/providers/core/example_dags/example_file_sensor.py
+++ b/astronomer/providers/core/example_dags/example_file_sensor.py
@@ -12,6 +12,8 @@ EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 with DAG(

--- a/astronomer/providers/databricks/example_dags/example_databricks.py
+++ b/astronomer/providers/databricks/example_dags/example_databricks.py
@@ -20,6 +20,8 @@ EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 new_cluster = {

--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py
@@ -46,6 +46,8 @@ INSERT_ROWS_QUERY = (
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 with DAG(

--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_sensors.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_sensors.py
@@ -35,7 +35,12 @@ SCHEMA = [
     {"name": "ds", "type": "DATE", "mode": "NULLABLE"},
 ]
 
-default_args = {"execution_timeout": timedelta(hours=EXECUTION_TIMEOUT), "gcp_conn_id": GCP_CONN_ID}
+default_args = {
+    "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "gcp_conn_id": GCP_CONN_ID,
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
+}
 
 with DAG(
     dag_id="example_bigquery_sensors",

--- a/astronomer/providers/google/cloud/example_dags/example_dataproc.py
+++ b/astronomer/providers/google/cloud/example_dags/example_dataproc.py
@@ -145,6 +145,8 @@ WORKFLOW_TEMPLATE = {
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 

--- a/astronomer/providers/google/cloud/example_dags/example_gcs.py
+++ b/astronomer/providers/google/cloud/example_dags/example_gcs.py
@@ -29,6 +29,8 @@ BUCKET_FILE_LOCATION = "example_gcs.py"
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 with DAG(

--- a/astronomer/providers/http/example_dags/example_http.py
+++ b/astronomer/providers/http/example_dags/example_http.py
@@ -11,6 +11,8 @@ EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 

--- a/astronomer/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
+++ b/astronomer/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
@@ -20,6 +20,8 @@ default_args = {
     "azure_data_factory_conn_id": "azure_data_factory_default",
     "factory_name": "ADFProvidersTeamDataFactoryTest",  # This can also be specified in the ADF connection.
     "resource_group_name": "team_provider_resource_group_test_1",  # This can also be specified in the ADF connection.
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 CLIENT_ID = os.getenv("CLIENT_ID", "")

--- a/astronomer/providers/snowflake/example_dags/example_snowflake.py
+++ b/astronomer/providers/snowflake/example_dags/example_snowflake.py
@@ -27,6 +27,8 @@ SNOWFLAKE_SLACK_MESSAGE = (
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
     "snowflake_conn_id": SNOWFLAKE_CONN_ID,
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 with DAG(


### PR DESCRIPTION
Adds `retries` argument along with `retry_delay` to reattempt
failed tasks in example DAGs.