### PR TITLE
Implement RedshiftDataOperatorAsync

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -94,6 +94,7 @@ with DAG(
     amazon_task_info = [
         {"s3_sensor_dag": "example_s3_sensor"},
         {"redshift_sql_dag": "example_async_redshift_sql"},
+        {"redshift_data_dag": "example_async_redshift_data"},
         {"redshift_cluster_mgmt_dag": "example_async_redshift_cluster_management"},
         {"batch_dag": "example_async_batch"},
     ]

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ docs:  ## Build the docs using Sphinx
 	cd docs && make clean html && cd .. && echo "Documentation built in $(shell pwd)/docs/_build/html/index.html"
 
 restart: ## Restart Triggerer & Scheduler container
-	docker-compose -f dev/docker-compose.yaml restart airflow-triggerer airflow-scheduler
+	docker-compose -f dev/docker-compose.yaml restart airflow-triggerer airflow-scheduler airflow-worker
 
 restart-all: ## Restart all the containers
 	docker-compose -f dev/docker-compose.yaml restart

--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_data.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_data.py
@@ -1,0 +1,219 @@
+import logging
+import os
+import time
+from datetime import datetime, timedelta
+
+from airflow.models.dag import DAG
+from airflow.operators.bash import BashOperator
+from airflow.operators.empty import EmptyOperator
+from airflow.operators.python import PythonOperator
+
+from astronomer.providers.amazon.aws.operators.redshift_cluster import (
+    RedshiftDeleteClusterOperatorAsync,
+)
+from astronomer.providers.amazon.aws.operators.redshift_data import (
+    RedshiftDataOperatorAsync,
+)
+
+AWS_CONN_ID = os.getenv("ASTRO_AWS_CONN_ID", "aws_default")
+AWS_DEFAULT_REGION = os.getenv("AWS_DEFAULT_REGION", "us-east-2")
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "**********")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "***********")
+EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
+REDSHIFT_CLUSTER_DB_NAME = os.getenv("REDSHIFT_CLUSTER_DB_NAME", "astro_dev")
+REDSHIFT_CLUSTER_IDENTIFIER = os.getenv("REDSHIFT_CLUSTER_IDENTIFIER", "astro-providers-cluster")
+REDSHIFT_CLUSTER_MASTER_USER = os.getenv("REDSHIFT_CLUSTER_MASTER_USER", "awsuser")
+REDSHIFT_CLUSTER_MASTER_PASSWORD = os.getenv("REDSHIFT_CLUSTER_MASTER_PASSWORD", "********")
+REDSHIFT_CLUSTER_NODE_TYPE = os.getenv("REDSHIFT_CLUSTER_NODE_TYPE", "dc2.large")
+REDSHIFT_CLUSTER_TYPE = os.getenv("REDSHIFT_CLUSTER_TYPE", "single-node")
+
+
+default_args = {
+    "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
+}
+
+
+def get_cluster_status() -> str:
+    """Get the status of aws redshift cluster"""
+    import boto3
+
+    client = boto3.client("redshift")
+
+    response = client.describe_clusters(
+        ClusterIdentifier=REDSHIFT_CLUSTER_IDENTIFIER,
+    )
+    logging.info("%s", response)
+    cluster = response.get("Clusters")[0]
+    cluster_status: str = cluster.get("ClusterStatus")
+    return cluster_status
+
+
+def create_redshift_cluster_callable() -> None:
+    """Creates an AWS Redshift cluster and waits until it is available."""
+    import boto3
+
+    client = boto3.client("redshift")
+
+    client.create_cluster(
+        DBName=REDSHIFT_CLUSTER_DB_NAME,
+        ClusterIdentifier=REDSHIFT_CLUSTER_IDENTIFIER,
+        ClusterType=REDSHIFT_CLUSTER_TYPE,
+        NodeType=REDSHIFT_CLUSTER_NODE_TYPE,
+        MasterUsername=REDSHIFT_CLUSTER_MASTER_USER,
+        MasterUserPassword=REDSHIFT_CLUSTER_MASTER_PASSWORD,
+        Tags=[
+            {"Key": "Purpose", "Value": "ProviderTest"},
+        ],
+    )
+
+    while get_cluster_status() != "available":
+        logging.info("Waiting for cluster to be available. Sleeping for 30 seconds.")
+        time.sleep(30)
+
+
+with DAG(
+    dag_id="example_async_redshift_data",
+    start_date=datetime(2022, 1, 1),
+    schedule_interval=None,
+    catchup=False,
+    default_args=default_args,
+    tags=["example", "async", "redshift"],
+) as dag:
+
+    config = BashOperator(
+        task_id="aws_config",
+        bash_command=f"aws configure set aws_access_key_id {AWS_ACCESS_KEY_ID}; "
+        f"aws configure set aws_secret_access_key {AWS_SECRET_ACCESS_KEY}; "
+        f"aws configure set default.region {AWS_DEFAULT_REGION}; ",
+    )
+
+    create_redshift_cluster = PythonOperator(
+        task_id="create_redshift_cluster",
+        python_callable=create_redshift_cluster_callable,
+    )
+
+    # [START howto_operator_redshift_data_operator_async]
+    task_create_func = RedshiftDataOperatorAsync(
+        task_id="task_create_func",
+        sql="""
+            create or replace procedure just_a_loop() as $$
+            declare
+                CurrId INTEGER := 0;
+                MaxId INTEGER := 500000;
+            begin
+                while CurrId <= MaxId
+                LOOP
+                    CurrId = CurrId + 1;
+                end LOOP;
+            end;
+            $$ language plpgsql;
+            """,
+        cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
+        db_user=REDSHIFT_CLUSTER_MASTER_USER,
+        aws_conn_id=AWS_CONN_ID,
+        database=REDSHIFT_CLUSTER_DB_NAME,
+        region=AWS_DEFAULT_REGION,
+    )
+    # [END howto_operator_redshift_data_operator_async]
+
+    task_long_running_query = RedshiftDataOperatorAsync(
+        task_id="task_long_running_query",
+        sql="CALL just_a_loop();",
+        cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
+        db_user=REDSHIFT_CLUSTER_MASTER_USER,
+        aws_conn_id=AWS_CONN_ID,
+        database=REDSHIFT_CLUSTER_DB_NAME,
+        region=AWS_DEFAULT_REGION,
+    )
+
+    task_create_table = RedshiftDataOperatorAsync(
+        task_id="task_create_table",
+        sql="""
+            CREATE TABLE IF NOT EXISTS fruit (
+            fruit_id INTEGER,
+            name VARCHAR NOT NULL,
+            color VARCHAR NOT NULL
+            );
+        """,
+        cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
+        db_user=REDSHIFT_CLUSTER_MASTER_USER,
+        aws_conn_id=AWS_CONN_ID,
+        database=REDSHIFT_CLUSTER_DB_NAME,
+        region=AWS_DEFAULT_REGION,
+    )
+
+    task_insert_data = RedshiftDataOperatorAsync(
+        task_id="task_insert_data",
+        sql=[
+            "INSERT INTO fruit VALUES ( 1, 'Banana', 'Yellow');",
+            "INSERT INTO fruit VALUES ( 2, 'Apple', 'Red');",
+            "INSERT INTO fruit VALUES ( 3, 'Lemon', 'Yellow');",
+            "INSERT INTO fruit VALUES ( 4, 'Grape', 'Purple');",
+            "INSERT INTO fruit VALUES ( 5, 'Pear', 'Green');",
+            "INSERT INTO fruit VALUES ( 6, 'Strawberry', 'Red');",
+        ],
+        cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
+        db_user=REDSHIFT_CLUSTER_MASTER_USER,
+        aws_conn_id=AWS_CONN_ID,
+        database=REDSHIFT_CLUSTER_DB_NAME,
+        region=AWS_DEFAULT_REGION,
+    )
+
+    task_get_all_data = RedshiftDataOperatorAsync(
+        task_id="task_get_all_data",
+        sql="SELECT * FROM fruit;",
+        cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
+        db_user=REDSHIFT_CLUSTER_MASTER_USER,
+        aws_conn_id=AWS_CONN_ID,
+        database=REDSHIFT_CLUSTER_DB_NAME,
+        region=AWS_DEFAULT_REGION,
+    )
+
+    task_get_data_with_filter = RedshiftDataOperatorAsync(
+        task_id="task_get_data_with_filter",
+        sql="SELECT * FROM fruit WHERE color = '{{ params.color }}';",
+        params={"color": "Red"},
+        cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
+        db_user=REDSHIFT_CLUSTER_MASTER_USER,
+        aws_conn_id=AWS_CONN_ID,
+        database=REDSHIFT_CLUSTER_DB_NAME,
+        region=AWS_DEFAULT_REGION,
+    )
+
+    task_delete_table = RedshiftDataOperatorAsync(
+        task_id="task_delete_table",
+        sql="drop table fruit;",
+        cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
+        db_user=REDSHIFT_CLUSTER_MASTER_USER,
+        aws_conn_id=AWS_CONN_ID,
+        database=REDSHIFT_CLUSTER_DB_NAME,
+        region=AWS_DEFAULT_REGION,
+    )
+
+    delete_redshift_cluster = RedshiftDeleteClusterOperatorAsync(
+        task_id="delete_redshift_cluster",
+        trigger_rule="all_done",
+        cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
+        aws_conn_id=AWS_CONN_ID,
+        skip_final_cluster_snapshot=True,
+        final_cluster_snapshot_identifier=None,
+    )
+
+    end = EmptyOperator(task_id="end")
+
+    (
+        config
+        >> create_redshift_cluster
+        >> task_create_func
+        >> task_long_running_query
+        >> task_create_table
+        >> task_insert_data
+        >> task_get_all_data
+        >> task_get_data_with_filter
+        >> task_delete_table
+        >> delete_redshift_cluster
+    )
+
+    [task_delete_table, delete_redshift_cluster] >> end

--- a/astronomer/providers/amazon/aws/operators/redshift_data.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_data.py
@@ -1,0 +1,70 @@
+from typing import Any, Dict, cast
+
+from airflow.exceptions import AirflowException
+from airflow.providers.amazon.aws.operators.redshift_data import RedshiftDataOperator
+from airflow.utils.context import Context
+
+from astronomer.providers.amazon.aws.hooks.redshift_data import RedshiftDataHook
+from astronomer.providers.amazon.aws.triggers.redshift_data import RedshiftDataTrigger
+
+
+class RedshiftDataOperatorAsync(RedshiftDataOperator):
+    """
+    Executes SQL Statements against an Amazon Redshift cluster.
+
+    :param sql: the SQL code to be executed as a single string, or
+        a list of str (sql statements), or a reference to a template file.
+        Template references are recognized by str ending in '.sql'
+    :param aws_conn_id: AWS connection ID
+    :param parameters: (optional) the parameters to render the SQL query with.
+    :param autocommit: if True, each command is automatically committed.
+        (default value: False)
+    """
+
+    def __init__(
+        self,
+        *,
+        poll_interval: float = 5,
+        **kwargs: Any,
+    ) -> None:
+        self.poll_interval = poll_interval
+        super().__init__(**kwargs)
+
+    def execute(self, context: "Context") -> None:
+        """
+        Makes a sync call to RedshiftDataHook, executes the query and gets back the list of query_ids and
+        defers trigger to poll for the status for the queries executed.
+        """
+        redshift_data_hook = RedshiftDataHook(aws_conn_id=self.aws_conn_id)
+        query_ids, response = redshift_data_hook.execute_query(sql=cast(str, self.sql), params=self.params)
+        self.log.info("Query IDs %s", query_ids)
+        if response.get("status") == "error":
+            self.execute_complete({}, response)
+            return
+        self.defer(
+            timeout=self.execution_timeout,
+            trigger=RedshiftDataTrigger(
+                task_id=self.task_id,
+                polling_period_seconds=self.poll_interval,
+                aws_conn_id=self.aws_conn_id,
+                query_ids=query_ids,
+            ),
+            method_name="execute_complete",
+        )
+
+    def execute_complete(self, context: Dict[str, Any], event: Any = None) -> None:
+        """
+        Callback for when the trigger fires - returns immediately.
+        Relies on trigger to throw an exception, otherwise it assumes execution was
+        successful.
+        """
+        if event:
+            if "status" in event and event["status"] == "error":
+                msg = "{0}".format(event["message"])
+                raise AirflowException(msg)
+            elif "status" in event and event["status"] == "success":
+                self.log.info("%s completed successfully.", self.task_id)
+                return None
+        else:
+            self.log.info("%s completed successfully.", self.task_id)
+            return None

--- a/astronomer/providers/amazon/aws/triggers/redshift_data.py
+++ b/astronomer/providers/amazon/aws/triggers/redshift_data.py
@@ -1,0 +1,54 @@
+from typing import Any, AsyncIterator, Dict, List, Tuple
+
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+from astronomer.providers.amazon.aws.hooks.redshift_data import RedshiftDataHook
+
+
+class RedshiftDataTrigger(BaseTrigger):
+    """
+    RedshiftDataTrigger is fired as deferred class with params to run the task in triggerer.
+
+    :param task_id: task ID of the Dag
+    :param polling_period_seconds:  polling period in seconds to check for the status
+    :param aws_conn_id: AWS connection ID for redshift
+    :param query_ids: list of query IDs to run and poll for the status
+    """
+
+    def __init__(
+        self,
+        task_id: str,
+        polling_period_seconds: float,
+        aws_conn_id: str,
+        query_ids: List[str],
+    ):
+        super().__init__()
+        self.task_id = task_id
+        self.polling_period_seconds = polling_period_seconds
+        self.aws_conn_id = aws_conn_id
+        self.query_ids = query_ids
+
+    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+        """Serializes RedshiftDataTrigger arguments and classpath."""
+        return (
+            "astronomer.providers.amazon.aws.triggers.redshift_data.RedshiftDataTrigger",
+            {
+                "task_id": self.task_id,
+                "polling_period_seconds": self.polling_period_seconds,
+                "aws_conn_id": self.aws_conn_id,
+                "query_ids": self.query_ids,
+            },
+        )
+
+    async def run(self) -> AsyncIterator["TriggerEvent"]:  # type: ignore[override]
+        """Make async connection and execute query using the Amazon Redshift Data API."""
+        hook = RedshiftDataHook(aws_conn_id=self.aws_conn_id)
+        try:
+            response = await hook.get_query_status(self.query_ids)
+            if response:
+                yield TriggerEvent(response)
+            else:
+                error_message = f"{self.task_id} failed"
+                yield TriggerEvent({"status": "error", "message": error_message})
+        except Exception as e:
+            yield TriggerEvent({"status": "error", "message": str(e)})


### PR DESCRIPTION
The PR adds the following implementation
- Operator, Trigger and Hook changes for the async version of RedshiftDataOperator
- Creates an example DAG to test the RedshiftDataOperatorAsync and adds the 
   example DAG to master_dag so it runs as part of the integration test suite.
- Restart the airflow worker component too as part of the `make restart` target
- Unit tests covering the implementation

closes: #463 

WIP: Unit tests 