### PR TITLE
Add async implementation for Redshift cluster deletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,11 @@ clean: ## Remove all the containers along with volumes
 build: ## Build the Docker image (ignoring cache)
 	docker build -f dev/Dockerfile . -t astronomer-providers-dev:latest --no-cache
 
-build-emr_eks_container_example_dag-image: ## Build the Docker image for EMR EKS containers example DAG (ignoring cache)
-	docker build -f dev/Dockerfile.emr_eks_container . -t astronomer-providers-dev:latest --no-cache
+build-emr_eks_container_example_dag-image: ## Build the Docker image for EMR EKS containers example DAG
+	docker build -f dev/Dockerfile.emr_eks_container . -t astronomer-providers-dev:latest
+
+build-aws: ## Build the Docker image with aws-cli installed
+	docker build -f dev/Dockerfile.aws . -t astronomer-providers-dev:latest
 
 build-run: ## Build the Docker Image & then run the containers
 	docker-compose -f dev/docker-compose.yaml up --build -d

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -17,17 +17,21 @@ from astronomer.providers.amazon.aws.sensors.redshift_cluster import (
     RedshiftClusterSensorAsync,
 )
 
+AWS_CONN_ID = os.getenv("ASTRO_AWS_CONN_ID", "aws_default")
+AWS_DEFAULT_REGION = os.getenv("AWS_DEFAULT_REGION", "us-east-2")
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "**********")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "***********")
+EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
+REDSHIFT_CLUSTER_DB_NAME = os.getenv("REDSHIFT_CLUSTER_DB_NAME", "astro_dev")
 REDSHIFT_CLUSTER_IDENTIFIER = os.getenv("REDSHIFT_CLUSTER_IDENTIFIER", "astro-providers-cluster")
 REDSHIFT_CLUSTER_MASTER_USER = os.getenv("REDSHIFT_CLUSTER_MASTER_USER", "awsuser")
 REDSHIFT_CLUSTER_MASTER_PASSWORD = os.getenv("REDSHIFT_CLUSTER_MASTER_PASSWORD", "********")
-REDSHIFT_CLUSTER_DB_NAME = os.getenv("REDSHIFT_CLUSTER_DB_NAME", "astro_dev")
-REDSHIFT_CLUSTER_TYPE = os.getenv("REDSHIFT_CLUSTER_TYPE", "single-node")
 REDSHIFT_CLUSTER_NODE_TYPE = os.getenv("REDSHIFT_CLUSTER_NODE_TYPE", "dc2.large")
-AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "**********")
-AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "***********")
-AWS_DEFAULT_REGION = os.getenv("AWS_DEFAULT_REGION", "us-east-2")
-AWS_CONN_ID = os.getenv("ASTRO_AWS_CONN_ID", "aws_default")
-EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
+REDSHIFT_CLUSTER_STATUS_FETCH_INTERVAL_SECONDS = int(
+    os.getenv("REDSHIFT_CLUSTER_STATUS_FETCH_INTERVAL_SECONDS", 10)
+)
+REDSHIFT_CLUSTER_TYPE = os.getenv("REDSHIFT_CLUSTER_TYPE", "single-node")
+
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
@@ -147,34 +151,6 @@ def delete_redshift_cluster_snapshot_callable() -> None:
         time.sleep(30)
 
 
-def delete_redshift_cluster_callable() -> None:
-    """Delete a redshift cluster and wait until it completely removed"""
-    import boto3
-    from botocore.exceptions import ClientError
-
-    client = boto3.client("redshift")
-
-    try:
-        client.delete_cluster(
-            ClusterIdentifier=REDSHIFT_CLUSTER_IDENTIFIER,
-            SkipFinalClusterSnapshot=True,
-        )
-
-        while get_cluster_status() == "deleting":
-            logging.info("Waiting for cluster to be deleted. Sleeping for 30 seconds.")
-            time.sleep(30)
-
-    except ClientError as exception:
-        if exception.response.get("Error", {}).get("Code", "") == "ClusterNotFound":
-            logging.error(
-                "Cluster might have already been deleted. Error message is: %s",
-                exception.response["Error"]["Message"],
-            )
-        else:
-            logging.exception("Error deleting redshift cluster")
-            raise
-
-
 with DAG(
     dag_id="example_async_redshift_cluster_management",
     start_date=datetime(2022, 1, 1),
@@ -241,6 +217,7 @@ with DAG(
         aws_conn_id=AWS_CONN_ID,
         skip_final_cluster_snapshot=True,
         final_cluster_snapshot_identifier=None,
+        cluster_status_fetch_interval_seconds=REDSHIFT_CLUSTER_STATUS_FETCH_INTERVAL_SECONDS,
     )
     # [END howto_operator_redshift_delete_cluster_async]
 

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -233,6 +233,7 @@ with DAG(
         trigger_rule="all_done",
     )
 
+    # [START howto_operator_redshift_delete_cluster_async]
     delete_redshift_cluster = RedshiftDeleteClusterOperatorAsync(
         task_id="delete_redshift_cluster",
         trigger_rule="all_done",
@@ -241,6 +242,7 @@ with DAG(
         skip_final_cluster_snapshot=True,
         final_cluster_snapshot_identifier=None,
     )
+    # [END howto_operator_redshift_delete_cluster_async]
 
     end = DummyOperator(task_id="end")
 

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -27,9 +27,6 @@ REDSHIFT_CLUSTER_IDENTIFIER = os.getenv("REDSHIFT_CLUSTER_IDENTIFIER", "astro-pr
 REDSHIFT_CLUSTER_MASTER_USER = os.getenv("REDSHIFT_CLUSTER_MASTER_USER", "awsuser")
 REDSHIFT_CLUSTER_MASTER_PASSWORD = os.getenv("REDSHIFT_CLUSTER_MASTER_PASSWORD", "********")
 REDSHIFT_CLUSTER_NODE_TYPE = os.getenv("REDSHIFT_CLUSTER_NODE_TYPE", "dc2.large")
-REDSHIFT_CLUSTER_STATUS_FETCH_INTERVAL_SECONDS = int(
-    os.getenv("REDSHIFT_CLUSTER_STATUS_FETCH_INTERVAL_SECONDS", 10)
-)
 REDSHIFT_CLUSTER_TYPE = os.getenv("REDSHIFT_CLUSTER_TYPE", "single-node")
 
 
@@ -217,7 +214,6 @@ with DAG(
         aws_conn_id=AWS_CONN_ID,
         skip_final_cluster_snapshot=True,
         final_cluster_snapshot_identifier=None,
-        cluster_status_fetch_interval_seconds=REDSHIFT_CLUSTER_STATUS_FETCH_INTERVAL_SECONDS,
     )
     # [END howto_operator_redshift_delete_cluster_async]
 

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -9,6 +9,7 @@ from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import PythonOperator
 
 from astronomer.providers.amazon.aws.operators.redshift_cluster import (
+    RedshiftDeleteClusterOperatorAsync,
     RedshiftPauseClusterOperatorAsync,
     RedshiftResumeClusterOperatorAsync,
 )
@@ -232,10 +233,13 @@ with DAG(
         trigger_rule="all_done",
     )
 
-    delete_redshift_cluster = PythonOperator(
+    delete_redshift_cluster = RedshiftDeleteClusterOperatorAsync(
         task_id="delete_redshift_cluster",
-        python_callable=delete_redshift_cluster_callable,
         trigger_rule="all_done",
+        cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
+        aws_conn_id=AWS_CONN_ID,
+        skip_final_cluster_snapshot=True,
+        final_cluster_snapshot_identifier=None,
     )
 
     end = DummyOperator(task_id="end")

--- a/astronomer/providers/amazon/aws/operators/redshift_cluster.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_cluster.py
@@ -1,8 +1,9 @@
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.redshift_cluster import RedshiftHook
 from airflow.providers.amazon.aws.operators.redshift_cluster import (
+    RedshiftDeleteClusterOperator,
     RedshiftPauseClusterOperator,
     RedshiftResumeClusterOperator,
 )
@@ -13,6 +14,74 @@ from astronomer.providers.amazon.aws.triggers.redshift_cluster import (
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
+
+
+class RedshiftDeleteClusterOperatorAsync(RedshiftDeleteClusterOperator):
+    """
+    Delete an AWS Redshift Cluster if cluster status is in `available` state.
+
+    :param cluster_identifier: ID of the AWS Redshift Cluster
+    :param aws_conn_id: aws connection to use
+    :param skip_final_cluster_snapshot: determines cluster snapshot creation
+    :param final_cluster_snapshot_identifier: name of final cluster snapshot
+    """
+
+    def __init__(
+        self,
+        *,
+        skip_final_cluster_snapshot: bool = True,
+        final_cluster_snapshot_identifier: Optional[str] = None,
+        aws_conn_id: str = "aws_default",
+        poll_interval: float = 5.0,
+        **kwargs: Any,
+    ):
+        self.skip_final_cluster_snapshot = skip_final_cluster_snapshot
+        self.final_cluster_snapshot_identifier = final_cluster_snapshot_identifier
+        self.aws_conn_id = aws_conn_id
+        self.poll_interval = poll_interval
+        super().__init__(**kwargs)
+
+    def execute(self, context: "Context") -> None:
+        """
+        Logic that the operator uses to correctly identify which trigger to
+        execute, and defer execution as expected.
+        """
+        redshift_hook = RedshiftHook(aws_conn_id=self.aws_conn_id)
+        cluster_state = redshift_hook.cluster_status(cluster_identifier=self.cluster_identifier)
+        if cluster_state == "available":
+            self.defer(
+                timeout=self.execution_timeout,
+                trigger=RedshiftClusterTrigger(
+                    task_id=self.task_id,
+                    polling_period_seconds=self.poll_interval,
+                    aws_conn_id=self.aws_conn_id,
+                    cluster_identifier=self.cluster_identifier,
+                    operation_type="delete_cluster",
+                ),
+                method_name="execute_complete",
+            )
+        else:
+            self.log.warning(
+                "Unable to delete cluster since cluster is currently in status: %s", cluster_state
+            )
+
+    def execute_complete(self, context: Dict[str, Any], event: Any = None) -> None:
+        """
+        Callback for when the trigger fires - returns immediately.
+        Relies on trigger to throw an exception, otherwise it assumes execution was
+        successful.
+        """
+        if event:
+            if "status" in event and event["status"] == "error":
+                msg = "{0}: {1}".format(event["status"], event["message"])
+                raise AirflowException(msg)
+            elif "status" in event and event["status"] == "success":
+                self.log.info("%s completed successfully.", self.task_id)
+                self.log.info("Deleted cluster successfully")
+                return None
+        else:
+            self.log.info("%s completed successfully.", self.task_id)
+            return None
 
 
 class RedshiftResumeClusterOperatorAsync(RedshiftResumeClusterOperator):

--- a/astronomer/providers/amazon/aws/operators/redshift_cluster.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_cluster.py
@@ -24,6 +24,7 @@ class RedshiftDeleteClusterOperatorAsync(RedshiftDeleteClusterOperator):
     :param aws_conn_id: aws connection to use
     :param skip_final_cluster_snapshot: determines cluster snapshot creation
     :param final_cluster_snapshot_identifier: name of final cluster snapshot
+    :param cluster_status_fetch_interval_seconds: interval seconds to wait for fetching cluster status
     """
 
     def __init__(
@@ -31,12 +32,14 @@ class RedshiftDeleteClusterOperatorAsync(RedshiftDeleteClusterOperator):
         *,
         skip_final_cluster_snapshot: bool = True,
         final_cluster_snapshot_identifier: Optional[str] = None,
+        cluster_status_fetch_interval_seconds: int = 10,
         aws_conn_id: str = "aws_default",
         poll_interval: float = 5.0,
         **kwargs: Any,
     ):
         self.skip_final_cluster_snapshot = skip_final_cluster_snapshot
         self.final_cluster_snapshot_identifier = final_cluster_snapshot_identifier
+        self.cluster_status_fetch_interval_seconds = cluster_status_fetch_interval_seconds
         self.aws_conn_id = aws_conn_id
         self.poll_interval = poll_interval
         super().__init__(**kwargs)
@@ -57,6 +60,9 @@ class RedshiftDeleteClusterOperatorAsync(RedshiftDeleteClusterOperator):
                     aws_conn_id=self.aws_conn_id,
                     cluster_identifier=self.cluster_identifier,
                     operation_type="delete_cluster",
+                    skip_final_cluster_snapshot=self.skip_final_cluster_snapshot,
+                    final_cluster_snapshot_identifier=self.final_cluster_snapshot_identifier,
+                    cluster_status_fetch_interval_seconds=self.cluster_status_fetch_interval_seconds,
                 ),
                 method_name="execute_complete",
             )

--- a/astronomer/providers/amazon/aws/triggers/redshift_cluster.py
+++ b/astronomer/providers/amazon/aws/triggers/redshift_cluster.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, AsyncIterator, Dict, Tuple
+from typing import Any, AsyncIterator, Dict, Optional, Tuple
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
@@ -14,7 +14,10 @@ class RedshiftClusterTrigger(BaseTrigger):
     :param polling_period_seconds:  polling period in seconds to check for the status
     :param aws_conn_id: Reference to AWS connection id for redshift
     :param cluster_identifier: unique identifier of a cluster
-    :param operation_type: Reference to the type of operation need to be performed eg: pause_cluster, resume_cluster
+    :param operation_type: Reference to the type of operation need to be performed
+        eg: pause_cluster, resume_cluster, delete_cluster
+    :param skip_final_cluster_snapshot: determines cluster snapshot creation
+    :param final_cluster_snapshot_identifier: name of final cluster snapshot
     """
 
     def __init__(
@@ -24,6 +27,8 @@ class RedshiftClusterTrigger(BaseTrigger):
         aws_conn_id: str,
         cluster_identifier: str,
         operation_type: str,
+        skip_final_cluster_snapshot: bool = True,
+        final_cluster_snapshot_identifier: Optional[str] = None,
     ):
         super().__init__()
         self.task_id = task_id
@@ -31,6 +36,8 @@ class RedshiftClusterTrigger(BaseTrigger):
         self.aws_conn_id = aws_conn_id
         self.cluster_identifier = cluster_identifier
         self.operation_type = operation_type
+        self.skip_final_cluster_snapshot = skip_final_cluster_snapshot
+        self.final_cluster_snapshot_identifier = final_cluster_snapshot_identifier
 
     def serialize(self) -> Tuple[str, Dict[str, Any]]:
         """Serializes RedshiftClusterTrigger arguments and classpath."""
@@ -42,6 +49,8 @@ class RedshiftClusterTrigger(BaseTrigger):
                 "aws_conn_id": self.aws_conn_id,
                 "cluster_identifier": self.cluster_identifier,
                 "operation_type": self.operation_type,
+                "skip_final_cluster_snapshot": self.skip_final_cluster_snapshot,
+                "final_cluster_snapshot_identifier": self.final_cluster_snapshot_identifier,
             },
         )
 
@@ -54,14 +63,25 @@ class RedshiftClusterTrigger(BaseTrigger):
         """
         hook = RedshiftHookAsync(aws_conn_id=self.aws_conn_id)
         try:
-            if self.operation_type == "resume_cluster":
+            if self.operation_type == "delete_cluster":
+                response = await hook.delete_cluster(
+                    cluster_identifier=self.cluster_identifier,
+                    skip_final_cluster_snapshot=self.skip_final_cluster_snapshot,
+                    final_cluster_snapshot_identifier=self.final_cluster_snapshot_identifier,
+                )
+                if response:
+                    yield TriggerEvent(response)
+                else:
+                    error_message = f"{self.task_id} failed"
+                    yield TriggerEvent({"status": "error", "message": error_message})
+            elif self.operation_type == "resume_cluster":
                 response = await hook.resume_cluster(cluster_identifier=self.cluster_identifier)
                 if response:
                     yield TriggerEvent(response)
                 else:
                     error_message = f"{self.task_id} failed"
                     yield TriggerEvent({"status": "error", "message": error_message})
-            else:
+            elif self.operation_type == "pause_cluster":
                 response = await hook.pause_cluster(cluster_identifier=self.cluster_identifier)
                 if response:
                     yield TriggerEvent(response)

--- a/astronomer/providers/amazon/aws/triggers/redshift_cluster.py
+++ b/astronomer/providers/amazon/aws/triggers/redshift_cluster.py
@@ -18,6 +18,7 @@ class RedshiftClusterTrigger(BaseTrigger):
         eg: pause_cluster, resume_cluster, delete_cluster
     :param skip_final_cluster_snapshot: determines cluster snapshot creation
     :param final_cluster_snapshot_identifier: name of final cluster snapshot
+    :param cluster_status_fetch_interval_seconds: interval seconds to wait for fetching cluster status
     """
 
     def __init__(
@@ -29,6 +30,7 @@ class RedshiftClusterTrigger(BaseTrigger):
         operation_type: str,
         skip_final_cluster_snapshot: bool = True,
         final_cluster_snapshot_identifier: Optional[str] = None,
+        cluster_status_fetch_interval_seconds: int = 10,
     ):
         super().__init__()
         self.task_id = task_id
@@ -38,6 +40,7 @@ class RedshiftClusterTrigger(BaseTrigger):
         self.operation_type = operation_type
         self.skip_final_cluster_snapshot = skip_final_cluster_snapshot
         self.final_cluster_snapshot_identifier = final_cluster_snapshot_identifier
+        self.cluster_status_fetch_interval_seconds = cluster_status_fetch_interval_seconds
 
     def serialize(self) -> Tuple[str, Dict[str, Any]]:
         """Serializes RedshiftClusterTrigger arguments and classpath."""
@@ -51,6 +54,7 @@ class RedshiftClusterTrigger(BaseTrigger):
                 "operation_type": self.operation_type,
                 "skip_final_cluster_snapshot": self.skip_final_cluster_snapshot,
                 "final_cluster_snapshot_identifier": self.final_cluster_snapshot_identifier,
+                "cluster_status_fetch_interval_seconds": self.cluster_status_fetch_interval_seconds,
             },
         )
 

--- a/dev/Dockerfile.aws
+++ b/dev/Dockerfile.aws
@@ -1,0 +1,22 @@
+ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.2-base"
+FROM ${IMAGE_NAME}
+
+USER root
+RUN apt-get update -y && apt-get install -y git
+RUN apt-get install -y --no-install-recommends \
+        build-essential \
+        libsasl2-2 \
+        libsasl2-dev \
+        libsasl2-modules \
+        unzip
+
+# install AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install;
+
+COPY setup.cfg ${AIRFLOW_HOME}/astronomer_providers/setup.cfg
+COPY pyproject.toml ${AIRFLOW_HOME}/astronomer_providers/pyproject.toml
+
+RUN pip install -e "${AIRFLOW_HOME}/astronomer_providers[all,tests,mypy]"
+USER astro

--- a/tests/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/amazon/aws/operators/test_redshift_cluster.py
@@ -4,6 +4,7 @@ import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
 
 from astronomer.providers.amazon.aws.operators.redshift_cluster import (
+    RedshiftDeleteClusterOperatorAsync,
     RedshiftPauseClusterOperatorAsync,
     RedshiftResumeClusterOperatorAsync,
 )
@@ -19,6 +20,99 @@ def context():
     """
     context = {}
     yield context
+
+
+@mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_cluster.RedshiftHookAsync.delete_cluster")
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_cluster.RedshiftHookAsync.get_client_async")
+def test_delete_cluster(mock_async_client, mock_async_delete_cluster, mock_sync_cluster_status):
+    """Test Delete cluster operator with available cluster state and check the trigger instance"""
+    mock_sync_cluster_status.return_value = "available"
+    mock_async_client.return_value.delete_cluster.return_value = {
+        "Cluster": {"ClusterIdentifier": "test_cluster", "ClusterStatus": "deleting"}
+    }
+    mock_async_delete_cluster.return_value = {"status": "success", "cluster_state": "cluster_not_found"}
+
+    redshift_operator = RedshiftDeleteClusterOperatorAsync(
+        task_id="task_test", cluster_identifier="test_cluster", aws_conn_id="aws_conn_test"
+    )
+
+    with pytest.raises(TaskDeferred) as exc:
+        redshift_operator.execute(context)
+
+    assert isinstance(exc.value.trigger, RedshiftClusterTrigger), "Trigger is not a RedshiftClusterTrigger"
+
+
+@mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_cluster.RedshiftHookAsync.delete_cluster")
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_cluster.RedshiftHookAsync.get_client_async")
+def test_delete_cluster_failure(mock_async_client, mock_async_delete_cluster, mock_sync_cluster_status):
+    """Test Delete cluster operator with available cluster state in failure test case"""
+    mock_sync_cluster_status.return_value = "available"
+    mock_async_client.return_value.delete_cluster.return_value = {
+        "Cluster": {"ClusterIdentifier": "test_cluster", "ClusterStatus": "deleting"}
+    }
+    mock_async_delete_cluster.return_value = {"status": "success", "cluster_state": "cluster_not_found"}
+
+    redshift_operator = RedshiftDeleteClusterOperatorAsync(
+        task_id="task_test", cluster_identifier="test_cluster", aws_conn_id="aws_conn_test"
+    )
+
+    with pytest.raises(AirflowException):
+        redshift_operator.execute_complete(
+            context=None, event={"status": "error", "message": "test failure message"}
+        )
+
+
+@mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_cluster.RedshiftHookAsync.delete_cluster")
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_cluster.RedshiftHookAsync.get_client_async")
+def test_delete_cluster_execute_complete(
+    mock_async_client, mock_async_delete_cluster, mock_sync_cluster_status
+):
+    """
+    Test Delete cluster operator execute_complete with available cluster state and return state as cluster_not_found.
+    """
+    mock_sync_cluster_status.return_value = "available"
+    mock_async_client.return_value.delete_cluster.return_value = {
+        "Cluster": {"ClusterIdentifier": "test_cluster", "ClusterStatus": "deleting"}
+    }
+    mock_async_delete_cluster.return_value = {"status": "success", "cluster_state": "cluster_not_found"}
+
+    redshift_operator = RedshiftDeleteClusterOperatorAsync(
+        task_id="task_test", cluster_identifier="test_cluster", aws_conn_id="aws_conn_test"
+    )
+
+    with mock.patch.object(redshift_operator.log, "info") as mock_log_info:
+        redshift_operator.execute_complete(
+            context=None, event={"status": "success", "cluster_state": "cluster_not_found"}
+        )
+    mock_log_info.assert_called_with("Deleted cluster successfully")
+
+
+def test_delete_cluster_execute_complete_none():
+    """Asserts that logging occurs as expected"""
+    task = RedshiftDeleteClusterOperatorAsync(
+        task_id="task_test", cluster_identifier="test_cluster", aws_conn_id="aws_conn_test"
+    )
+    with mock.patch.object(task.log, "info") as mock_log_info:
+        task.execute_complete(context=None, event=None)
+    mock_log_info.assert_called_with("%s completed successfully.", "task_test")
+
+
+@mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
+def test_delete_cluster_execute_warning(mock_sync_cluster_status):
+    """Test Pause cluster operator execute method with warnings message"""
+    mock_sync_cluster_status.return_value = "cluster_not_found"
+    redshift_operator = RedshiftDeleteClusterOperatorAsync(
+        task_id="task_test", cluster_identifier="test_cluster", aws_conn_id="aws_conn_test"
+    )
+
+    with mock.patch.object(redshift_operator.log, "warning") as mock_log_warning:
+        redshift_operator.execute(context=None)
+    mock_log_warning.assert_called_with(
+        "Unable to delete cluster since cluster is currently in status: %s", "cluster_not_found"
+    )
 
 
 @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")

--- a/tests/amazon/aws/triggers/test_redshift_cluster.py
+++ b/tests/amazon/aws/triggers/test_redshift_cluster.py
@@ -33,6 +33,8 @@ def test_redshift_cluster_resume_trigger_serialization():
         "aws_conn_id": "test_redshift_conn_id",
         "cluster_identifier": "mock_cluster_identifier",
         "operation_type": "resume_cluster",
+        "final_cluster_snapshot_identifier": None,
+        "skip_final_cluster_snapshot": True,
     }
 
 
@@ -108,6 +110,8 @@ def test_redshift_pause_resume_trigger_serialization():
         "aws_conn_id": "test_redshift_conn_id",
         "cluster_identifier": "mock_cluster_identifier",
         "operation_type": "pause_cluster",
+        "final_cluster_snapshot_identifier": None,
+        "skip_final_cluster_snapshot": True,
     }
 
 

--- a/tests/amazon/aws/triggers/test_redshift_cluster.py
+++ b/tests/amazon/aws/triggers/test_redshift_cluster.py
@@ -35,7 +35,6 @@ def test_redshift_cluster_delete_trigger_serialization():
         "operation_type": "delete_cluster",
         "final_cluster_snapshot_identifier": None,
         "skip_final_cluster_snapshot": True,
-        "cluster_status_fetch_interval_seconds": 10,
     }
 
 
@@ -113,7 +112,6 @@ def test_redshift_cluster_resume_trigger_serialization():
         "operation_type": "resume_cluster",
         "final_cluster_snapshot_identifier": None,
         "skip_final_cluster_snapshot": True,
-        "cluster_status_fetch_interval_seconds": 10,
     }
 
 
@@ -191,7 +189,6 @@ def test_redshift_pause_resume_trigger_serialization():
         "operation_type": "pause_cluster",
         "final_cluster_snapshot_identifier": None,
         "skip_final_cluster_snapshot": True,
-        "cluster_status_fetch_interval_seconds": 10,
     }
 
 

--- a/tests/amazon/aws/triggers/test_redshift_cluster.py
+++ b/tests/amazon/aws/triggers/test_redshift_cluster.py
@@ -35,6 +35,7 @@ def test_redshift_cluster_delete_trigger_serialization():
         "operation_type": "delete_cluster",
         "final_cluster_snapshot_identifier": None,
         "skip_final_cluster_snapshot": True,
+        "cluster_status_fetch_interval_seconds": 10,
     }
 
 
@@ -112,6 +113,7 @@ def test_redshift_cluster_resume_trigger_serialization():
         "operation_type": "resume_cluster",
         "final_cluster_snapshot_identifier": None,
         "skip_final_cluster_snapshot": True,
+        "cluster_status_fetch_interval_seconds": 10,
     }
 
 
@@ -189,6 +191,7 @@ def test_redshift_pause_resume_trigger_serialization():
         "operation_type": "pause_cluster",
         "final_cluster_snapshot_identifier": None,
         "skip_final_cluster_snapshot": True,
+        "cluster_status_fetch_interval_seconds": 10,
     }
 
 

--- a/tests/amazon/aws/triggers/test_redshift_cluster.py
+++ b/tests/amazon/aws/triggers/test_redshift_cluster.py
@@ -13,6 +13,83 @@ TASK_ID = "redshift_trigger_check"
 POLLING_PERIOD_SECONDS = 1.0
 
 
+def test_redshift_cluster_delete_trigger_serialization():
+    """
+    Asserts that the RedshiftClusterTrigger correctly serializes its arguments
+    and classpath for delete cluster operation.
+    """
+    trigger = RedshiftClusterTrigger(
+        task_id=TASK_ID,
+        polling_period_seconds=POLLING_PERIOD_SECONDS,
+        aws_conn_id="test_redshift_conn_id",
+        cluster_identifier="mock_cluster_identifier",
+        operation_type="delete_cluster",
+    )
+    classpath, kwargs = trigger.serialize()
+    assert classpath == "astronomer.providers.amazon.aws.triggers.redshift_cluster.RedshiftClusterTrigger"
+    assert kwargs == {
+        "task_id": TASK_ID,
+        "polling_period_seconds": POLLING_PERIOD_SECONDS,
+        "aws_conn_id": "test_redshift_conn_id",
+        "cluster_identifier": "mock_cluster_identifier",
+        "operation_type": "delete_cluster",
+        "final_cluster_snapshot_identifier": None,
+        "skip_final_cluster_snapshot": True,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "operation_type,return_value,response",
+    [
+        (
+            "delete_cluster",
+            {"status": "error", "message": "test error"},
+            TriggerEvent({"status": "error", "message": "test error"}),
+        ),
+        (
+            "delete_cluster",
+            {"status": "success", "cluster_state": "cluster_not_found"},
+            TriggerEvent({"status": "success", "cluster_state": "cluster_not_found"}),
+        ),
+        ("delete_cluster", None, TriggerEvent({"status": "error", "message": f"{TASK_ID} failed"})),
+    ],
+)
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_cluster.RedshiftHookAsync.delete_cluster")
+async def test_redshift_cluster_delete_trigger_run(
+    mock_delete_cluster, operation_type, return_value, response
+):
+    """Test RedshiftClusterTrigger delete cluster with success"""
+    mock_delete_cluster.return_value = return_value
+    trigger = RedshiftClusterTrigger(
+        task_id=TASK_ID,
+        polling_period_seconds=POLLING_PERIOD_SECONDS,
+        aws_conn_id="test_redshift_conn_id",
+        cluster_identifier="mock_cluster_identifier",
+        operation_type=operation_type,
+    )
+    generator = trigger.run()
+    actual = await generator.asend(None)
+    assert response == actual
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_cluster.RedshiftHookAsync.delete_cluster")
+async def test_redshift_cluster_delete_trigger_failure(mock_delete_cluster):
+    """Test RedshiftClusterTrigger delete cluster with failure status"""
+    mock_delete_cluster.side_effect = Exception("Test exception")
+    trigger = RedshiftClusterTrigger(
+        task_id=TASK_ID,
+        polling_period_seconds=POLLING_PERIOD_SECONDS,
+        aws_conn_id="test_redshift_conn_id",
+        cluster_identifier="mock_cluster_identifier",
+        operation_type="delete_cluster",
+    )
+    task = [i async for i in trigger.run()]
+    assert len(task) == 1
+    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+
+
 def test_redshift_cluster_resume_trigger_serialization():
     """
     Asserts that the RedshiftClusterTrigger correctly serializes its arguments


### PR DESCRIPTION
The PR addresses the following:
- Implements necessary operator, trigger, hook changes to allow  async deletion of a Redshift cluster.
- Uses this new operator `RedshiftPauseClusterOperatorAsync` in the example DAG.
- Fixes existing tests that fail due to method signature change.
- Add a make target to build images with `aws-cli` installed required for local testing of AWS example DAGs

closes: #403 