### PR TITLE
Handle dataproc create cluster error gracefully

### DIFF
--- a/tests/google/cloud/triggers/test_dataproc.py
+++ b/tests/google/cloud/triggers/test_dataproc.py
@@ -3,6 +3,7 @@ import time
 from unittest import mock
 
 import pytest
+from airflow.exceptions import AirflowException
 from airflow.triggers.base import TriggerEvent
 from google.api_core.exceptions import NotFound
 from google.cloud import dataproc
@@ -170,6 +171,9 @@ def test_dataproc_create_cluster_trigger_serialization():
         "cluster_name": "test_cluster",
         "gcp_conn_id": TEST_GCP_CONN_ID,
         "polling_interval": TEST_POLLING_INTERVAL,
+        "delete_on_error": True,
+        "labels": None,
+        "cluster_config": None,
         "end_time": 100,
         "metadata": (),
     }
@@ -262,6 +266,189 @@ async def test_run_timeout():
     assert actual == TriggerEvent({"status": "error", "message": "Timeout"})
 
 
+@mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocHook.create_cluster")
+def test__create_cluster(mock_create_cluster):
+    trigger = DataprocCreateClusterTrigger(
+        project_id=TEST_PROJECT_ID,
+        region=TEST_REGION,
+        cluster_name=TEST_CLUSTER_NAME,
+        polling_interval=TEST_POLLING_INTERVAL,
+        end_time=time.monotonic() - 100,
+        metadata=(),
+    )
+    trigger._create_cluster()
+
+    mock_create_cluster.assert_called_once_with(
+        region=TEST_REGION,
+        project_id=TEST_PROJECT_ID,
+        cluster_name=TEST_CLUSTER_NAME,
+        cluster_config=None,
+        labels=None,
+        metadata=(),
+    )
+
+
+@mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocHook.diagnose_cluster")
+def test__diagnose_cluster(mock_diagnose_cluster):
+    """Assert diagnose_cluster call with correct param"""
+    trigger = DataprocCreateClusterTrigger(
+        project_id=TEST_PROJECT_ID,
+        region=TEST_REGION,
+        cluster_name=TEST_CLUSTER_NAME,
+        polling_interval=TEST_POLLING_INTERVAL,
+        end_time=time.monotonic() - 100,
+        metadata=(),
+    )
+    trigger._diagnose_cluster()
+
+    mock_diagnose_cluster.assert_called_once_with(
+        region=TEST_REGION,
+        project_id=TEST_PROJECT_ID,
+        cluster_name=TEST_CLUSTER_NAME,
+        metadata=(),
+    )
+
+
+@mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocHook.delete_cluster")
+def test__delete_cluster(mock_delete_cluster):
+    """Assert delete_cluster call with correct param"""
+    trigger = DataprocCreateClusterTrigger(
+        project_id=TEST_PROJECT_ID,
+        region=TEST_REGION,
+        cluster_name=TEST_CLUSTER_NAME,
+        polling_interval=TEST_POLLING_INTERVAL,
+        end_time=time.monotonic() - 100,
+        metadata=(),
+    )
+    trigger._delete_cluster()
+
+    mock_delete_cluster.assert_called_once_with(
+        region=TEST_REGION,
+        project_id=TEST_PROJECT_ID,
+        cluster_name=TEST_CLUSTER_NAME,
+        metadata=(),
+    )
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._get_cluster")
+async def test__wait_for_deleting(mock_get_cluster):
+    """Assert that _wait_for_deleting wait if cluster status is deleting"""
+    mock_get_cluster.return_value = Cluster(
+        cluster_name="test_cluster",
+        status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.DELETING),
+    )
+
+    trigger = DataprocCreateClusterTrigger(
+        project_id=TEST_PROJECT_ID,
+        region=TEST_REGION,
+        cluster_name="test_cluster",
+        polling_interval=TEST_POLLING_INTERVAL,
+        end_time=time.monotonic() + 100,
+        metadata=(),
+    )
+
+    task = asyncio.create_task(trigger._wait_for_deleting())
+    await asyncio.sleep(0.5)
+
+    # TriggerEvent was not returned
+    assert task.done() is False
+    asyncio.get_event_loop().stop()
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._get_cluster")
+async def test_wait_for_deleting_success(mock__get_cluster):
+    """Assert that _wait_for_deleting return success if cluster not found exception raise by get_cluster"""
+    mock__get_cluster.side_effect = NotFound("Cluster deleted")
+    trigger = DataprocCreateClusterTrigger(
+        project_id=TEST_PROJECT_ID,
+        region=TEST_REGION,
+        cluster_name="test_cluster",
+        polling_interval=TEST_POLLING_INTERVAL,
+        end_time=time.monotonic() + 100,
+        metadata=(),
+    )
+    assert await trigger._wait_for_deleting() is None
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._get_cluster")
+async def test_wait_for_deleting_exception(mock__get_cluster):
+    """Assert that _wait_for_deleting return raise exception when get_cluster raise exception"""
+    mock__get_cluster.side_effect = Exception("Error occur while deleting")
+    trigger = DataprocCreateClusterTrigger(
+        project_id=TEST_PROJECT_ID,
+        region=TEST_REGION,
+        cluster_name="test_cluster",
+        polling_interval=TEST_POLLING_INTERVAL,
+        end_time=time.monotonic() + 100,
+        metadata=(),
+    )
+    with pytest.raises(Exception):
+        await trigger._wait_for_deleting()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "delete_on_error",
+    [
+        True,
+        False,
+    ],
+)
+@mock.patch(
+    "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._delete_cluster"
+)
+@mock.patch(
+    "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._wait_for_deleting"
+)
+@mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocHook.diagnose_cluster")
+async def test__handle_error(
+    mock_diagnose_cluster, mock_wait_for_deleting, mock_delete_cluster, delete_on_error
+):
+    """Assert that _handle_error raise exception correctly in case of error"""
+    mock_diagnose_cluster.return_value = {}
+    mock_delete_cluster.return_value = {}
+    mock_wait_for_deleting.return_value = {}
+    cluster = Cluster(
+        cluster_name="test_cluster",
+        status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.ERROR),
+    )
+
+    trigger = DataprocCreateClusterTrigger(
+        project_id=TEST_PROJECT_ID,
+        region=TEST_REGION,
+        cluster_name="test_cluster",
+        polling_interval=TEST_POLLING_INTERVAL,
+        end_time=time.monotonic() + 100,
+        metadata=(),
+        delete_on_error=delete_on_error,
+    )
+    with pytest.raises(AirflowException):
+        await trigger._handle_error(cluster=cluster)
+
+
+@pytest.mark.asyncio
+async def test__handle_error_with_no_error():
+    """Assert that _handle_error return success when no error"""
+    cluster = Cluster(
+        cluster_name="test_cluster",
+        status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.DELETING),
+    )
+
+    trigger = DataprocCreateClusterTrigger(
+        project_id=TEST_PROJECT_ID,
+        region=TEST_REGION,
+        cluster_name="test_cluster",
+        polling_interval=TEST_POLLING_INTERVAL,
+        end_time=time.monotonic() + 100,
+        metadata=(),
+    )
+
+    assert await trigger._handle_error(cluster=cluster) is None
+
+
 def test_dataproc_delete_cluster_trigger_serialization():
     """
     asserts that the DataprocDeleteClusterTrigger correctly serializes its arguments
@@ -351,6 +538,45 @@ async def test_delete_run_exception(mock_get_cluster):
     generator = trigger.run()
     actual = await generator.asend(None)
     assert actual == TriggerEvent({"status": "error", "message": "Cluster deletion fail"})
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._handle_error")
+@mock.patch(
+    "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._create_cluster"
+)
+@mock.patch(
+    "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._wait_for_deleting"
+)
+@mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
+async def test_run_deleting(mock_get_cluster, mock_wait_for_deleting, mock_create_cluster, mock_handle_error):
+    """
+    assert that run method call
+    1. _wait_for_deleting correctly
+    2. _create_cluster
+    3. _handle_error
+    methods correctly when cluster status is deleting
+    """
+    cluster = Cluster(
+        cluster_name="test_cluster",
+        status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.DELETING),
+    )
+    mock_get_cluster.return_value = cluster
+
+    trigger = DataprocCreateClusterTrigger(
+        project_id=TEST_PROJECT_ID,
+        region=TEST_REGION,
+        cluster_name="test_cluster",
+        polling_interval=TEST_POLLING_INTERVAL,
+        end_time=time.monotonic() + 100,
+        metadata=(),
+    )
+    asyncio.create_task(trigger.run().__anext__())
+    await asyncio.sleep(0.5)
+    mock_wait_for_deleting.assert_called_once_with()
+    mock_create_cluster.assert_called_once_with()
+    mock_handle_error.assert_called_once_with(cluster)
+    asyncio.get_event_loop().stop()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
closes: #424 
This PR handle below scenario for the DataprocCreateClusterOperatorAsync
- when clusters already exist and the use_if_exists param set true then use the existing cluster 
- when clusters already exist and use_if_exists param set false then raise an error
-  when the cluster is in deleting state, wait for the cluster to delete and create a new one
- when an error occurs and the delete_on_error param is set to true delete the cluster 
- in case of error exception will have diagnose_cluster API response 

The above behaviours were missing in async in my prev implemention