### PR TITLE
Fix BigQueryInsertJobOperatorAsync failure after the google provider upgrade

### DIFF
--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -86,7 +86,14 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
         hook = _BigQueryHook(gcp_conn_id=self.gcp_conn_id)
 
         self.hook = hook
-        job_id = self._job_id(context)
+        job_id = self.hook.generate_job_id(
+            job_id=self.job_id,
+            dag_id=self.dag_id,
+            task_id=self.task_id,
+            logical_date=context["logical_date"],
+            configuration=self.configuration,
+            force_rerun=self.force_rerun,
+        )
 
         try:
             job = self._submit_job(hook, job_id)

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -86,7 +86,7 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
         hook = _BigQueryHook(gcp_conn_id=self.gcp_conn_id)
 
         self.hook = hook
-        job_id = self.hook.generate_job_id(  # type: ignore[attr-defined]
+        job_id = self.hook.generate_job_id(
             job_id=self.job_id,
             dag_id=self.dag_id,
             task_id=self.task_id,

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -93,7 +93,7 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
             logical_date=context["logical_date"],
             configuration=self.configuration,
             force_rerun=self.force_rerun,
-        )
+        )  # type: ignore[attr-defined]
 
         try:
             job = self._submit_job(hook, job_id)

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -86,14 +86,14 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
         hook = _BigQueryHook(gcp_conn_id=self.gcp_conn_id)
 
         self.hook = hook
-        job_id = self.hook.generate_job_id(
+        job_id = self.hook.generate_job_id(  # type: ignore[attr-defined]
             job_id=self.job_id,
             dag_id=self.dag_id,
             task_id=self.task_id,
             logical_date=context["logical_date"],
             configuration=self.configuration,
             force_rerun=self.force_rerun,
-        )  # type: ignore[attr-defined]
+        )
 
         try:
             job = self._submit_job(hook, job_id)

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ cncf.kubernetes =
 databricks =
     apache-airflow-providers-databricks>=2.2.0
 google =
-    apache-airflow-providers-google>=8.0.0
+    apache-airflow-providers-google>=8.1.0
     gcloud-aio-storage
     gcloud-aio-bigquery
 snowflake =
@@ -117,7 +117,7 @@ all =
     apache-airflow-providers-amazon>=3.0.0
     apache-airflow-providers-cncf-kubernetes>=4
     apache-airflow-providers-databricks>=2.2.0
-    apache-airflow-providers-google>=8.0.0
+    apache-airflow-providers-google>=8.1.0
     apache-airflow-providers-apache-livy
     apache-airflow-providers-apache-hive
     apache-airflow-providers-snowflake

--- a/tests/google/cloud/extractors/test_bigquery_async_extractor.py
+++ b/tests/google/cloud/extractors/test_bigquery_async_extractor.py
@@ -75,11 +75,11 @@ def context():
 
 def create_context(task):
     dag = DAG(dag_id="dag")
-    execution_date = datetime(2022, 1, 1, 0, 0, 0)
+    logical_date = datetime(2022, 1, 1, 0, 0, 0)
     dag_run = DagRun(
         dag_id=dag.dag_id,
-        execution_date=execution_date,
-        run_id=DagRun.generate_run_id(DagRunType.MANUAL, execution_date),
+        execution_date=logical_date,
+        run_id=DagRun.generate_run_id(DagRunType.MANUAL, logical_date),
     )
     task_instance = TaskInstance(task=task)
     task_instance.dag_run = dag_run
@@ -91,6 +91,7 @@ def create_context(task):
         "task": task,
         "ti": task_instance,
         "task_instance": task_instance,
+        "logical_date": logical_date,
     }
 
 

--- a/tests/google/cloud/operators/test_bigquery.py
+++ b/tests/google/cloud/operators/test_bigquery.py
@@ -220,7 +220,7 @@ def test_execute_force_rerun(mock_hook):
     )
 
     with pytest.raises(AirflowException) as exc:
-        op.execute(context)
+        op.execute(create_context(op))
 
     expected_exception_msg = (
         f"Job with id: {real_job_id} already exists and is in {job.state} state. "

--- a/tests/google/cloud/operators/test_bigquery.py
+++ b/tests/google/cloud/operators/test_bigquery.py
@@ -148,7 +148,6 @@ def test_execute_reattach(mock_hook):
     job_id = "123456"
     hash_ = "hash"
     real_job_id = f"{job_id}_{hash_}"
-    # mock_md5.return_value = job_id
     mock_hook.return_value.generate_job_id.return_value = f"{job_id}_{hash_}"
 
     configuration = {


### PR DESCRIPTION
- Sync version has changed and removed _job_id in operator which was used in our repo,
- Code has been moved to hooks with certain changes.
- Implement the code change needed for it in our repo

closes #470 