### PR TITLE
Implement Async Snowflake SQL API Operator

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -160,7 +160,10 @@ with DAG(
     chain(*http_trigger_tasks)
 
     # Snowflake DAG
-    snowflake_task_info = [{"snowflake_dag": "example_snowflake"}]
+    snowflake_task_info = [
+        {"snowflake_dag": "example_snowflake"},
+        {"snowflake_sql_api_dag": "example_snowflake_sql_api"},
+    ]
     snowflake_trigger_tasks, ids = prepare_dag_dependency(snowflake_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)
     chain(*snowflake_trigger_tasks)

--- a/astronomer/providers/snowflake/example_dags/example_snowflake_sql_api.py
+++ b/astronomer/providers/snowflake/example_dags/example_snowflake_sql_api.py
@@ -1,0 +1,49 @@
+"""Example use of SnowflakeSqlApiAsync operator."""
+
+import os
+from datetime import timedelta
+
+from airflow import DAG
+from airflow.utils.timezone import datetime
+
+from astronomer.providers.snowflake.operators.snowflake import (
+    SnowflakeSqlApiOperatorAsync,
+)
+
+SNOWFLAKE_CONN_ID = os.getenv("ASTRO_SNOWFLAKE_CONN_ID", "snowflake_api_default")
+EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
+
+
+default_args = {
+    "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "snowflake_conn_id": SNOWFLAKE_CONN_ID,
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
+}
+
+with DAG(
+    dag_id="example_snowflake_sql_api",
+    start_date=datetime(2022, 1, 1),
+    schedule_interval=None,
+    default_args=default_args,
+    tags=["example", "async", "snowflake"],
+    catchup=False,
+) as dag:
+    # [START howto_operator_snowflake_sql_api_async]
+    snowflake_op_sql_multiple_stmt = SnowflakeSqlApiOperatorAsync(
+        task_id="snowflake_op_sql_multiple_stmt",
+        sql="create or replace table user_test (i int); insert into user_test (i) "
+        "values (200); insert into user_test (i) values (300); select i from user_test order by i;",
+        statement_count=4,
+    )
+    # [END howto_operator_snowflake_sql_api_async]
+
+    # [START howto_operator_snowflake_single_sql_stmt]
+    snowflake_single_sql_stmt = SnowflakeSqlApiOperatorAsync(
+        task_id="snowflake_single_sql_stmt",
+        sql="select i from user_test order by i;",
+        statement_count=1,
+    )
+    # [END howto_operator_snowflake_single_sql_stmt]
+
+    (snowflake_op_sql_multiple_stmt >> snowflake_single_sql_stmt)

--- a/astronomer/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/astronomer/providers/snowflake/hooks/snowflake_sql_api.py
@@ -1,0 +1,240 @@
+import uuid
+from abc import ABC
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import aiohttp
+import requests
+from airflow import AirflowException
+from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+
+from astronomer.providers.snowflake.hooks.sql_api_generate_jwt import JWTGenerator
+
+
+class SnowflakeSqlApiHookAsync(SnowflakeHook, ABC):
+    """
+    A client to interact with Snowflake using SQL API  and allows submitting
+    multiple SQL statements in a single request. In combination with aiohttp, make post request to submit SQL
+    statements for execution, poll to check the status of the execution of a statement. Fetch query results
+    asynchronously.
+
+    This hook requires the snowflake_conn_id connection. This hooks mainly uses account, schema, database, warehouse,
+    private_key_file or private_key_content field must be setup in the connection.
+    Other inputs can be defined in the connection or hook instantiation.
+
+    :param snowflake_conn_id: Reference to
+        :ref:`Snowflake connection id<howto/connection:snowflake>`
+    :param account: snowflake account name
+    :param authenticator: authenticator for Snowflake.
+        'snowflake' (default) to use the internal Snowflake authenticator
+        'externalbrowser' to authenticate using your web browser and
+        Okta, ADFS or any other SAML 2.0-compliant identify provider
+        (IdP) that has been defined for your account
+        'https://<your_okta_account_name>.okta.com' to authenticate
+        through native Okta.
+    :param warehouse: name of snowflake warehouse
+    :param database: name of snowflake database
+    :param region: name of snowflake region
+    :param role: name of snowflake role
+    :param schema: name of snowflake schema
+    :param session_parameters: You can set session-level parameters at
+        the time you connect to Snowflake
+    :param token_life_time: lifetime of the JWT Token in timedelta
+    :param token_renewal_delta: Renewal time of the JWT Token in  timedelta
+    """
+
+    LIFETIME = timedelta(minutes=59)  # The tokens will have a 59 minute lifetime
+    RENEWAL_DELTA = timedelta(minutes=54)  # Tokens will be renewed after 54 minutes
+
+    def __init__(
+        self,
+        snowflake_conn_id: str,
+        token_life_time: timedelta = LIFETIME,
+        token_renewal_delta: timedelta = RENEWAL_DELTA,
+        *args: Any,
+        **kwargs: Any,
+    ):
+        self.snowflake_conn_id = snowflake_conn_id
+        self.token_life_time = token_life_time
+        self.token_renewal_delta = token_renewal_delta
+        super().__init__(snowflake_conn_id, *args, **kwargs)
+        self.private_key = None
+
+    def get_private_key(self) -> None:
+        """Gets the private key from snowflake connection"""
+        conn = self.get_connection(self.snowflake_conn_id)
+
+        # If private_key_file is specified in the extra json, load the contents of the file as a private key.
+        # If private_key_content is specified in the extra json, use it as a private key.
+        # As a next step, specify this private key in the connection configuration.
+        # The connection password then becomes the passphrase for the private key.
+        # If your private key is not encrypted (not recommended), then leave the password empty.
+
+        private_key_file = conn.extra_dejson.get(
+            "extra__snowflake__private_key_file"
+        ) or conn.extra_dejson.get("private_key_file")
+        private_key_content = conn.extra_dejson.get(
+            "extra__snowflake__private_key_content"
+        ) or conn.extra_dejson.get("private_key_content")
+
+        private_key_pem = None
+        if private_key_content and private_key_file:
+            raise AirflowException(
+                "The private_key_file and private_key_content extra fields are mutually exclusive. "
+                "Please remove one."
+            )
+        elif private_key_file:
+            private_key_pem = Path(private_key_file).read_bytes()
+        elif private_key_content:
+            private_key_pem = private_key_content.encode()
+
+        if private_key_pem:
+            passphrase = None
+            if conn.password:
+                passphrase = conn.password.strip().encode()
+
+            self.private_key = serialization.load_pem_private_key(
+                private_key_pem, password=passphrase, backend=default_backend()
+            )
+
+    def execute_query(
+        self, sql: str, statement_count: int, query_tag: str = "", bindings: Optional[Dict[str, Any]] = None
+    ) -> List[str]:
+        """
+        Using SnowflakeSQL API, run the query in snowflake by making API request
+
+        :param sql: the sql string to be executed with possibly multiple statements
+        :param statement_count: set the MULTI_STATEMENT_COUNT field to the number of SQL statements in the request
+        :param query_tag: (Optional) Query tag that you want to associate with the SQL statement.
+            For details, see https://docs.snowflake.com/en/sql-reference/parameters.html#label-query-tag parameter.
+        :param bindings: (Optional) Values of bind variables in the SQL statement.
+            When executing the statement, Snowflake replaces placeholders (? and :name) in
+            the statement with these specified values.
+        """
+        conn_config = self._get_conn_params()
+
+        req_id = uuid.uuid4()
+        url = "https://{0}.snowflakecomputing.com/api/v2/statements".format(conn_config["account"])
+        params: Optional[Union[Dict[str, Any]]] = {"requestId": str(req_id), "async": True, "pageSize": 10}
+        headers = self.get_headers()
+        if bindings is None:
+            bindings = {}
+        data = {
+            "statement": sql,
+            "resultSetMetaData": {"format": "json"},
+            "database": conn_config["database"],
+            "schema": conn_config["schema"],
+            "warehouse": conn_config["warehouse"],
+            "role": conn_config["role"],
+            "bindings": bindings,
+            "parameters": {
+                "MULTI_STATEMENT_COUNT": statement_count,
+                "query_tag": query_tag,
+            },
+        }
+        response = requests.post(url, json=data, headers=headers, params=params)
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:  # pragma: no cover
+            raise AirflowException(
+                f"Response: {e.response.content}, " f"Status Code: {e.response.status_code}"
+            )  # pragma: no cover
+        json_response = response.json()
+        self.log.info("Snowflake SQL POST API response: %s", json_response)
+        if "statementHandles" in json_response:
+            self.query_ids = json_response["statementHandles"]
+        elif "statementHandle" in json_response:
+            self.query_ids.append(json_response["statementHandle"])
+        else:
+            raise AirflowException("No statementHandle/statementHandles present in response")
+        return self.query_ids
+
+    def get_headers(self) -> Dict[str, Any]:
+        """Based on the private key, and with connection details JWT Token is generated and header is formed"""
+        if not self.private_key:
+            self.get_private_key()
+        conn_config = self._get_conn_params()
+
+        # Get the JWT token from the connection details and the private key
+        token = JWTGenerator(
+            conn_config["account"],  # type: ignore[arg-type]
+            conn_config["user"],  # type: ignore[arg-type]
+            private_key=self.private_key,
+            lifetime=self.token_life_time,
+            renewal_delay=self.token_renewal_delta,
+        ).get_token()
+
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "User-Agent": "snowflakeSQLAPI/1.0",
+            "X-Snowflake-Authorization-Token-Type": "KEYPAIR_JWT",
+        }
+        return headers
+
+    def get_request_url_header_params(self, query_id: str) -> Tuple[Dict[str, Any], Dict[str, Any], str]:
+        """
+        Build the request header Url with account name identifier and query id from the connection params
+
+        :param query_id: statement handles query ids for the individual statements.
+        """
+        conn_config = self._get_conn_params()
+        req_id = uuid.uuid4()
+        header = self.get_headers()
+        params = {"requestId": str(req_id), "page": 2, "pageSize": 10}
+        url = "https://{0}.snowflakecomputing.com/api/v2/statements/{1}".format(
+            conn_config["account"], query_id
+        )
+        return header, params, url
+
+    def check_query_output(self, query_ids: List[str]) -> None:
+        """
+        Based on the query ids passed as the parameter make HTTP request to snowflake SQL API and logs the response
+
+        :param query_ids: statement handles query id for the individual statements.
+        """
+        for query_id in query_ids:
+            header, params, url = self.get_request_url_header_params(query_id)
+            try:
+                response = requests.get(url, headers=header, params=params)
+                response.raise_for_status()
+                self.log.info(response.json())
+            except requests.exceptions.HTTPError as e:
+                raise AirflowException(
+                    f"Response: {e.response.content}, Status Code: {e.response.status_code}"
+                )
+
+    async def get_sql_api_query_status(self, query_id: str) -> Dict[str, Union[str, List[str]]]:
+        """
+        Based on the query id async HTTP request is made to snowflake SQL API and return response.
+
+        :param query_id: statement handle id for the individual statements.
+        """
+        self.log.info("Retrieving status for query id %s", {query_id})
+        header, params, url = self.get_request_url_header_params(query_id)
+        async with aiohttp.ClientSession(headers=header) as session:
+            async with session.get(url, params=params) as response:
+                status_code = response.status
+                resp = await response.json()
+                self.log.info("Snowflake SQL GET statements status API response: %s", resp)
+                if status_code == 202:
+                    return {"status": "running", "message": "Query statements are still running"}
+                elif status_code == 422:
+                    return {"status": "error", "message": resp["message"]}
+                elif status_code == 200:
+                    statement_handles = []
+                    if "statementHandles" in resp and resp["statementHandles"]:
+                        statement_handles = resp["statementHandles"]
+                    elif "statementHandle" in resp and resp["statementHandle"]:
+                        statement_handles.append(resp["statementHandle"])
+                    return {
+                        "status": "success",
+                        "message": resp["message"],
+                        "statement_handles": statement_handles,
+                    }
+                else:
+                    return {"status": "error", "message": resp["message"]}

--- a/astronomer/providers/snowflake/hooks/sql_api_generate_jwt.py
+++ b/astronomer/providers/snowflake/hooks/sql_api_generate_jwt.py
@@ -1,0 +1,154 @@
+import base64
+import hashlib
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional, Text
+
+# This class relies on the PyJWT module (https://pypi.org/project/PyJWT/).
+import jwt
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+logger = logging.getLogger(__name__)
+
+
+ISSUER = "iss"
+EXPIRE_TIME = "exp"
+ISSUE_TIME = "iat"
+SUBJECT = "sub"
+
+# If you generated an encrypted private key, implement this method to return
+# the passphrase for decrypting your private key. As an example, this function
+# prompts the user for the passphrase.
+
+
+class JWTGenerator(object):
+    """
+    Creates and signs a JWT with the specified private key file, username, and account identifier.
+    The JWTGenerator keeps the generated token and only regenerates the token if a specified period of time has passed.
+
+    Creates an object that generates JWTs for the specified user, account identifier, and private key
+
+    :param account: Your Snowflake account identifier.
+        See https://docs.snowflake.com/en/user-guide/admin-account-identifier.html. Note that if you are using
+        the account locator, exclude any region information from the account locator.
+    :param user: The Snowflake username.
+    :param private_key: Private key from the file path for signing the JWTs.
+    :param lifetime: The number of minutes (as a timedelta) during which the key will be valid.
+    :param renewal_delay: The number of minutes (as a timedelta) from now after which the JWT
+        generator should renew the JWT.
+    """
+
+    LIFETIME = timedelta(minutes=59)  # The tokens will have a 59 minute lifetime
+    RENEWAL_DELTA = timedelta(minutes=54)  # Tokens will be renewed after 54 minutes
+    ALGORITHM = "RS256"  # Tokens will be generated using RSA with SHA256
+
+    def __init__(
+        self,
+        account: Text,
+        user: Text,
+        private_key: Any,
+        lifetime: timedelta = LIFETIME,
+        renewal_delay: timedelta = RENEWAL_DELTA,
+    ):
+        logger.info(
+            """Creating JWTGenerator with arguments
+            account : %s, user : %s, lifetime : %s, renewal_delay : %s""",
+            account,
+            user,
+            lifetime,
+            renewal_delay,
+        )
+
+        # Construct the fully qualified name of the user in uppercase.
+        self.account = self.prepare_account_name_for_jwt(account)
+        self.user = user.upper()
+        self.qualified_username = self.account + "." + self.user
+
+        self.lifetime = lifetime
+        self.renewal_delay = renewal_delay
+        self.private_key = private_key
+        self.renew_time = datetime.now(timezone.utc)
+        self.token = None
+
+    def prepare_account_name_for_jwt(self, raw_account: Text) -> Text:
+        """
+        Prepare the account identifier for use in the JWT.
+        For the JWT, the account identifier must not include the subdomain or any region or cloud provider information.
+
+        :param raw_account: The specified account identifier.
+        """
+        account = raw_account
+        if ".global" not in account:
+            # Handle the general case.
+            idx = account.find(".")
+            if idx > 0:
+                account = account[0:idx]
+        else:
+            # Handle the replication case.
+            idx = account.find("-")
+            if idx > 0:
+                account = account[0:idx]  # pragma: no cover
+        # Use uppercase for the account identifier.
+        return account.upper()
+
+    def get_token(self) -> Optional[Text]:
+        """
+        Generates a new JWT. If a JWT has been already been generated earlier, return the previously
+        generated token unless the specified renewal time has passed.
+        """
+        now = datetime.now(timezone.utc)  # Fetch the current time
+
+        # If the token has expired or doesn't exist, regenerate the token.
+        if self.token is None or self.renew_time <= now:
+            logger.info(
+                "Generating a new token because the present time (%s) is later than the renewal time (%s)",
+                now,
+                self.renew_time,
+            )
+            # Calculate the next time we need to renew the token.
+            self.renew_time = now + self.renewal_delay
+
+            # Prepare the fields for the payload.
+            # Generate the public key fingerprint for the issuer in the payload.
+            public_key_fp = self.calculate_public_key_fingerprint(self.private_key)
+
+            # Create our payload
+            payload = {
+                # Set the issuer to the fully qualified username concatenated with the public key fingerprint.
+                ISSUER: self.qualified_username + "." + public_key_fp,
+                # Set the subject to the fully qualified username.
+                SUBJECT: self.qualified_username,
+                # Set the issue time to now.
+                ISSUE_TIME: now,
+                # Set the expiration time, based on the lifetime specified for this object.
+                EXPIRE_TIME: now + self.lifetime,
+            }
+
+            # Regenerate the actual token
+            token = jwt.encode(payload, key=self.private_key, algorithm=JWTGenerator.ALGORITHM)
+
+            if isinstance(token, bytes):
+                token = token.decode("utf-8")
+            self.token = token
+
+        return self.token
+
+    def calculate_public_key_fingerprint(self, private_key: Any) -> Text:
+        """
+        Given a private key in PEM format, return the public key fingerprint.
+
+        :param private_key: private key
+        """
+        # Get the raw bytes of public key.
+        public_key_raw = private_key.public_key().public_bytes(
+            Encoding.DER, PublicFormat.SubjectPublicKeyInfo
+        )
+
+        # Get the sha256 hash of the raw bytes.
+        sha256hash = hashlib.sha256()
+        sha256hash.update(public_key_raw)
+
+        # Base64-encode the value and prepend the prefix 'SHA256:'.
+        public_key_fp = "SHA256:" + base64.b64encode(sha256hash.digest()).decode("utf-8")
+
+        return public_key_fp

--- a/astronomer/providers/snowflake/operators/snowflake.py
+++ b/astronomer/providers/snowflake/operators/snowflake.py
@@ -1,4 +1,5 @@
 import typing
+from datetime import timedelta
 from typing import Any, Dict, List, Optional, Union
 
 from airflow.exceptions import AirflowException
@@ -6,7 +7,11 @@ from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
 from airflow.utils.context import Context
 
 from astronomer.providers.snowflake.hooks.snowflake import SnowflakeHookAsync
+from astronomer.providers.snowflake.hooks.snowflake_sql_api import (
+    SnowflakeSqlApiHookAsync,
+)
 from astronomer.providers.snowflake.triggers.snowflake_trigger import (
+    SnowflakeSqlApiTrigger,
     SnowflakeTrigger,
     get_db_hook,
 )
@@ -111,3 +116,138 @@ class SnowflakeOperatorAsync(SnowflakeOperator):
         else:
             self.log.info("%s completed successfully.", self.task_id)
             return None
+
+
+class SnowflakeSqlApiOperatorAsync(SnowflakeOperator):
+    """
+    Implemented Async Snowflake SQL API Operator to support multiple SQL statements sequentially,
+    which is the behavior of the SnowflakeOperator, the Snowflake SQL API allows submitting
+    multiple SQL statements in a single request. In combination with aiohttp, make post request to submit SQL
+    statements for execution, poll to check the status of the execution of a statement. Fetch query results
+    concurrently.
+    This Operator currently uses key pair authentication, so you need tp provide private key raw content or
+    private key file path in the snowflake connection along with other details
+
+    .. see also::
+        https://docs.snowflake.com/en/developer-guide/sql-api/authenticating.html#label-sql-api-authenticating-key-pair
+
+    where can this operator fit in?
+         - To Execute Multiple SQL statement in single request
+         - To Execute the SQL statement asynchronously and to execute standard queries and most DDL and DML statements
+         - To develop custom applications and integrations that perform queries
+         - To create provision users and roles, create table, etc.
+
+    The following commands are not supported:
+        - The PUT command (in Snowflake SQL)
+        - The GET command (in Snowflake SQL)
+        - The CALL command with stored procedures that return a table(stored procedures with the RETURNS TABLE clause).
+
+    .. see also::
+        To know more about the Snowflake SQL API.
+        - https://docs.snowflake.com/en/developer-guide/sql-api/intro.html#introduction-to-the-sql-api
+        - https://docs.snowflake.com/en/developer-guide/sql-api/reference.html#snowflake-sql-api-reference
+        - https://docs.snowflake.com/en/developer-guide/sql-api/intro.html#limitations-of-the-sql-api
+        Limitation on snowflake SQL API
+        - https://docs.snowflake.com/en/developer-guide/sql-api/intro.html#limitations-of-the-sql-api
+
+    :param snowflake_conn_id: Reference to Snowflake connection id
+    :param sql: the sql code to be executed. (templated)
+    :param autocommit: if True, each command is automatically committed.
+        (default value: True)
+    :param parameters: (optional) the parameters to render the SQL query with.
+    :param warehouse: name of warehouse (will overwrite any warehouse
+        defined in the connection's extra JSON)
+    :param database: name of database (will overwrite database defined
+        in connection)
+    :param schema: name of schema (will overwrite schema defined in
+        connection)
+    :param role: name of role (will overwrite any role defined in
+        connection's extra JSON)
+    :param authenticator: authenticator for Snowflake.
+        'snowflake' (default) to use the internal Snowflake authenticator
+        'externalbrowser' to authenticate using your web browser and
+        Okta, ADFS or any other SAML 2.0-compliant identify provider
+        (IdP) that has been defined for your account
+        'https://<your_okta_account_name>.okta.com' to authenticate
+        through native Okta.
+    :param session_parameters: You can set session-level parameters at
+        the time you connect to Snowflake
+    :param poll_interval: the interval in seconds to poll the query
+    :param statement_count: Number of SQL statement to be executed
+    :param token_life_time: lifetime of the JWT Token
+    :param token_renewal_delta: Renewal time of the JWT Token
+    :param bindings: (Optional) Values of bind variables in the SQL statement.
+            When executing the statement, Snowflake replaces placeholders (? and :name) in
+            the statement with these specified values.
+    """
+
+    LIFETIME = timedelta(minutes=59)  # The tokens will have a 59 minutes lifetime
+    RENEWAL_DELTA = timedelta(minutes=54)  # Tokens will be renewed after 54 minutes
+
+    def __init__(
+        self,
+        *,
+        poll_interval: int = 5,
+        statement_count: int = 0,
+        token_life_time: timedelta = LIFETIME,
+        token_renewal_delta: timedelta = RENEWAL_DELTA,
+        bindings: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        self.poll_interval = poll_interval
+        self.statement_count = statement_count
+        self.token_life_time = token_life_time
+        self.token_renewal_delta = token_renewal_delta
+        self.bindings = bindings
+        self.execute_async = False
+        super().__init__(**kwargs)
+
+    def execute(self, context: Context) -> None:
+        """
+        Make a POST API request to snowflake by using SnowflakeSQL and execute the query to get the ids.
+        By deferring the SnowflakeSqlApiTrigger class passed along with query ids.
+        """
+        self.log.info("Executing: %s", self.sql)
+        hook = SnowflakeSqlApiHookAsync(
+            snowflake_conn_id=self.snowflake_conn_id,
+            token_life_time=self.token_life_time,
+            token_renewal_delta=self.token_renewal_delta,
+        )
+        hook.execute_query(self.sql, statement_count=self.statement_count, bindings=self.bindings)
+        self.query_ids = hook.query_ids
+        self.log.info("List of query ids %s", self.query_ids)
+
+        if self.do_xcom_push:
+            context["ti"].xcom_push(key="query_ids", value=self.query_ids)
+
+        self.defer(
+            timeout=self.execution_timeout,
+            trigger=SnowflakeSqlApiTrigger(
+                poll_interval=self.poll_interval,
+                query_ids=self.query_ids,
+                snowflake_conn_id=self.snowflake_conn_id,
+                token_life_time=self.token_life_time,
+                token_renewal_delta=self.token_renewal_delta,
+            ),
+            method_name="execute_complete",
+        )
+
+    def execute_complete(
+        self, context: Dict[str, Any], event: Optional[Dict[str, Union[str, List[str]]]] = None
+    ) -> None:
+        """
+        Callback for when the trigger fires - returns immediately.
+        Relies on trigger to throw an exception, otherwise it assumes execution was
+        successful.
+        """
+        if event:
+            if "status" in event and event["status"] == "error":
+                msg = "{0}: {1}".format(event["status"], event["message"])
+                raise AirflowException(msg)
+            elif "status" in event and event["status"] == "success":
+                hook = SnowflakeSqlApiHookAsync(snowflake_conn_id=self.snowflake_conn_id)
+                query_ids = typing.cast(List[str], event["statement_query_ids"])
+                hook.check_query_output(query_ids)
+                self.log.info("%s completed successfully.", self.task_id)
+        else:
+            self.log.info("%s completed successfully.", self.task_id)

--- a/astronomer/providers/snowflake/triggers/snowflake_trigger.py
+++ b/astronomer/providers/snowflake/triggers/snowflake_trigger.py
@@ -1,8 +1,13 @@
+import asyncio
+from datetime import timedelta
 from typing import Any, AsyncIterator, Dict, List, Tuple
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 from astronomer.providers.snowflake.hooks.snowflake import SnowflakeHookAsync
+from astronomer.providers.snowflake.hooks.snowflake_sql_api import (
+    SnowflakeSqlApiHookAsync,
+)
 
 
 def get_db_hook(snowflake_conn_id: str) -> SnowflakeHookAsync:
@@ -65,3 +70,80 @@ class SnowflakeTrigger(BaseTrigger):
                 yield TriggerEvent({"status": "error", "message": error_message})
         except Exception as e:
             yield TriggerEvent({"status": "error", "message": str(e)})
+
+
+class SnowflakeSqlApiTrigger(BaseTrigger):
+    """
+    SnowflakeSqlApi Trigger inherits from the BaseTrigger,it is fired as
+    deferred class with params to run the task in trigger worker and
+    fetch the status for the query ids passed
+
+    :param task_id: Reference to task id of the Dag
+    :param poll_interval:  polling period in seconds to check for the status
+    :param query_ids: List of Query ids to run and poll for the status
+    :param snowflake_conn_id: Reference to Snowflake connection id
+    """
+
+    def __init__(
+        self,
+        poll_interval: float,
+        query_ids: List[str],
+        snowflake_conn_id: str,
+        token_life_time: timedelta,
+        token_renewal_delta: timedelta,
+    ):
+        super().__init__()
+        self.poll_interval = poll_interval
+        self.query_ids = query_ids
+        self.snowflake_conn_id = snowflake_conn_id
+        self.token_life_time = token_life_time
+        self.token_renewal_delta = token_renewal_delta
+
+    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+        """Serializes SnowflakeSqlApiTrigger arguments and classpath."""
+        return (
+            "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger",
+            {
+                "poll_interval": self.poll_interval,
+                "query_ids": self.query_ids,
+                "snowflake_conn_id": self.snowflake_conn_id,
+                "token_life_time": self.token_life_time,
+                "token_renewal_delta": self.token_renewal_delta,
+            },
+        )
+
+    async def run(self) -> AsyncIterator["TriggerEvent"]:  # type: ignore[override]
+        """
+        Makes a GET API request to snowflake with query_id to get the status of the query
+        by get_sql_api_query_status async function
+        """
+        hook = SnowflakeSqlApiHookAsync(
+            self.snowflake_conn_id, self.token_life_time, self.token_renewal_delta
+        )
+        try:
+            statement_query_ids: List[str] = []
+            for query_id in self.query_ids:
+                while await self.is_still_running(query_id):
+                    await asyncio.sleep(self.poll_interval)
+                statement_status = await hook.get_sql_api_query_status(query_id)
+                if statement_status["status"] == "error":
+                    yield TriggerEvent(statement_status)
+                if statement_status["status"] == "success":
+                    statement_query_ids.extend(statement_status["statement_handles"])
+            yield TriggerEvent({"status": "success", "statement_query_ids": statement_query_ids})
+        except Exception as e:
+            yield TriggerEvent({"status": "error", "message": str(e)})
+
+    async def is_still_running(self, query_id: str) -> bool:
+        """
+        Async function to check whether the query statement submitted via SQL API is still
+        running state and returns True if it is still running else
+        return False
+        """
+        hook = SnowflakeSqlApiHookAsync(
+            self.snowflake_conn_id, self.token_life_time, self.token_renewal_delta
+        )
+        statement_status = await hook.get_sql_api_query_status(query_id)
+        if statement_status["status"] in ["running"]:
+            return True
+        return False

--- a/docs/providers/snowflake/index.rst
+++ b/docs/providers/snowflake/index.rst
@@ -6,6 +6,8 @@ Snowflake Example DAG
   :maxdepth: 2
 
     Snowflake Operators <operators/snowflake>
+    Snowflake Sql Api Operators <operators/snowflake_sql_api>
 
 
 * `Snowflake Operators <operators/snowflake.html>`_
+* `Snowflake Sql Api Operators <operators/snowflake_sql_api.html>`_

--- a/docs/providers/snowflake/operators/snowflake_sql_api.rst
+++ b/docs/providers/snowflake/operators/snowflake_sql_api.rst
@@ -1,0 +1,14 @@
+Snowflake SQL API Operator Async
+"""""""""""""""""""""""""""""""""
+
+
+The Snowflake SQL API allows submitting multiple SQL statements in a single request.
+In combination with aiohttp, make post request to submit SQL statements for execution,
+poll to check the status of the execution of a statement. Fetch query results concurrently
+:class:`~astronomer.providers.snowflake.operators.snowflake_sql_api.SnowflakeSqlApiOperatorAsync`.
+
+.. exampleinclude:: /../astronomer/providers/snowflake/example_dags/example_snowflake_sql_api.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_snowflake_sql_api_async]
+    :end-before: [END howto_operator_snowflake_sql_api_async]

--- a/tests/snowflake/hooks/test_snowflake_sql_api.py
+++ b/tests/snowflake/hooks/test_snowflake_sql_api.py
@@ -1,0 +1,445 @@
+import unittest
+import uuid
+from pathlib import Path
+from typing import Any, Dict
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import pytest
+import requests
+from airflow import AirflowException
+from airflow.models import Connection
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from astronomer.providers.snowflake.hooks.snowflake_sql_api import (
+    SnowflakeSqlApiHookAsync,
+)
+
+SQL_MULTIPLE_STMTS = (
+    "create or replace table user_test (i int); insert into user_test (i) "
+    "values (200); insert into user_test (i) values (300); select i from user_test order by i;"
+)
+_PASSWORD = "snowflake42"
+
+SINGLE_STMT = "select i from user_test order by i;"
+BASE_CONNECTION_KWARGS: Dict = {
+    "login": "user",
+    "conn_type": "snowflake",
+    "password": "pw",
+    "schema": "public",
+    "extra": {
+        "database": "db",
+        "account": "airflow",
+        "warehouse": "af_wh",
+        "region": "af_region",
+        "role": "af_role",
+    },
+}
+CONN_PARAMS = {
+    "account": "airflow",
+    "application": "AIRFLOW",
+    "authenticator": "snowflake",
+    "database": "db",
+    "password": "pw",
+    "region": "af_region",
+    "role": "af_role",
+    "schema": "public",
+    "session_parameters": None,
+    "user": "user",
+    "warehouse": "af_wh",
+}
+HEADERS = {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer newT0k3n",
+    "Accept": "application/json",
+    "User-Agent": "snowflakeSQLAPI/1.0",
+    "X-Snowflake-Authorization-Token-Type": "KEYPAIR_JWT",
+}
+
+GET_RESPONSE = {
+    "resultSetMetaData": {
+        "numRows": 10000,
+        "format": "jsonv2",
+        "rowType": [
+            {
+                "name": "SEQ8()",
+                "database": "",
+                "schema": "",
+                "table": "",
+                "scale": 0,
+                "precision": 19,
+            },
+            {
+                "name": "RANDSTR(1000, RANDOM())",
+                "database": "",
+                "schema": "",
+                "table": "",
+            },
+        ],
+        "partitionInfo": [
+            {
+                "rowCount": 12344,
+                "uncompressedSize": 14384873,
+            },
+            {"rowCount": 43746, "uncompressedSize": 43748274, "compressedSize": 746323},
+        ],
+    },
+    "code": "090001",
+    "statementStatusUrl": "/api/v2/statements/{handle}?requestId={id5}&partition=10",
+    "sqlState": "00000",
+    "statementHandle": "{handle}",
+    "message": "Statement executed successfully.",
+    "createdOn": 1620151693299,
+}
+
+
+def create_successful_response_mock(content):
+    """Create mock response for success state"""
+    response = mock.MagicMock()
+    response.json.return_value = content
+    response.status_code = 200
+    return response
+
+
+@pytest.mark.parametrize(
+    "sql,statement_count,expected_response, expected_query_ids",
+    [
+        (SINGLE_STMT, 1, {"statementHandle": "uuid"}, ["uuid"]),
+        (SQL_MULTIPLE_STMTS, 4, {"statementHandles": ["uuid", "uuid1"]}, ["uuid", "uuid1"]),
+    ],
+)
+@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.requests")
+@mock.patch(
+    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync._get_conn_params"
+)
+@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_headers")
+def test_execute_query(
+    mock_get_header,
+    mock_conn_param,
+    mock_requests,
+    sql,
+    statement_count,
+    expected_response,
+    expected_query_ids,
+):
+    """Test execute_query method, run query by mocking post request method and return the query ids"""
+    mock_requests.codes.ok = 200
+    mock_requests.post.side_effect = [
+        create_successful_response_mock(expected_response),
+    ]
+    status_code_mock = mock.PropertyMock(return_value=200)
+    type(mock_requests.post.return_value).status_code = status_code_mock
+
+    hook = SnowflakeSqlApiHookAsync("mock_conn_id")
+    query_ids = hook.execute_query(sql, statement_count)
+    assert query_ids == expected_query_ids
+
+
+def create_post_side_effect(status_code=429):
+    """create mock response for post side effect"""
+    response = mock.MagicMock()
+    response.status_code = status_code
+    response.reason = "test"
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError(response=response)
+    return response
+
+
+@pytest.mark.parametrize(
+    "sql,statement_count,expected_response, expected_query_ids",
+    [(SINGLE_STMT, 1, {"statementHandle": "uuid"}, ["uuid"])],
+)
+@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.requests")
+@mock.patch(
+    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync._get_conn_params"
+)
+@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_headers")
+def test_execute_query_exception_without_statement_handel(
+    mock_get_header,
+    mock_conn_param,
+    mock_requests,
+    sql,
+    statement_count,
+    expected_response,
+    expected_query_ids,
+):
+    """
+    Test execute_query method by mocking the exception response and raise airflow exception
+    without statementHandle in the response
+    """
+    side_effect = create_post_side_effect()
+    mock_requests.post.side_effect = side_effect
+    hook = SnowflakeSqlApiHookAsync("mock_conn_id")
+
+    with pytest.raises(AirflowException) as exception_info:
+        hook.execute_query(sql, statement_count)
+    assert exception_info
+
+
+@pytest.mark.parametrize(
+    "query_ids",
+    [
+        (["uuid", "uuid1"]),
+    ],
+)
+@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.requests")
+@mock.patch(
+    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync."
+    "get_request_url_header_params"
+)
+def test_check_query_output(mock_geturl_header_params, mock_requests, query_ids):
+    """Test check_query_output by passing query ids as params and mock get_request_url_header_params"""
+    req_id = uuid.uuid4()
+    params = {"requestId": str(req_id), "page": 2, "pageSize": 10}
+    mock_geturl_header_params.return_value = HEADERS, params, "/test/airflow/"
+    mock_requests.get.return_value.json.return_value = GET_RESPONSE
+    hook = SnowflakeSqlApiHookAsync("mock_conn_id")
+    with mock.patch.object(hook.log, "info") as mock_log_info:
+        hook.check_query_output(query_ids)
+    mock_log_info.assert_called_with(GET_RESPONSE)
+
+
+@pytest.mark.parametrize(
+    "query_ids",
+    [
+        (["uuid", "uuid1"]),
+    ],
+)
+@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.requests.get")
+@mock.patch(
+    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync."
+    "get_request_url_header_params"
+)
+def test_check_query_output_exception(mock_geturl_header_params, mock_requests, query_ids):
+    """
+    Test check_query_output by passing query ids as params and mock get_request_url_header_params
+    to raise airflow exception and mock with http error
+    """
+    req_id = uuid.uuid4()
+    params = {"requestId": str(req_id), "page": 2, "pageSize": 10}
+    mock_geturl_header_params.return_value = HEADERS, params, "/test/airflow/"
+    mock_resp = requests.models.Response()
+    mock_resp.status_code = 404
+    mock_requests.return_value = mock_resp
+    hook = SnowflakeSqlApiHookAsync("mock_conn_id")
+    with mock.patch.object(hook.log, "error"):
+        with pytest.raises(AirflowException) as airflow_exception:
+            hook.check_query_output(query_ids)
+        assert airflow_exception
+
+
+@mock.patch(
+    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync._get_conn_params"
+)
+@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_headers")
+def test_get_request_url_header_params(mock_get_header, mock_conn_param):
+    """Test get_request_url_header_params by mocking _get_conn_params and get_headers"""
+    mock_conn_param.return_value = CONN_PARAMS
+    mock_get_header.return_value = HEADERS
+    hook = SnowflakeSqlApiHookAsync("mock_conn_id")
+    header, params, url = hook.get_request_url_header_params("uuid")
+    assert header == HEADERS
+    assert url == "https://airflow.snowflakecomputing.com/api/v2/statements/uuid"
+
+
+@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_private_key")
+@mock.patch(
+    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync._get_conn_params"
+)
+@mock.patch("astronomer.providers.snowflake.hooks.sql_api_generate_jwt.JWTGenerator.get_token")
+def test_get_headers(mock_get_token, mock_conn_param, mock_private_key):
+    """Test get_headers method by mocking get_private_key and _get_conn_params method"""
+    mock_get_token.return_value = "newT0k3n"
+    mock_conn_param.return_value = CONN_PARAMS
+    hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="mock_conn_id")
+    result = hook.get_headers()
+    assert result == HEADERS
+
+
+@pytest.fixture()
+def non_encrypted_temporary_private_key(tmp_path: Path) -> Path:
+    """Encrypt the pem file from the path"""
+    key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=2048)
+    private_key = key.private_bytes(
+        serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8, serialization.NoEncryption()
+    )
+    test_key_file = tmp_path / "test_key.pem"
+    test_key_file.write_bytes(private_key)
+    return test_key_file
+
+
+@pytest.fixture()
+def encrypted_temporary_private_key(tmp_path: Path) -> Path:
+    """Encrypt private key from the temp path"""
+    key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=2048)
+    private_key = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.BestAvailableEncryption(_PASSWORD.encode()),
+    )
+    test_key_file: Path = tmp_path / "test_key.p8"
+    test_key_file.write_bytes(private_key)
+    return test_key_file
+
+
+def test_get_private_key_should_support_private_auth_in_connection(encrypted_temporary_private_key: Path):
+    """Test get_private_key function with private_key_content in connection"""
+    connection_kwargs: Any = {
+        **BASE_CONNECTION_KWARGS,
+        "password": _PASSWORD,
+        "extra": {
+            "database": "db",
+            "account": "airflow",
+            "warehouse": "af_wh",
+            "region": "af_region",
+            "role": "af_role",
+            "private_key_content": str(encrypted_temporary_private_key.read_text()),
+        },
+    }
+    with unittest.mock.patch.dict(
+        "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
+    ):
+        hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
+        hook.get_private_key()
+        assert hook.private_key is not None
+
+
+def test_get_private_key_raise_exception(encrypted_temporary_private_key: Path):
+    """
+    Test get_private_key function with private_key_content and private_key_file in connection
+    and raise airflow exception
+    """
+    connection_kwargs: Any = {
+        **BASE_CONNECTION_KWARGS,
+        "password": _PASSWORD,
+        "extra": {
+            "database": "db",
+            "account": "airflow",
+            "warehouse": "af_wh",
+            "region": "af_region",
+            "role": "af_role",
+            "private_key_content": str(encrypted_temporary_private_key.read_text()),
+            "private_key_file": str(encrypted_temporary_private_key),
+        },
+    }
+    hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
+    with unittest.mock.patch.dict(
+        "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
+    ), pytest.raises(
+        AirflowException,
+        match="The private_key_file and private_key_content extra fields are mutually "
+        "exclusive. Please remove one.",
+    ):
+        hook.get_private_key()
+
+
+def test_get_private_key_should_support_private_auth_with_encrypted_key(encrypted_temporary_private_key):
+    """Test get_private_key method by supporting for private auth encrypted_key"""
+    connection_kwargs = {
+        **BASE_CONNECTION_KWARGS,
+        "password": _PASSWORD,
+        "extra": {
+            "database": "db",
+            "account": "airflow",
+            "warehouse": "af_wh",
+            "region": "af_region",
+            "role": "af_role",
+            "private_key_file": str(encrypted_temporary_private_key),
+        },
+    }
+    with unittest.mock.patch.dict(
+        "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
+    ):
+        hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
+        hook.get_private_key()
+        assert hook.private_key is not None
+
+
+def test_get_private_key_should_support_private_auth_with_unencrypted_key(
+    non_encrypted_temporary_private_key,
+):
+    connection_kwargs = {
+        **BASE_CONNECTION_KWARGS,
+        "password": None,
+        "extra": {
+            "database": "db",
+            "account": "airflow",
+            "warehouse": "af_wh",
+            "region": "af_region",
+            "role": "af_role",
+            "private_key_file": str(non_encrypted_temporary_private_key),
+        },
+    }
+    with unittest.mock.patch.dict(
+        "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
+    ):
+        hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
+        hook.get_private_key()
+        assert hook.private_key is not None
+    connection_kwargs["password"] = ""
+    with unittest.mock.patch.dict(
+        "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
+    ):
+        hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
+        hook.get_private_key()
+        assert hook.private_key is not None
+    connection_kwargs["password"] = _PASSWORD
+    with unittest.mock.patch.dict(
+        "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
+    ), pytest.raises(TypeError, match="Password was given but private key is not encrypted."):
+        SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn").get_private_key()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status_code,response,expected_response",
+    [
+        (
+            200,
+            {
+                "status": "success",
+                "message": "Statement executed successfully.",
+                "statementHandle": "uuid",
+            },
+            {
+                "status": "success",
+                "message": "Statement executed successfully.",
+                "statement_handles": ["uuid"],
+            },
+        ),
+        (
+            200,
+            {
+                "status": "success",
+                "message": "Statement executed successfully.",
+                "statementHandles": ["uuid", "uuid1"],
+            },
+            {
+                "status": "success",
+                "message": "Statement executed successfully.",
+                "statement_handles": ["uuid", "uuid1"],
+            },
+        ),
+        (202, {}, {"status": "running", "message": "Query statements are still running"}),
+        (422, {"status": "error", "message": "test"}, {"status": "error", "message": "test"}),
+        (404, {"status": "error", "message": "test"}, {"status": "error", "message": "test"}),
+    ],
+)
+@mock.patch(
+    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync."
+    "get_request_url_header_params"
+)
+@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.aiohttp.ClientSession.get")
+async def test_get_sql_api_query_status(
+    mock_get, mock_geturl_header_params, status_code, response, expected_response
+):
+    """Test Async get_sql_api_query_status function by mocking the status, response and expected response"""
+    req_id = uuid.uuid4()
+    params = {"requestId": str(req_id), "page": 2, "pageSize": 10}
+    mock_geturl_header_params.return_value = HEADERS, params, "/test/airflow/"
+    mock_get.return_value.__aenter__.return_value.status = status_code
+    mock_get.return_value.__aenter__.return_value.json = AsyncMock(return_value=response)
+    hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
+    response = await hook.get_sql_api_query_status("uuid")
+    assert response == expected_response

--- a/tests/snowflake/hooks/test_sql_api_generate_jwt.py
+++ b/tests/snowflake/hooks/test_sql_api_generate_jwt.py
@@ -1,0 +1,33 @@
+import pytest
+from cryptography.hazmat.backends import default_backend as crypto_default_backend
+from cryptography.hazmat.primitives import serialization as crypto_serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from astronomer.providers.snowflake.hooks.sql_api_generate_jwt import JWTGenerator
+
+_PASSWORD = "snowflake42"
+
+key = rsa.generate_private_key(backend=crypto_default_backend(), public_exponent=65537, key_size=2048)
+
+private_key = key.private_bytes(
+    crypto_serialization.Encoding.PEM,
+    crypto_serialization.PrivateFormat.PKCS8,
+    crypto_serialization.NoEncryption(),
+)
+
+
+@pytest.mark.parametrize(
+    "account_name, expected_account_name",
+    [("test.us-east-1", "TEST"), ("test.global", "TEST.GLOBAL"), ("test", "TEST")],
+)
+def test_prepare_account_name_for_jwt(account_name, expected_account_name):
+    """Test prepare_account_name_for_jwt by passing the account identifier and get the proper account name in caps"""
+    jwt_generator = JWTGenerator(account_name, "test_user", private_key)
+    response = jwt_generator.prepare_account_name_for_jwt(account_name)
+    assert response == expected_account_name
+
+
+def test_calculate_public_key_fingerprint():
+    """Asserting get_token and calculate_public_key_fingerprint by passing key and generating token"""
+    jwt_generator = JWTGenerator("test.us-east-1", "test_user", key)
+    assert jwt_generator.get_token()

--- a/tests/snowflake/operators/test_snowflake.py
+++ b/tests/snowflake/operators/test_snowflake.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import timedelta
 from unittest import mock
 
 import pytest
@@ -10,8 +11,14 @@ from airflow.utils import timezone
 from airflow.utils.types import DagRunType
 
 from astronomer.providers.snowflake.hooks.snowflake import SnowflakeHookAsync
-from astronomer.providers.snowflake.operators.snowflake import SnowflakeOperatorAsync
-from astronomer.providers.snowflake.triggers.snowflake_trigger import SnowflakeTrigger
+from astronomer.providers.snowflake.operators.snowflake import (
+    SnowflakeOperatorAsync,
+    SnowflakeSqlApiOperatorAsync,
+)
+from astronomer.providers.snowflake.triggers.snowflake_trigger import (
+    SnowflakeSqlApiTrigger,
+    SnowflakeTrigger,
+)
 
 DEFAULT_DATE = timezone.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
@@ -29,6 +36,15 @@ POLLING_PERIOD_SECONDS = 1.0
 XCOM_RUN_ID_KEY = "run_id"
 XCOM_RUN_PAGE_URL_KEY = "run_page_url"
 TEST_SQL = "select * from any;"
+
+LIFETIME = timedelta(minutes=59)
+RENEWAL_DELTA = timedelta(minutes=54)
+SQL_MULTIPLE_STMTS = (
+    "create or replace table user_test (i int); insert into user_test (i) "
+    "values (200); insert into user_test (i) values (300); select i from user_test order by i;"
+)
+
+SINGLE_STMT = "select i from user_test order by i;"
 
 
 @pytest.fixture
@@ -139,3 +155,66 @@ def test_get_db_hook():
     )
     result = operator.get_db_hook()
     assert isinstance(result, SnowflakeHookAsync)
+
+
+@pytest.mark.parametrize("mock_sql, statement_count", [(SQL_MULTIPLE_STMTS, 4), (SINGLE_STMT, 1)])
+@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.execute_query")
+def test_snowflake_sql_api_execute_operator_async(mock_db_hook, mock_sql, statement_count):
+    """
+    Asserts that a task is deferred and an SnowflakeSqlApiTrigger will be fired
+    when the SnowflakeSqlApiOperatorAsync is executed.
+    """
+    args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
+    dag = DAG("test_snowflake_async_execute_complete_failure", default_args=args)
+    operator = SnowflakeSqlApiOperatorAsync(
+        task_id=TASK_ID,
+        snowflake_conn_id=CONN_ID,
+        sql=mock_sql,
+        statement_count=statement_count,
+    )
+
+    with pytest.raises(TaskDeferred) as exc:
+        operator.execute(create_context(operator, dag=dag))
+
+    assert isinstance(exc.value.trigger, SnowflakeSqlApiTrigger), "Trigger is not a SnowflakeSqlApiTrigger"
+
+
+def test_snowflake_sql_api_execute_complete_failure():
+    """Test SnowflakeSqlApiOperatorAsync raise AirflowException of error event"""
+
+    operator = SnowflakeSqlApiOperatorAsync(
+        task_id=TASK_ID,
+        snowflake_conn_id=CONN_ID,
+        sql=SQL_MULTIPLE_STMTS,
+        statement_count=4,
+    )
+    with pytest.raises(AirflowException):
+        operator.execute_complete(
+            context=None,
+            event={"status": "error", "message": "Test failure message", "type": "FAILED_WITH_ERROR"},
+        )
+
+
+@pytest.mark.parametrize(
+    "mock_event",
+    [
+        None,
+        ({"status": "success", "statement_query_ids": ["uuid", "uuid"]}),
+    ],
+)
+@mock.patch(
+    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.check_query_output"
+)
+def test_snowflake_sql_api_execute_complete(mock_conn, mock_event):
+    """Tests execute_complete assert with successful message"""
+
+    operator = SnowflakeSqlApiOperatorAsync(
+        task_id=TASK_ID,
+        snowflake_conn_id=CONN_ID,
+        sql=SQL_MULTIPLE_STMTS,
+        statement_count=4,
+    )
+
+    with mock.patch.object(operator.log, "info") as mock_log_info:
+        operator.execute_complete(context=None, event=mock_event)
+    mock_log_info.assert_called_with("%s completed successfully.", TASK_ID)

--- a/tests/snowflake/triggers/test_snowflake.py
+++ b/tests/snowflake/triggers/test_snowflake.py
@@ -1,13 +1,19 @@
 import asyncio
+from datetime import timedelta
 from unittest import mock
 
 import pytest
 from airflow.triggers.base import TriggerEvent
 
-from astronomer.providers.snowflake.triggers.snowflake_trigger import SnowflakeTrigger
+from astronomer.providers.snowflake.triggers.snowflake_trigger import (
+    SnowflakeSqlApiTrigger,
+    SnowflakeTrigger,
+)
 
 TASK_ID = "snowflake_check"
 POLLING_PERIOD_SECONDS = 1.0
+LIFETIME = timedelta(minutes=59)
+RENEWAL_DELTA = timedelta(minutes=54)
 
 
 def test_snowflake_trigger_serialization():
@@ -160,3 +166,163 @@ async def test_snowflake_trigger_exception(mock_query_status, query_ids):
     task = [i async for i in trigger.run()]
     assert len(task) == 1
     assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+
+
+def test_snowflake_sql_trigger_serialization():
+    """
+    Asserts that the SnowflakeSqlApiTrigger correctly serializes its arguments
+    and classpath.
+    """
+    trigger = SnowflakeSqlApiTrigger(
+        poll_interval=POLLING_PERIOD_SECONDS,
+        query_ids=[],
+        snowflake_conn_id="test_conn",
+        token_life_time=LIFETIME,
+        token_renewal_delta=RENEWAL_DELTA,
+    )
+    classpath, kwargs = trigger.serialize()
+    assert classpath == "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger"
+    assert kwargs == {
+        "poll_interval": POLLING_PERIOD_SECONDS,
+        "query_ids": [],
+        "snowflake_conn_id": "test_conn",
+        "token_life_time": LIFETIME,
+        "token_renewal_delta": RENEWAL_DELTA,
+    }
+
+
+@pytest.mark.asyncio
+@mock.patch(
+    "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
+)
+@mock.patch(
+    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
+)
+async def test_snowflake_sql_trigger_running(mock_get_sql_api_query_status, mock_is_still_running):
+    """Tests that the SnowflakeSqlApiTrigger in running by mocking is_still_running to true"""
+    mock_is_still_running.return_value = True
+    trigger = SnowflakeSqlApiTrigger(
+        poll_interval=POLLING_PERIOD_SECONDS,
+        query_ids=["uuid"],
+        snowflake_conn_id="test_conn",
+        token_life_time=LIFETIME,
+        token_renewal_delta=RENEWAL_DELTA,
+    )
+
+    task = asyncio.create_task(trigger.run().__anext__())
+    await asyncio.sleep(0.5)
+
+    # TriggerEvent was not returned
+    assert task.done() is False
+    asyncio.get_event_loop().stop()
+
+
+@pytest.mark.asyncio
+@mock.patch(
+    "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
+)
+@mock.patch(
+    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
+)
+async def test_snowflake_sql_trigger_completed(mock_get_sql_api_query_status, mock_is_still_running):
+    """
+    Test SnowflakeSqlApiTrigger run method with success status and mock the get_sql_api_query_status result
+    and  is_still_running to False.
+    """
+    mock_is_still_running.return_value = False
+    statement_query_ids = ["uuid", "uuid1"]
+    mock_get_sql_api_query_status.return_value = {
+        "message": "Statement executed successfully.",
+        "status": "success",
+        "statement_handles": statement_query_ids,
+    }
+    trigger = SnowflakeSqlApiTrigger(
+        poll_interval=POLLING_PERIOD_SECONDS,
+        query_ids=["uuid"],
+        snowflake_conn_id="test_conn",
+        token_life_time=LIFETIME,
+        token_renewal_delta=RENEWAL_DELTA,
+    )
+    generator = trigger.run()
+    actual = await generator.asend(None)
+    assert TriggerEvent({"status": "success", "statement_query_ids": statement_query_ids}) == actual
+
+
+@pytest.mark.asyncio
+@mock.patch(
+    "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
+)
+@mock.patch(
+    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
+)
+async def test_snowflake_sql_trigger_failure_status(mock_get_sql_api_query_status, mock_is_still_running):
+    """Test SnowflakeSqlApiTrigger task is executed and triggered with failure status."""
+    mock_is_still_running.return_value = False
+    mock_response = {
+        "status": "error",
+        "message": "An error occurred when executing the statement. Check "
+        "the error code and error message for details",
+    }
+    mock_get_sql_api_query_status.return_value = mock_response
+    trigger = SnowflakeSqlApiTrigger(
+        poll_interval=POLLING_PERIOD_SECONDS,
+        query_ids=["uuid"],
+        snowflake_conn_id="test_conn",
+        token_life_time=LIFETIME,
+        token_renewal_delta=RENEWAL_DELTA,
+    )
+    generator = trigger.run()
+    actual = await generator.asend(None)
+    assert TriggerEvent(mock_response) == actual
+
+
+@pytest.mark.asyncio
+@mock.patch(
+    "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
+)
+@mock.patch(
+    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
+)
+async def test_snowflake_sql_trigger_exception(mock_get_sql_api_query_status, mock_is_still_running):
+    """Tests the SnowflakeSqlApiTrigger does not fire if there is an exception."""
+    mock_is_still_running.return_value = False
+    mock_get_sql_api_query_status.side_effect = Exception("Test exception")
+
+    trigger = SnowflakeSqlApiTrigger(
+        poll_interval=POLLING_PERIOD_SECONDS,
+        query_ids=["uuid"],
+        snowflake_conn_id="test_conn",
+        token_life_time=LIFETIME,
+        token_renewal_delta=RENEWAL_DELTA,
+    )
+
+    task = [i async for i in trigger.run()]
+    assert len(task) == 1
+    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mock_query_id, mock_response, expected_status",
+    [
+        (["uuid"], {"status": "success"}, False),
+        (["uuid"], {"status": "error"}, False),
+        (["uuid"], {"status": "running"}, True),
+    ],
+)
+@mock.patch(
+    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
+)
+async def test_snowflake_sql_trigger_is_still_running(
+    mock_get_sql_api_query_status, mock_query_id, mock_response, expected_status
+):
+    mock_get_sql_api_query_status.return_value = mock_response
+    trigger = SnowflakeSqlApiTrigger(
+        poll_interval=POLLING_PERIOD_SECONDS,
+        query_ids=mock_query_id,
+        snowflake_conn_id="test_conn",
+        token_life_time=LIFETIME,
+        token_renewal_delta=RENEWAL_DELTA,
+    )
+    response = await trigger.is_still_running(mock_query_id)
+    assert response == expected_status


### PR DESCRIPTION
Implemented Async Snowflake SQL API Operator to support multiple  SQL statements sequentially, which is the behavior of the SnowflakeOperator,  the Snowflake SQL API allows for submitting multiple SQL statements in a single request. In combination with aiohttp, this may be an option for creating a SnowflakeSQLOperatorAsync that matches the query submission behavior of the SnowflakeOperator.

- [x] Added Snowflake Async SQL API operator, hooks, trigger
- [x] Added Example DAG
- [x] Added Doc string 
- [x] Exception Handling in case of errors
- [x] Added Test case for Hook,  Triggers, Operator
- [x] Added Example Documentation
<img width="1153" alt="Screenshot 2022-07-05 at 12 26 17 AM" src="https://user-images.githubusercontent.com/94612827/177206586-3e6ae699-0438-4340-8740-13e743bcce31.png">
<img width="1688" alt="Screenshot 2022-07-07 at 10 05 42 AM" src="https://user-images.githubusercontent.com/94612827/177692190-cfcf5f68-07d1-4dbf-b9a3-05f395014b84.png">



Documentation 
https://www.notion.so/astronomerio/Snowflake-Async-Operators-2a62522b1f534a02bde099b104216c41

closes: #477