### PR TITLE
Disable GKEStartPod Integration Test

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -119,7 +119,9 @@ with DAG(
         {"gcs_sensor_dag": "example_async_gcs_sensors"},
         {"big_query_sensor_dag": "example_bigquery_sensors"},
         {"dataproc_dag": "example_gcp_dataproc"},
-        {"kubernetes_engine_dag": "example_google_kubernetes_engine"},
+        # GkeStartPod operator do not work on astro-cloud
+        # https://github.com/astronomer/astronomer-providers/issues/443
+        # {"kubernetes_engine_dag": "example_google_kubernetes_engine"},
     ]
     google_trigger_tasks, ids = prepare_dag_dependency(google_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ build-emr_eks_container_example_dag-image: ## Build the Docker image for EMR EKS
 build-aws: ## Build the Docker image with aws-cli installed
 	docker build -f dev/Dockerfile.aws . -t astronomer-providers-dev:latest
 
+build-google-cloud: ## Build the Docker image with aws-cli installed
+	docker build -f dev/Dockerfile.google_cloud . -t astronomer-providers-dev:latest
+
 build-run: ## Build the Docker Image & then run the containers
 	docker-compose -f dev/docker-compose.yaml up --build -d
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ build-emr_eks_container_example_dag-image: ## Build the Docker image for EMR EKS
 build-aws: ## Build the Docker image with aws-cli installed
 	docker build -f dev/Dockerfile.aws . -t astronomer-providers-dev:latest
 
-build-google-cloud: ## Build the Docker image with aws-cli installed
+build-google-cloud: ## Build the Docker image with google-cloud cli installed
 	docker build -f dev/Dockerfile.google_cloud . -t astronomer-providers-dev:latest
 
 build-run: ## Build the Docker Image & then run the containers

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -12,13 +12,6 @@ RUN apt-get install -y --no-install-recommends \
 COPY setup.cfg ${AIRFLOW_HOME}/astronomer_providers/setup.cfg
 COPY pyproject.toml ${AIRFLOW_HOME}/astronomer_providers/pyproject.toml
 
-RUN apt-get update && \
-    apt-get install -y curl gnupg && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
-    apt-get update -y && \
-    apt-get install google-cloud-sdk -y
-
 
 RUN pip install -e "${AIRFLOW_HOME}/astronomer_providers[all,tests,mypy]"
 USER astro

--- a/dev/Dockerfile.google_cloud
+++ b/dev/Dockerfile.google_cloud
@@ -1,0 +1,22 @@
+ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.4-base"
+FROM ${IMAGE_NAME}
+
+USER root
+RUN apt-get update -y && apt-get install -y git
+RUN apt-get install -y --no-install-recommends \
+        build-essential \
+        libsasl2-2 \
+        libsasl2-dev \
+        libsasl2-modules \
+        unzip && \
+        apt-get install -y curl gnupg && \
+        echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+        curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
+        apt-get update -y && \
+        apt-get install google-cloud-sdk -y
+
+COPY setup.cfg ${AIRFLOW_HOME}/astronomer_providers/setup.cfg
+COPY pyproject.toml ${AIRFLOW_HOME}/astronomer_providers/pyproject.toml
+
+RUN pip install -e "${AIRFLOW_HOME}/astronomer_providers[all]"
+USER astro


### PR DESCRIPTION
Look like GKEStartPodOpetror both sync and async do not work on astro-cloud tested both on astro-cloud posted log on git issue

- Disable GKEStartPod in the integration test
- Remove google cloud installation steps from the dev docker file since it was slowing down the dev build 
- Create dev/Dockerfile.google_cloud and add build-google-cloud in the makefile to install google-cloud cli in the image

Issue: https://github.com/astronomer/astronomer-providers/issues/443