### PR TITLE
Fix CI: Update CNCF.Kubernetes and Bigquery Test

### DIFF
--- a/tests/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -53,6 +53,7 @@ def test_raise_for_trigger_status_done():
 KUBE_POD_MOD = "astronomer.providers.cncf.kubernetes.operators.kubernetes_pod"
 
 
+@mock.patch("airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.client")
 @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.cleanup")
 @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
 @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.raise_for_trigger_status")
@@ -66,11 +67,13 @@ def test_get_logs_running(
     raise_for_trigger_status,
     get_kube_client,
     cleanup,
+    mock_client,
 ):
     """When logs fetch exits with status running, raise task deferred"""
     pod = MagicMock()
     find_pod.return_value = pod
     op = KubernetesPodOperatorAsync(task_id="test_task", name="test-pod", get_logs=True)
+    mock_client.return_value = {}
     context = create_context(op)
     await_pod_completion.return_value = None
     fetch_container_logs.return_value = PodLoggingStatus(True, None)
@@ -79,6 +82,7 @@ def test_get_logs_running(
     fetch_container_logs.is_called_with(pod, "base")
 
 
+@mock.patch("airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.client")
 @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.cleanup")
 @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
 @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.raise_for_trigger_status")
@@ -92,9 +96,11 @@ def test_get_logs_not_running(
     raise_for_trigger_status,
     get_kube_client,
     cleanup,
+    mock_client,
 ):
     pod = MagicMock()
     find_pod.return_value = pod
+    mock_client.return_value = {}
     op = KubernetesPodOperatorAsync(task_id="test_task", name="test-pod", get_logs=True)
     context = create_context(op)
     await_pod_completion.return_value = None

--- a/tests/google/cloud/operators/test_bigquery.py
+++ b/tests/google/cloud/operators/test_bigquery.py
@@ -152,7 +152,7 @@ def test_job_id_validity(mock_md5, test_dag_id, expected_job_id):
     """Asserts that job id is correctly generated"""
     hash_ = "hash"
     mock_md5.return_value.hexdigest.return_value = hash_
-    context = {"execution_date": datetime(2020, 1, 23)}
+    context = {"logical_date": datetime(2020, 1, 23)}
     configuration = {
         "query": {
             "query": "SELECT * FROM any",


### PR DESCRIPTION
Closes: #438 

- in apache-airflow-providers-google 8.0.0 in bigquery it is expecting that context should have logical_date not execution_date
- apache-airflow-providers-cncf-kubernetes 4.1.0 Kubernetes hook has changed and expect a few more params so kube client is getting affected
-------
- Updated bigquery test to set logical_date in context
- for Kubernetes mock client