### PR TITLE
Reorder sequence for execution of tasks

### DIFF
--- a/astronomer/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
+++ b/astronomer/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
@@ -185,17 +185,17 @@ with DAG(
     # [END howto_create_resource_group]
 
     # [START howto_operator_adf_run_pipeline]
-    run_pipeline_no_wait = AzureDataFactoryRunPipelineOperatorAsync(
-        task_id="run_pipeline_no_wait",
+    run_pipeline_wait = AzureDataFactoryRunPipelineOperatorAsync(
+        task_id="run_pipeline_wait",
         pipeline_name=PIPELINE_NAME,
-        wait_for_termination=False,
     )
     # [END howto_operator_adf_run_pipeline]
 
     # [START howto_operator_adf_run_pipeline]
-    run_pipeline_wait = AzureDataFactoryRunPipelineOperatorAsync(
-        task_id="run_pipeline_wait",
+    run_pipeline_no_wait = AzureDataFactoryRunPipelineOperatorAsync(
+        task_id="run_pipeline_no_wait",
         pipeline_name=PIPELINE_NAME,
+        wait_for_termination=False,
     )
     # [END howto_operator_adf_run_pipeline]
 
@@ -214,8 +214,8 @@ with DAG(
 
     (
         create_azure_data_factory_storage_pipeline
-        >> run_pipeline_no_wait
         >> run_pipeline_wait
+        >> run_pipeline_no_wait
         >> pipeline_run_sensor_async
         >> remove_azure_data_factory_storage_pipeline
     )


### PR DESCRIPTION
I am unable to reproduce issue #366 locally after trying multiple
times. Looking at the code, I am understanding that the
`run_pipeline_no_wait` and `run_pipeline_wait` try to execute the
same pipeline with same name and resources. The `run_pipeline_no_wait`
tasks starts the pipeline and does not wait for the pipeline to finish
before marking the task as success. My hunch here is that since
the pipeline launched by `run_pipeline_no_wait` is still in progress,
another immediate attempt by `run_pipeline_wait` task to start the
same pipeline is the reason for the failure of the task observed in
issue #366. Hence, I am reordering the task sequence so that
`run_pipeline_wait` task runs first; the task waits for the pipeline
to finish before marking the task as success and then we launch
the `run_pipeline_no_wait` task as the downstream task.

I would like to push this commit &  merge to main so that we can
observe in our Astro Cloud deployment's master DAG run on whether this
solves the problem. If the problem still persists, we will then need
to spend additional efforts in investigating the issue.