### PR TITLE
Implement Azure WasbBlobSensorAsync and WasbPrefixSensorAsync

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -172,11 +172,14 @@ with DAG(
     dag_run_ids.extend(ids)
     chain(*hive_trigger_tasks)
 
-    # microsoft Azure Data factory pipeline DAG
-    adf_pipeline_task_info = [{"adf_pipeline_dag": "example_async_adf_run_pipeline"}]
-    adf_pipeline_trigger_tasks, ids = prepare_dag_dependency(adf_pipeline_task_info, "{{ ds }}")
+    # Microsoft Azure DAGs
+    azure_task_info = [
+        {"wasb_sensors_dag": "example_wasb_sensors"},
+        {"adf_pipeline_dag": "example_async_adf_run_pipeline"},
+    ]
+    azure_trigger_tasks, ids = prepare_dag_dependency(azure_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)
-    chain(*adf_pipeline_trigger_tasks)
+    chain(*azure_trigger_tasks)
 
     report = PythonOperator(
         task_id="get_report",
@@ -201,7 +204,7 @@ with DAG(
         snowflake_trigger_tasks[0],
         livy_trigger_tasks[0],
         hive_trigger_tasks[0],
-        adf_pipeline_trigger_tasks[0],
+        azure_trigger_tasks[0],
     ]
 
     last_task = [
@@ -215,7 +218,7 @@ with DAG(
         snowflake_trigger_tasks[-1],
         livy_trigger_tasks[-1],
         hive_trigger_tasks[-1],
-        adf_pipeline_trigger_tasks[-1],
+        azure_trigger_tasks[-1],
     ]
 
     last_task >> end

--- a/astronomer/providers/microsoft/azure/example_dags/example_azure_test_file.txt
+++ b/astronomer/providers/microsoft/azure/example_dags/example_azure_test_file.txt
@@ -1,0 +1,1 @@
+sample file to upload to Azure Data Storage

--- a/astronomer/providers/microsoft/azure/example_dags/example_wasb_sensors.py
+++ b/astronomer/providers/microsoft/azure/example_dags/example_wasb_sensors.py
@@ -56,7 +56,7 @@ def upload_blob_callable(file_path: str, container_name: str, blob_name: str) ->
     """
     Uploads the given example file as a blob in the given container.
 
-    It raises an exception if the specified name of the blob is less that 10 characters with an interest to test
+    It raises an exception if the specified name of the blob is less than 10 characters with an interest to test
     the WASB Prefix Sensor successfully.
 
     :param file_path: local file path to be uploaded
@@ -154,4 +154,12 @@ with DAG(
     upload_blob >> [wasb_blob_sensor, wasb_prefix_sensor]
     [wasb_blob_sensor, wasb_prefix_sensor] >> delete_blob
     delete_blob >> delete_data_storage_container
-    delete_data_storage_container >> end
+
+    [
+        create_data_storage_container,
+        upload_blob,
+        wasb_blob_sensor,
+        wasb_prefix_sensor,
+        delete_blob,
+        delete_data_storage_container,
+    ] >> end

--- a/astronomer/providers/microsoft/azure/example_dags/example_wasb_sensors.py
+++ b/astronomer/providers/microsoft/azure/example_dags/example_wasb_sensors.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime, timedelta
 
 from airflow import DAG
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 
 from astronomer.providers.microsoft.azure.sensors.wasb import (
@@ -147,7 +148,10 @@ with DAG(
         trigger_rule="all_done",
     )
 
+    end = EmptyOperator(task_id="end")
+
     create_data_storage_container >> upload_blob
     upload_blob >> [wasb_blob_sensor, wasb_prefix_sensor]
     [wasb_blob_sensor, wasb_prefix_sensor] >> delete_blob
     delete_blob >> delete_data_storage_container
+    delete_data_storage_container >> end

--- a/astronomer/providers/microsoft/azure/example_dags/example_wasb_sensors.py
+++ b/astronomer/providers/microsoft/azure/example_dags/example_wasb_sensors.py
@@ -1,0 +1,153 @@
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+from astronomer.providers.microsoft.azure.sensors.wasb import (
+    WasbBlobSensorAsync,
+    WasbPrefixSensorAsync,
+)
+
+AZURE_DATA_STORAGE_BLOB_NAME = os.getenv("AZURE_DATA_STORAGE_BLOB_NAME", "test_blob_providers_team.txt")
+AZURE_DATA_STORAGE_CONTAINER_NAME = os.getenv(
+    "AZURE_DATA_STORAGE_CONTAINER_NAME", "test-container-providers-team"
+)
+AZURE_WASB_CONN_ID = os.getenv("AZURE_WASB_CONN_ID", "wasb_default")
+EXAMPLE_AZURE_TEST_FILE_PATH = "/usr/local/airflow/dags/example_azure_test_file.txt"
+EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
+
+
+default_args = {
+    "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 10))),
+}
+
+
+def create_azure_data_storage_container_callable(container_name: str):
+    """
+    Creates an Azure Data Storage container.
+
+    If a container with the given name already exists, it just logs saying that and does not raise an Exception.
+
+    :param container_name: name of the data storage container to be created
+    """
+    from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
+
+    hook = WasbHook(wasb_conn_id=AZURE_WASB_CONN_ID)
+    hook.create_container(container_name)
+
+
+def delete_azure_data_storage_container_callable(container_name: str):
+    """
+    Deletes the Azure Data Storage container.
+
+    :param container_name: name of the data storage container to be deleted
+    """
+    from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
+
+    hook = WasbHook(wasb_conn_id=AZURE_WASB_CONN_ID)
+    hook.delete_container(container_name)
+
+
+def upload_blob_callable(file_path: str, container_name: str, blob_name: str):
+    """
+    Uploads the given example file as a blob in the given container.
+
+    It raises an exception if the specified name of the blob is less that 10 characters with an interest to test
+    the WASB Prefix Sensor successfully.
+
+    :param file_path: local file path to be uploaded
+    :param container_name: name of the data storage container in which the blob needs to be uploaded
+    :param blob_name: name of the blob the file should be uploaded as in the container
+    """
+    if len(blob_name) < 10:
+        raise ValueError("Blob name of least 10 characters long is recommended to test the 'Prefix Sensor'")
+
+    import logging
+
+    from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
+    from azure.core.exceptions import ResourceExistsError
+
+    hook = WasbHook(wasb_conn_id=AZURE_WASB_CONN_ID)
+    try:
+        hook.load_file(file_path, container_name, blob_name)
+    except ResourceExistsError:
+        logging.warning("Blob exists already")
+
+
+def delete_blob_callable(container_name: str, blob_name: str):
+    """
+    Deletes the blob from the given container.
+
+    :param container_name: name of the container in which to search for the blob to be deleted
+    :param blob_name: name of the blob to be deleted
+    """
+    from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
+
+    hook = WasbHook(wasb_conn_id=AZURE_WASB_CONN_ID)
+    hook.delete_file(container_name, blob_name)
+
+
+with DAG(
+    dag_id="example_wasb_sensors",
+    start_date=datetime(2021, 8, 13),
+    schedule_interval=None,
+    catchup=False,
+    default_args=default_args,
+    tags=["example", "async", "Azure Pipeline"],
+) as dag:
+
+    create_data_storage_container = PythonOperator(
+        task_id="create_data_storage_container",
+        python_callable=create_azure_data_storage_container_callable,
+        op_args=[AZURE_DATA_STORAGE_CONTAINER_NAME],
+    )
+
+    upload_blob = PythonOperator(
+        task_id="upload_blob",
+        python_callable=upload_blob_callable,
+        op_args=[
+            EXAMPLE_AZURE_TEST_FILE_PATH,
+            AZURE_DATA_STORAGE_CONTAINER_NAME,
+            AZURE_DATA_STORAGE_BLOB_NAME,
+        ],
+    )
+
+    # [START howto_sensor_wasb_blob_sensor_async]
+    wasb_blob_sensor = WasbBlobSensorAsync(
+        task_id="wasb_blob_sensor",
+        container_name=AZURE_DATA_STORAGE_CONTAINER_NAME,
+        blob_name=AZURE_DATA_STORAGE_BLOB_NAME,
+        wasb_conn_id=AZURE_WASB_CONN_ID,
+    )
+    # [END howto_sensor_wasb_blob_sensor_async]
+
+    # [START howto_sensor_wasb_prefix_sensor_async]
+    wasb_prefix_sensor = WasbPrefixSensorAsync(
+        task_id="wasb_prefix_sensor",
+        container_name=AZURE_DATA_STORAGE_CONTAINER_NAME,
+        prefix=AZURE_DATA_STORAGE_BLOB_NAME[:10],
+        wasb_conn_id=AZURE_WASB_CONN_ID,
+    )
+    # [END howto_sensor_wasb_prefix_sensor_async]
+
+    delete_blob = PythonOperator(
+        task_id="delete_blob",
+        python_callable=delete_blob_callable,
+        op_args=[AZURE_DATA_STORAGE_CONTAINER_NAME, AZURE_DATA_STORAGE_BLOB_NAME],
+        trigger_rule="all_done",
+    )
+
+    delete_data_storage_container = PythonOperator(
+        task_id="delete_data_storage_container",
+        python_callable=delete_azure_data_storage_container_callable,
+        op_args=[AZURE_DATA_STORAGE_CONTAINER_NAME],
+        trigger_rule="all_done",
+    )
+
+    create_data_storage_container >> upload_blob
+    upload_blob >> [wasb_blob_sensor, wasb_prefix_sensor]
+    [wasb_blob_sensor, wasb_prefix_sensor] >> delete_blob
+    delete_blob >> delete_data_storage_container

--- a/astronomer/providers/microsoft/azure/example_dags/example_wasb_sensors.py
+++ b/astronomer/providers/microsoft/azure/example_dags/example_wasb_sensors.py
@@ -25,7 +25,7 @@ default_args = {
 }
 
 
-def create_azure_data_storage_container_callable(container_name: str):
+def create_azure_data_storage_container_callable(container_name: str) -> None:
     """
     Creates an Azure Data Storage container.
 
@@ -39,7 +39,7 @@ def create_azure_data_storage_container_callable(container_name: str):
     hook.create_container(container_name)
 
 
-def delete_azure_data_storage_container_callable(container_name: str):
+def delete_azure_data_storage_container_callable(container_name: str) -> None:
     """
     Deletes the Azure Data Storage container.
 
@@ -51,7 +51,7 @@ def delete_azure_data_storage_container_callable(container_name: str):
     hook.delete_container(container_name)
 
 
-def upload_blob_callable(file_path: str, container_name: str, blob_name: str):
+def upload_blob_callable(file_path: str, container_name: str, blob_name: str) -> None:
     """
     Uploads the given example file as a blob in the given container.
 
@@ -77,7 +77,7 @@ def upload_blob_callable(file_path: str, container_name: str, blob_name: str):
         logging.warning("Blob exists already")
 
 
-def delete_blob_callable(container_name: str, blob_name: str):
+def delete_blob_callable(container_name: str, blob_name: str) -> None:
     """
     Deletes the blob from the given container.
 

--- a/astronomer/providers/microsoft/azure/hooks/wasb.py
+++ b/astronomer/providers/microsoft/azure/hooks/wasb.py
@@ -94,8 +94,6 @@ class WasbHookAsync(WasbHook):
         :param container_name: name of the container
         :param blob_name: name of the blob
         :param kwargs: optional keyword arguments for ``BlobClient.get_blob_properties`` takes
-        :return: True if the blob exists, False otherwise
-        :rtype: bool
         """
         try:
             await self._get_blob_client(container_name, blob_name).get_blob_properties(**kwargs)
@@ -108,7 +106,6 @@ class WasbHookAsync(WasbHook):
         Instantiates a container client.
 
         :param container_name: the name of the container
-        :return: ContainerClient
         """
         return self.blob_service_client.get_container_client(container_name)
 
@@ -145,8 +142,6 @@ class WasbHookAsync(WasbHook):
         :param container_name: Name of the container.
         :param prefix: Prefix of the blob.
         :param kwargs: Optional keyword arguments that ``ContainerClient.walk_blobs`` takes
-        :return: True if blobs matching the prefix exist, False otherwise.
-        :rtype: bool
         """
         blobs = await self.get_blobs_list(container_name=container_name, prefix=prefix, **kwargs)
         return len(blobs) > 0

--- a/astronomer/providers/microsoft/azure/hooks/wasb.py
+++ b/astronomer/providers/microsoft/azure/hooks/wasb.py
@@ -1,8 +1,9 @@
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity.aio import ClientSecretCredential, DefaultAzureCredential
+from azure.storage.blob._models import BlobProperties
 from azure.storage.blob.aio import BlobClient, BlobServiceClient, ContainerClient
 
 Credentials = Union[ClientSecretCredential, DefaultAzureCredential]
@@ -84,7 +85,9 @@ class WasbHookAsync(WasbHook):
         """
         return self.blob_service_client.get_blob_client(container=container_name, blob=blob_name)
 
-    async def check_for_blob(self, container_name: str, blob_name: str, **kwargs) -> bool:
+    async def check_for_blob(  # type: ignore[override]
+        self, container_name: str, blob_name: str, **kwargs: Any
+    ) -> bool:
         """
         Check if a blob exists on Azure Blob Storage.
 
@@ -109,14 +112,14 @@ class WasbHookAsync(WasbHook):
         """
         return self.blob_service_client.get_container_client(container_name)
 
-    async def get_blobs_list(
+    async def get_blobs_list(  # type: ignore[override]
         self,
         container_name: str,
         prefix: Optional[str] = None,
         include: Optional[List[str]] = None,
         delimiter: Optional[str] = "/",
-        **kwargs,
-    ) -> List:
+        **kwargs: Any,
+    ) -> List[BlobProperties]:
         """
         List blobs in a given container.
 
@@ -135,7 +138,7 @@ class WasbHookAsync(WasbHook):
             blob_list.append(blob.name)
         return blob_list
 
-    async def check_for_prefix(self, container_name: str, prefix: str, **kwargs):
+    async def check_for_prefix(self, container_name: str, prefix: str, **kwargs: Any) -> bool:
         """
         Check if a prefix exists on Azure Blob storage.
 

--- a/astronomer/providers/microsoft/azure/hooks/wasb.py
+++ b/astronomer/providers/microsoft/azure/hooks/wasb.py
@@ -93,7 +93,7 @@ class WasbHookAsync(WasbHook):
 
         :param container_name: name of the container
         :param blob_name: name of the blob
-        :param kwargs: optional keyword arguments for ``BlobClient.get_blob_properties`` takes
+        :param kwargs: optional keyword arguments for ``BlobClient.get_blob_properties``
         """
         try:
             await self._get_blob_client(container_name, blob_name).get_blob_properties(**kwargs)
@@ -141,7 +141,7 @@ class WasbHookAsync(WasbHook):
 
         :param container_name: Name of the container.
         :param prefix: Prefix of the blob.
-        :param kwargs: Optional keyword arguments that ``ContainerClient.walk_blobs`` takes
+        :param kwargs: Optional keyword arguments for ``ContainerClient.walk_blobs``
         """
         blobs = await self.get_blobs_list(container_name=container_name, prefix=prefix, **kwargs)
         return len(blobs) > 0

--- a/astronomer/providers/microsoft/azure/hooks/wasb.py
+++ b/astronomer/providers/microsoft/azure/hooks/wasb.py
@@ -1,0 +1,149 @@
+from typing import List, Optional, Union
+
+from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
+from azure.core.exceptions import ResourceNotFoundError
+from azure.identity.aio import ClientSecretCredential, DefaultAzureCredential
+from azure.storage.blob.aio import BlobClient, BlobServiceClient, ContainerClient
+
+Credentials = Union[ClientSecretCredential, DefaultAzureCredential]
+
+
+class WasbHookAsync(WasbHook):
+    """
+    An async hook that connects to Azure WASB to perform operations.
+
+    :param wasb_conn_id: reference to the :ref:`wasb connection <howto/connection:wasb>`
+    :param public_read: whether an anonymous public read access should be used. default is False
+    """
+
+    def __init__(
+        self,
+        wasb_conn_id: str = "wasb_default",
+        public_read: bool = False,
+    ) -> None:
+        super().__init__()
+        self.conn_id = wasb_conn_id
+        self.public_read = public_read
+        self.blob_service_client = self.get_conn()
+
+    def get_conn(self) -> BlobServiceClient:
+        """Returns the async BlobServiceClient object."""
+        conn = self.get_connection(self.conn_id)
+        extra = conn.extra_dejson or {}
+
+        if self.public_read:
+            # Here we use anonymous public read
+            # more info
+            # https://docs.microsoft.com/en-us/azure/storage/blobs/storage-manage-access-to-resources
+            return BlobServiceClient(account_url=conn.host, **extra)
+
+        connection_string = extra.pop("connection_string", extra.pop("extra__wasb__connection_string", None))
+        if connection_string:
+            # connection_string auth takes priority
+            return BlobServiceClient.from_connection_string(connection_string, **extra)
+
+        shared_access_key = extra.pop("shared_access_key", extra.pop("extra__wasb__shared_access_key", None))
+        if shared_access_key:
+            # using shared access key
+            return BlobServiceClient(account_url=conn.host, credential=shared_access_key, **extra)
+
+        tenant = extra.pop("tenant_id", extra.pop("extra__wasb__tenant_id", None))
+        if tenant:
+            # use Active Directory auth
+            app_id = conn.login
+            app_secret = conn.password
+            token_credential = ClientSecretCredential(tenant, app_id, app_secret)
+            return BlobServiceClient(account_url=conn.host, credential=token_credential, **extra)
+
+        sas_token = extra.pop("sas_token", extra.pop("extra__wasb__sas_token", None))
+        if sas_token:
+            if sas_token.startswith("https"):
+                return BlobServiceClient(account_url=sas_token, **extra)
+            else:
+                return BlobServiceClient(
+                    account_url=f"https://{conn.login}.blob.core.windows.net/{sas_token}", **extra
+                )
+
+        # Fall back to old auth (password) or use managed identity if not provided.
+        credential = conn.password
+        if not credential:
+            credential = DefaultAzureCredential()
+            self.log.info("Using DefaultAzureCredential as credential")
+        return BlobServiceClient(
+            account_url=f"https://{conn.login}.blob.core.windows.net/",
+            credential=credential,
+            **extra,
+        )
+
+    def _get_blob_client(self, container_name: str, blob_name: str) -> BlobClient:
+        """
+        Instantiates a blob client.
+
+        :param container_name: the name of the blob container
+        :param blob_name: the name of the blob. This needs not be existing
+        """
+        return self.blob_service_client.get_blob_client(container=container_name, blob=blob_name)
+
+    async def check_for_blob(self, container_name: str, blob_name: str, **kwargs) -> bool:
+        """
+        Check if a blob exists on Azure Blob Storage.
+
+        :param container_name: name of the container
+        :param blob_name: name of the blob
+        :param kwargs: optional keyword arguments for ``BlobClient.get_blob_properties`` takes
+        :return: True if the blob exists, False otherwise
+        :rtype: bool
+        """
+        try:
+            await self._get_blob_client(container_name, blob_name).get_blob_properties(**kwargs)
+        except ResourceNotFoundError:
+            return False
+        return True
+
+    def _get_container_client(self, container_name: str) -> ContainerClient:
+        """
+        Instantiates a container client.
+
+        :param container_name: the name of the container
+        :return: ContainerClient
+        """
+        return self.blob_service_client.get_container_client(container_name)
+
+    async def get_blobs_list(
+        self,
+        container_name: str,
+        prefix: Optional[str] = None,
+        include: Optional[List[str]] = None,
+        delimiter: Optional[str] = "/",
+        **kwargs,
+    ) -> List:
+        """
+        List blobs in a given container.
+
+        :param container_name: the name of the container
+        :param prefix: filters the results to return only blobs whose names
+            begin with the specified prefix.
+        :param include: specifies one or more additional datasets to include in the
+            response. Options include: ``snapshots``, ``metadata``, ``uncommittedblobs``,
+            ``copy`, ``deleted``.
+        :param delimiter: filters objects based on the delimiter (for e.g '.csv')
+        """
+        container = self._get_container_client(container_name)
+        blob_list = []
+        blobs = container.walk_blobs(name_starts_with=prefix, include=include, delimiter=delimiter, **kwargs)
+        async for blob in blobs:
+            blob_list.append(blob.name)
+        return blob_list
+
+    async def check_for_prefix(self, container_name: str, prefix: str, **kwargs):
+        """
+        Check if a prefix exists on Azure Blob storage.
+
+        :param container_name: Name of the container.
+        :param prefix: Prefix of the blob.
+        :param kwargs: Optional keyword arguments that ``ContainerClient.walk_blobs`` takes
+        :return: True if blobs matching the prefix exist, False otherwise.
+        :rtype: bool
+        """
+        blobs = await self.get_blobs_list(container_name=container_name, prefix=prefix, **kwargs)
+        return len(blobs) > 0

--- a/astronomer/providers/microsoft/azure/sensors/wasb.py
+++ b/astronomer/providers/microsoft/azure/sensors/wasb.py
@@ -15,7 +15,7 @@ from astronomer.providers.microsoft.azure.triggers.wasb import (
 
 class WasbBlobSensorAsync(WasbBlobSensor):
     """
-    Polls for the existence of a blob of in a container of WASB.
+    Polls asynchronously for the existence of a blob in a WASB container.
 
     :param container_name: name of the container in which the blob should be searched for
     :param blob_name: name of the blob to check existence for
@@ -66,12 +66,12 @@ class WasbBlobSensorAsync(WasbBlobSensor):
                 raise AirflowException(event["message"])
             self.log.info(event["message"])
         else:
-            raise AirflowException("Did not receive valid event from the trigerrer")
+            raise AirflowException("Did not receive valid event from the triggerer")
 
 
 class WasbPrefixSensorAsync(WasbPrefixSensor):
     """
-    Polls for the existence of a blob of in a container of WASB.
+     Polls asynchronously for the existence of a blob having the given prefix in a WASB container.
 
     :param container_name: name of the container in which the blob should be searched for
     :param blob_name: name of the blob to check existence for
@@ -132,4 +132,4 @@ class WasbPrefixSensorAsync(WasbPrefixSensor):
                 raise AirflowException(event["message"])
             self.log.info(event["message"])
         else:
-            raise AirflowException("Did not receive valid event from the trigerrer")
+            raise AirflowException("Did not receive valid event from the triggerer")

--- a/astronomer/providers/microsoft/azure/sensors/wasb.py
+++ b/astronomer/providers/microsoft/azure/sensors/wasb.py
@@ -1,0 +1,133 @@
+from typing import Any, Dict, List, Optional
+
+from airflow import AirflowException
+from airflow.providers.microsoft.azure.sensors.wasb import (
+    WasbBlobSensor,
+    WasbPrefixSensor,
+)
+from airflow.utils.context import Context
+
+from astronomer.providers.microsoft.azure.triggers.wasb import (
+    WasbBlobSensorTrigger,
+    WasbPrefixSensorTrigger,
+)
+
+
+class WasbBlobSensorAsync(WasbBlobSensor):
+    """
+    Polls for the existence of a blob of in a container of WASB.
+
+    :param container_name: name of the container in which the blob should be searched for
+    :param blob_name: name of the blob to check existence for
+    :param wasb_conn_id: the connection identifier for connecting to Azure WASB
+    :param poll_interval:  polling period in seconds to check for the status
+    :param public_read: whether an anonymous public read access should be used. Default is False
+    """
+
+    def __init__(
+        self,
+        *,
+        container_name: str,
+        blob_name: str,
+        wasb_conn_id: str = "wasb_default",
+        public_read: bool = False,
+        poll_interval: float = 5.0,
+        **kwargs: Any,
+    ):
+        self.container_name = container_name
+        self.blob_name = blob_name
+        super().__init__(container_name=container_name, blob_name=blob_name, **kwargs)
+        self.wasb_conn_id = wasb_conn_id
+        self.public_read = public_read
+        self.poll_interval = poll_interval
+
+    def execute(self, context: Context) -> None:
+        """Defers trigger class to poll for state of the job run until it reaches a failure state or success state"""
+        self.defer(
+            timeout=self.execution_timeout,
+            trigger=WasbBlobSensorTrigger(
+                container_name=self.container_name,
+                blob_name=self.blob_name,
+                wasb_conn_id=self.wasb_conn_id,
+                public_read=self.public_read,
+                poll_interval=self.poll_interval,
+            ),
+            method_name="execute_complete",
+        )
+
+    def execute_complete(self, context: Dict[Any, Any], event: Dict[str, str]) -> None:
+        """
+        Callback for when the trigger fires - returns immediately.
+        Relies on trigger to throw an exception, otherwise it assumes execution was
+        successful.
+        """
+        if event:
+            if event["status"] == "error":
+                raise AirflowException(event["message"])
+            self.log.info(event["message"])
+        return None
+
+
+class WasbPrefixSensorAsync(WasbPrefixSensor):
+    """
+    Polls for the existence of a blob of in a container of WASB.
+
+    :param container_name: name of the container in which the blob should be searched for
+    :param blob_name: name of the blob to check existence for
+    :param include: specifies one or more additional datasets to include in the
+            response. Options include: ``snapshots``, ``metadata``, ``uncommittedblobs``,
+            ``copy`, ``deleted``
+    :param delimiter: filters objects based on the delimiter (for e.g '.csv')
+    :param wasb_conn_id: the connection identifier for connecting to Azure WASB
+    :param poll_interval:  polling period in seconds to check for the status
+    :param public_read: whether an anonymous public read access should be used. Default is False
+    """
+
+    def __init__(
+        self,
+        *,
+        container_name: str,
+        prefix: str,
+        include: Optional[List[str]] = None,
+        delimiter: Optional[str] = "/",
+        wasb_conn_id: str = "wasb_default",
+        public_read: bool = False,
+        poll_interval: float = 5.0,
+        **kwargs: Any,
+    ):
+        super().__init__(container_name=container_name, prefix=prefix, **kwargs)
+        self.container_name = container_name
+        self.prefix = prefix
+        self.include = include
+        self.delimiter = delimiter
+        self.wasb_conn_id = wasb_conn_id
+        self.public_read = public_read
+        self.poll_interval = poll_interval
+
+    def execute(self, context: Context) -> None:
+        """Defers trigger class to poll for state of the job run until it reaches a failure state or success state"""
+        self.defer(
+            timeout=self.execution_timeout,
+            trigger=WasbPrefixSensorTrigger(
+                container_name=self.container_name,
+                prefix=self.prefix,
+                include=self.include,
+                delimiter=self.delimiter,
+                wasb_conn_id=self.wasb_conn_id,
+                public_read=self.public_read,
+                poll_interval=self.poll_interval,
+            ),
+            method_name="execute_complete",
+        )
+
+    def execute_complete(self, context: Dict[Any, Any], event: Dict[str, str]) -> None:
+        """
+        Callback for when the trigger fires - returns immediately.
+        Relies on trigger to throw an exception, otherwise it assumes execution was
+        successful.
+        """
+        if event:
+            if event["status"] == "error":
+                raise AirflowException(event["message"])
+            self.log.info(event["message"])
+        return None

--- a/astronomer/providers/microsoft/azure/sensors/wasb.py
+++ b/astronomer/providers/microsoft/azure/sensors/wasb.py
@@ -65,7 +65,8 @@ class WasbBlobSensorAsync(WasbBlobSensor):
             if event["status"] == "error":
                 raise AirflowException(event["message"])
             self.log.info(event["message"])
-        return None
+        else:
+            raise AirflowException("Did not receive valid event from the trigerrer")
 
 
 class WasbPrefixSensorAsync(WasbPrefixSensor):
@@ -130,4 +131,5 @@ class WasbPrefixSensorAsync(WasbPrefixSensor):
             if event["status"] == "error":
                 raise AirflowException(event["message"])
             self.log.info(event["message"])
-        return None
+        else:
+            raise AirflowException("Did not receive valid event from the trigerrer")

--- a/astronomer/providers/microsoft/azure/triggers/wasb.py
+++ b/astronomer/providers/microsoft/azure/triggers/wasb.py
@@ -73,8 +73,8 @@ class WasbBlobSensorTrigger(BaseTrigger):
 
 class WasbPrefixSensorTrigger(BaseTrigger):
     """
-    WasbPrefixSensorTrigger is fired as deferred class with params to run the task in trigger worker to check for
-    existence of a blob with the given prefix in the provided container.
+    WasbPrefixSensorTrigger is fired as a deferred class with params to run the task in trigger worker.
+    It checks for the existence of a blob with the given prefix in the provided container.
 
     :param container_name: name of the container in which the blob should be searched for
     :param prefix: prefix of the blob to check existence for

--- a/astronomer/providers/microsoft/azure/triggers/wasb.py
+++ b/astronomer/providers/microsoft/azure/triggers/wasb.py
@@ -1,0 +1,148 @@
+import asyncio
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
+
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+from astronomer.providers.microsoft.azure.hooks.wasb import WasbHookAsync
+
+
+class WasbBlobSensorTrigger(BaseTrigger):
+    """
+    WasbBlobSensorTrigger is fired as deferred class with params to run the task in trigger worker to check for
+    existence of the given blob in the provided container.
+
+    :param container_name: name of the container in which the blob should be searched for
+    :param blob_name: name of the blob to check existence for
+    :param wasb_conn_id: the connection identifier for connecting to Azure WASB
+    :param poll_interval:  polling period in seconds to check for the status
+    :param public_read: whether an anonymous public read access should be used. Default is False
+    """
+
+    def __init__(
+        self,
+        container_name: str,
+        blob_name: str,
+        wasb_conn_id: str = "wasb_default",
+        public_read: bool = False,
+        poll_interval: float = 5.0,
+    ):
+        super().__init__()
+        self.container_name = container_name
+        self.blob_name = blob_name
+        self.wasb_conn_id = wasb_conn_id
+        self.poll_interval = poll_interval
+        self.public_read = public_read
+
+    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+        """Serializes WasbBlobSensorTrigger arguments and classpath."""
+        return (
+            "astronomer.providers.microsoft.azure.triggers.wasb.WasbBlobSensorTrigger",
+            {
+                "container_name": self.container_name,
+                "blob_name": self.blob_name,
+                "wasb_conn_id": self.wasb_conn_id,
+                "poll_interval": self.poll_interval,
+                "public_read": self.public_read,
+            },
+        )
+
+    async def run(self) -> AsyncIterator["TriggerEvent"]:  # type: ignore[override]
+        """Makes async connection to Azure WASB and polls for existence of the given blob name."""
+        blob_exists = False
+        hook = WasbHookAsync(wasb_conn_id=self.wasb_conn_id, public_read=self.public_read)
+        try:
+            async with hook.blob_service_client:
+                while not blob_exists:
+                    blob_exists = await hook.check_for_blob(
+                        container_name=self.container_name,
+                        blob_name=self.blob_name,
+                    )
+                    if blob_exists:
+                        message = f"Blob {self.blob_name} found in container {self.container_name}."
+                        yield TriggerEvent({"status": "success", "message": message})
+                    else:
+                        message = (
+                            f"Blob {self.blob_name} not available yet in container {self.container_name}."
+                            f" Sleeping for {self.poll_interval} seconds"
+                        )
+                        self.log.info(message)
+                        await asyncio.sleep(self.poll_interval)
+        except Exception as e:
+            yield TriggerEvent({"status": "error", "message": str(e)})
+
+
+class WasbPrefixSensorTrigger(BaseTrigger):
+    """
+    WasbPrefixSensorTrigger is fired as deferred class with params to run the task in trigger worker to check for
+    existence of a blob with the given prefix in the provided container.
+
+    :param container_name: name of the container in which the blob should be searched for
+    :param prefix: prefix of the blob to check existence for
+    :param include: specifies one or more additional datasets to include in the
+            response. Options include: ``snapshots``, ``metadata``, ``uncommittedblobs``,
+            ``copy`, ``deleted``
+    :param delimiter: filters objects based on the delimiter (for e.g '.csv')
+    :param wasb_conn_id: the connection identifier for connecting to Azure WASB
+    :param poll_interval:  polling period in seconds to check for the status
+    :param public_read: whether an anonymous public read access should be used. Default is False
+    """
+
+    def __init__(
+        self,
+        container_name: str,
+        prefix: str,
+        include: Optional[List[str]] = None,
+        delimiter: Optional[str] = "/",
+        wasb_conn_id: str = "wasb_default",
+        public_read: bool = False,
+        poll_interval: float = 5.0,
+    ):
+        super().__init__()
+        self.container_name = container_name
+        self.prefix = prefix
+        self.include = include
+        self.delimiter = delimiter
+        self.wasb_conn_id = wasb_conn_id
+        self.poll_interval = poll_interval
+        self.public_read = public_read
+
+    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+        """Serializes WasbPrefixSensorTrigger arguments and classpath."""
+        return (
+            "astronomer.providers.microsoft.azure.triggers.wasb.WasbPrefixSensorTrigger",
+            {
+                "container_name": self.container_name,
+                "prefix": self.prefix,
+                "include": self.include,
+                "delimiter": self.delimiter,
+                "wasb_conn_id": self.wasb_conn_id,
+                "poll_interval": self.poll_interval,
+                "public_read": self.public_read,
+            },
+        )
+
+    async def run(self) -> AsyncIterator["TriggerEvent"]:  # type: ignore[override]
+        """Makes async connection to Azure WASB and polls for existence of a blob with given prefix."""
+        prefix_exists = False
+        hook = WasbHookAsync(wasb_conn_id=self.wasb_conn_id, public_read=self.public_read)
+        try:
+            async with hook.blob_service_client:
+                while not prefix_exists:
+                    prefix_exists = await hook.check_for_prefix(
+                        container_name=self.container_name,
+                        prefix=self.prefix,
+                        include=self.include,
+                        delimiter=self.delimiter,
+                    )
+                    if prefix_exists:
+                        message = f"Prefix {self.prefix} found in container {self.container_name}."
+                        yield TriggerEvent({"status": "success", "message": message})
+                    else:
+                        message = (
+                            f"Prefix {self.prefix} not available yet in container {self.container_name}."
+                            f" Sleeping for {self.poll_interval} seconds"
+                        )
+                        self.log.info(message)
+                        await asyncio.sleep(self.poll_interval)
+        except Exception as e:
+            yield TriggerEvent({"status": "error", "message": str(e)})

--- a/tests/microsoft/azure/hooks/test_wasb.py
+++ b/tests/microsoft/azure/hooks/test_wasb.py
@@ -120,24 +120,44 @@ class TestWasbHookAsyncConnection:
         )
 
     def test_key(self):
+        """
+        Tests that a db connection gets created successfully for a given login/password pair and
+        that the hook is able to use this connection to generate a BlobServiceClient.
+        """
         hook = WasbHookAsync(wasb_conn_id="wasb_test_key")
         assert hook.conn_id == "wasb_test_key"
         assert isinstance(hook.blob_service_client, BlobServiceClient)
 
     def test_public_read(self):
+        """
+        Tests that a db connection gets created successfully for anonymous public access read and
+        that the hook is able to use this connection to generate a BlobServiceClient.
+        """
         hook = WasbHookAsync(wasb_conn_id=self.public_read_conn_id, public_read=True)
         assert isinstance(hook.get_conn(), BlobServiceClient)
 
     def test_connection_string(self):
+        """
+        Tests that a db connection gets created successfully from a connection string and
+        that the hook is able to use this connection to generate a BlobServiceClient.
+        """
         hook = WasbHookAsync(wasb_conn_id=self.connection_string_id)
         assert hook.conn_id == self.connection_string_id
         assert isinstance(hook.get_conn(), BlobServiceClient)
 
     def test_shared_key_connection(self):
+        """
+        Tests that a db connection gets created successfully with the given shared access key and
+        that the hook is able to use this connection to generate a BlobServiceClient.
+        """
         hook = WasbHookAsync(wasb_conn_id=self.shared_key_conn_id)
         assert isinstance(hook.get_conn(), BlobServiceClient)
 
     def test_managed_identity(self):
+        """
+        Tests that a db connection gets created successfully with a managed identity and
+        that the hook is able to use this connection to generate a BlobServiceClient.
+        """
         hook = WasbHookAsync(wasb_conn_id=self.managed_identity_conn_id)
         assert isinstance(hook.get_conn(), BlobServiceClient)
         assert isinstance(hook.get_conn().credential, DefaultAzureCredential)
@@ -152,6 +172,10 @@ class TestWasbHookAsyncConnection:
         ],
     )
     def test_sas_token_connection(self, conn_id_str, extra_key):
+        """
+        Tests that a db connection gets created successfully with the given SAS tokens and
+        that the hook is able to use this connection to generate a BlobServiceClient.
+        """
         conn_id = self.__getattribute__(conn_id_str)
         hook = WasbHookAsync(wasb_conn_id=conn_id)
         conn = hook.get_conn()
@@ -174,12 +198,21 @@ class TestWasbHookAsyncConnection:
         ],
     )
     def test_connection_extra_arguments(self, conn_id_str):
+        """
+        Tests that the db connections are created with the correct extra arguments provided.
+        Proxies are given as part of the extras while creating the connections and the same
+        are tested that they get attached properly to the connections.
+        """
         conn_id = self.__getattribute__(conn_id_str)
         hook = WasbHookAsync(wasb_conn_id=conn_id)
         conn = hook.get_conn()
         assert conn._config.proxy_policy.proxies == self.proxies
 
     def test_connection_extra_arguments_public_read(self):
+        """
+        Tests that the provided extra_arguments (in this case, proxies) are rightly
+        attached to the public_read connection.
+        """
         conn_id = self.public_read_conn_id
         hook = WasbHookAsync(wasb_conn_id=conn_id, public_read=True)
         conn = hook.get_conn()
@@ -213,7 +246,7 @@ class BlobPropertiesAsyncIterator(BlobProperties):
 )
 @mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.BlobServiceClient")
 async def test_check_for_blob(mock_service_client, mock_blob_properties, expected_result):
-    """Test check_for_blob function with mocked response"""
+    """Tests check_for_blob function with mocked response."""
     hook = WasbHookAsync(wasb_conn_id=TEST_WASB_CONN_ID)
     mock_blob_client = mock_service_client.return_value.get_blob_client
 
@@ -244,6 +277,7 @@ async def test_check_for_blob(mock_service_client, mock_blob_properties, expecte
 )
 @mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.BlobServiceClient")
 async def test_check_for_prefix(mock_service_client, blobs, expected_result):
+    """Test check_for_prefix function with mocked response."""
     hook = WasbHookAsync(wasb_conn_id=TEST_WASB_CONN_ID)
     mock_container_client = mock_service_client.return_value.get_container_client
 

--- a/tests/microsoft/azure/hooks/test_wasb.py
+++ b/tests/microsoft/azure/hooks/test_wasb.py
@@ -1,0 +1,257 @@
+import json
+from asyncio import Future
+from unittest import mock
+
+import pytest
+from airflow.models import Connection
+from airflow.utils import db
+from azure.core.exceptions import ResourceNotFoundError
+from azure.identity.aio._credentials import DefaultAzureCredential
+from azure.storage.blob._models import BlobProperties
+
+from astronomer.providers.microsoft.azure.hooks.wasb import (
+    BlobServiceClient,
+    WasbHookAsync,
+)
+
+TEST_DATA_STORAGE_BLOB_NAME = "test_blob_providers_team.txt"
+TEST_DATA_STORAGE_CONTAINER_NAME = "test-container-providers-team"
+TEST_DATA_STORAGE_BLOB_PREFIX = TEST_DATA_STORAGE_BLOB_NAME[:10]
+
+CONN_STRING = (
+    "DefaultEndpointsProtocol=https;AccountName=testname;AccountKey=wK7BOz;EndpointSuffix=core.windows.net"
+)
+TEST_CONNECTION_TYPE = "wasb"
+TEST_WASB_CONN_ID = "wasb_default"
+TEST_CONNECTION_PROXIES = {"http": "http_proxy_uri", "https": "https_proxy_uri"}
+
+
+class TestWasbHookAsyncConnection:
+    def setup(self):
+        db.merge_conn(Connection(conn_id="wasb_test_key", conn_type="wasb", login="login", password="key"))
+        self.connection_type = "wasb"
+        self.connection_string_id = "azure_test_connection_string"
+        self.shared_key_conn_id = "azure_shared_key_test"
+        self.ad_conn_id = "azure_AD_test"
+        self.sas_conn_id = "sas_token_id"
+        self.extra__wasb__sas_conn_id = "extra__sas_token_id"
+        self.http_sas_conn_id = "http_sas_token_id"
+        self.extra__wasb__http_sas_conn_id = "extra__http_sas_token_id"
+        self.public_read_conn_id = "pub_read_id"
+        self.managed_identity_conn_id = "managed_identity"
+
+        self.proxies = {"http": "http_proxy_uri", "https": "https_proxy_uri"}
+
+        db.merge_conn(
+            Connection(
+                conn_id=self.public_read_conn_id,
+                conn_type=self.connection_type,
+                host="https://accountname.blob.core.windows.net",
+                extra=json.dumps({"proxies": self.proxies}),
+            )
+        )
+
+        db.merge_conn(
+            Connection(
+                conn_id=self.connection_string_id,
+                conn_type=self.connection_type,
+                extra=json.dumps({"connection_string": CONN_STRING, "proxies": self.proxies}),
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id=self.shared_key_conn_id,
+                conn_type=self.connection_type,
+                host="https://accountname.blob.core.windows.net",
+                extra=json.dumps({"shared_access_key": "token", "proxies": self.proxies}),
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id=self.ad_conn_id,
+                conn_type=self.connection_type,
+                host="conn_host",
+                login="appID",
+                password="appsecret",
+                extra=json.dumps({"tenant_id": "token", "proxies": self.proxies}),
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id=self.managed_identity_conn_id,
+                conn_type=self.connection_type,
+                extra=json.dumps({"proxies": self.proxies}),
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id=self.sas_conn_id,
+                conn_type=self.connection_type,
+                extra=json.dumps({"sas_token": "token", "proxies": self.proxies}),
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id=self.extra__wasb__sas_conn_id,
+                conn_type=self.connection_type,
+                extra=json.dumps({"extra__wasb__sas_token": "token", "proxies": self.proxies}),
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id=self.http_sas_conn_id,
+                conn_type=self.connection_type,
+                extra=json.dumps(
+                    {"sas_token": "https://login.blob.core.windows.net/token", "proxies": self.proxies}
+                ),
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id=self.extra__wasb__http_sas_conn_id,
+                conn_type=self.connection_type,
+                extra=json.dumps(
+                    {
+                        "extra__wasb__sas_token": "https://login.blob.core.windows.net/token",
+                        "proxies": self.proxies,
+                    }
+                ),
+            )
+        )
+
+    def test_key(self):
+        hook = WasbHookAsync(wasb_conn_id="wasb_test_key")
+        assert hook.conn_id == "wasb_test_key"
+        assert isinstance(hook.blob_service_client, BlobServiceClient)
+
+    def test_public_read(self):
+        hook = WasbHookAsync(wasb_conn_id=self.public_read_conn_id, public_read=True)
+        assert isinstance(hook.get_conn(), BlobServiceClient)
+
+    def test_connection_string(self):
+        hook = WasbHookAsync(wasb_conn_id=self.connection_string_id)
+        assert hook.conn_id == self.connection_string_id
+        assert isinstance(hook.get_conn(), BlobServiceClient)
+
+    def test_shared_key_connection(self):
+        hook = WasbHookAsync(wasb_conn_id=self.shared_key_conn_id)
+        assert isinstance(hook.get_conn(), BlobServiceClient)
+
+    def test_managed_identity(self):
+        hook = WasbHookAsync(wasb_conn_id=self.managed_identity_conn_id)
+        assert isinstance(hook.get_conn(), BlobServiceClient)
+        assert isinstance(hook.get_conn().credential, DefaultAzureCredential)
+
+    @pytest.mark.parametrize(
+        argnames="conn_id_str, extra_key",
+        argvalues=[
+            ("sas_conn_id", "sas_token"),
+            ("extra__wasb__sas_conn_id", "extra__wasb__sas_token"),
+            ("http_sas_conn_id", "sas_token"),
+            ("extra__wasb__http_sas_conn_id", "extra__wasb__sas_token"),
+        ],
+    )
+    def test_sas_token_connection(self, conn_id_str, extra_key):
+        conn_id = self.__getattribute__(conn_id_str)
+        hook = WasbHookAsync(wasb_conn_id=conn_id)
+        conn = hook.get_conn()
+        hook_conn = hook.get_connection(hook.conn_id)
+        sas_token = hook_conn.extra_dejson[extra_key]
+        assert isinstance(conn, BlobServiceClient)
+        assert conn.url.endswith(sas_token + "/")
+
+    @pytest.mark.parametrize(
+        argnames="conn_id_str",
+        argvalues=[
+            "connection_string_id",
+            "shared_key_conn_id",
+            "ad_conn_id",
+            "managed_identity_conn_id",
+            "sas_conn_id",
+            "extra__wasb__sas_conn_id",
+            "http_sas_conn_id",
+            "extra__wasb__http_sas_conn_id",
+        ],
+    )
+    def test_connection_extra_arguments(self, conn_id_str):
+        conn_id = self.__getattribute__(conn_id_str)
+        hook = WasbHookAsync(wasb_conn_id=conn_id)
+        conn = hook.get_conn()
+        assert conn._config.proxy_policy.proxies == self.proxies
+
+    def test_connection_extra_arguments_public_read(self):
+        conn_id = self.public_read_conn_id
+        hook = WasbHookAsync(wasb_conn_id=conn_id, public_read=True)
+        conn = hook.get_conn()
+        assert conn._config.proxy_policy.proxies == self.proxies
+
+
+class BlobPropertiesAsyncIterator(BlobProperties):
+    def __init__(self, end_range):
+        self.end = end_range
+        self.start = 0
+        super().__init__(name=str(self.start))
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self.start < self.end:
+            self.start += 1
+            return self
+        else:
+            raise StopAsyncIteration
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mock_blob_properties, expected_result",
+    [
+        (BlobProperties(), True),
+        ("raise_resource_not_found", False),
+    ],
+)
+@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.BlobServiceClient")
+async def test_check_for_blob(mock_service_client, mock_blob_properties, expected_result):
+    """Test check_for_blob function with mocked response"""
+    hook = WasbHookAsync(wasb_conn_id=TEST_WASB_CONN_ID)
+    mock_blob_client = mock_service_client.return_value.get_blob_client
+
+    future = Future()
+    if mock_blob_properties == "raise_resource_not_found":
+        future.set_exception(ResourceNotFoundError())
+    else:
+        future.set_result(mock_blob_properties)
+    mock_blob_client.return_value.get_blob_properties.return_value = future
+    response = await hook.check_for_blob(
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME, blob_name=TEST_DATA_STORAGE_CONTAINER_NAME
+    )
+    assert response == expected_result
+
+    mock_blob_client.assert_called_once_with(
+        container=TEST_DATA_STORAGE_CONTAINER_NAME, blob=TEST_DATA_STORAGE_CONTAINER_NAME
+    )
+    mock_blob_client.return_value.get_blob_properties.assert_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "blobs, expected_result",
+    [
+        (BlobPropertiesAsyncIterator(5), True),
+        (BlobPropertiesAsyncIterator(0), False),
+    ],
+)
+@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.BlobServiceClient")
+async def test_check_for_prefix(mock_service_client, blobs, expected_result):
+    hook = WasbHookAsync(wasb_conn_id=TEST_WASB_CONN_ID)
+    mock_container_client = mock_service_client.return_value.get_container_client
+
+    mock_container_client.return_value.walk_blobs.return_value = blobs
+    response = await hook.check_for_prefix(
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME, prefix=TEST_DATA_STORAGE_BLOB_PREFIX
+    )
+    assert response == expected_result
+
+    mock_container_client.assert_called_once_with(TEST_DATA_STORAGE_CONTAINER_NAME)
+    mock_container_client.return_value.walk_blobs.assert_called()

--- a/tests/microsoft/azure/sensors/test_wasb.py
+++ b/tests/microsoft/azure/sensors/test_wasb.py
@@ -41,7 +41,7 @@ def test_wasb_blob_sensor_async(context):
     [None, {"status": "success", "message": "Job completed"}],
 )
 def test_wasb_blob_sensor_execute_complete_success(event):
-    """Assert execute_complete log success message when trigger fire with target status"""
+    """Assert execute_complete log success message when trigger fire with target status."""
     task = WasbBlobSensorAsync(
         task_id="wasb_blob_sensor_async",
         container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
@@ -51,7 +51,7 @@ def test_wasb_blob_sensor_execute_complete_success(event):
     if not event:
         with pytest.raises(AirflowException) as exception_info:
             task.execute_complete(context=None, event=None)
-        assert exception_info.value.args[0] == "Did not receive valid event from the trigerrer"
+        assert exception_info.value.args[0] == "Did not receive valid event from the triggerer"
     else:
         with mock.patch.object(task.log, "info") as mock_log_info:
             task.execute_complete(context={}, event=event)
@@ -59,7 +59,7 @@ def test_wasb_blob_sensor_execute_complete_success(event):
 
 
 def test_wasb_blob_sensor_execute_complete_failure():
-    """Assert execute_complete method fail"""
+    """Assert execute_complete method raises an exception when the triggerer fires an error event."""
     task = WasbBlobSensorAsync(
         task_id="wasb_blob_sensor_async",
         container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
@@ -86,7 +86,7 @@ def test_wasb_prefix_sensor_async(context):
     [None, {"status": "success", "message": "Job completed"}],
 )
 def test_wasb_prefix_sensor_execute_complete_success(event):
-    """Assert execute_complete log success message when trigger fire with target status"""
+    """Assert execute_complete log success message when trigger fire with target status."""
     task = WasbPrefixSensorAsync(
         task_id="wasb_prefix_sensor_async",
         container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
@@ -96,7 +96,7 @@ def test_wasb_prefix_sensor_execute_complete_success(event):
     if not event:
         with pytest.raises(AirflowException) as exception_info:
             task.execute_complete(context=None, event=None)
-        assert exception_info.value.args[0] == "Did not receive valid event from the trigerrer"
+        assert exception_info.value.args[0] == "Did not receive valid event from the triggerer"
     else:
         with mock.patch.object(task.log, "info") as mock_log_info:
             task.execute_complete(context={}, event=event)
@@ -104,7 +104,7 @@ def test_wasb_prefix_sensor_execute_complete_success(event):
 
 
 def test_wasb_prefix_sensor_execute_complete_failure():
-    """Assert execute_complete method fail"""
+    """Assert execute_complete method raises an exception when the triggerer fires an error event."""
     task = WasbPrefixSensorAsync(
         task_id="wasb_prefix_sensor_async",
         container_name=TEST_DATA_STORAGE_CONTAINER_NAME,

--- a/tests/microsoft/azure/sensors/test_wasb.py
+++ b/tests/microsoft/azure/sensors/test_wasb.py
@@ -1,0 +1,114 @@
+from unittest import mock
+
+import pytest
+from airflow.exceptions import AirflowException, TaskDeferred
+
+from astronomer.providers.microsoft.azure.sensors.wasb import (
+    WasbBlobSensorAsync,
+    WasbPrefixSensorAsync,
+)
+from astronomer.providers.microsoft.azure.triggers.wasb import (
+    WasbBlobSensorTrigger,
+    WasbPrefixSensorTrigger,
+)
+
+TEST_DATA_STORAGE_BLOB_NAME = "test_blob_providers_team.txt"
+TEST_DATA_STORAGE_CONTAINER_NAME = "test-container-providers-team"
+TEST_DATA_STORAGE_BLOB_PREFIX = TEST_DATA_STORAGE_BLOB_NAME[:10]
+
+
+@pytest.fixture
+def context():
+    """Creates an empty context."""
+    context = {}
+    yield context
+
+
+def test_wasb_blob_sensor_async(context):
+    """Assert execute method defer for wasb blob sensor"""
+    task = WasbBlobSensorAsync(
+        task_id="wasb_blob_sensor_async",
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        blob_name=TEST_DATA_STORAGE_BLOB_NAME,
+    )
+    with pytest.raises(TaskDeferred) as exc:
+        task.execute(context)
+    assert isinstance(exc.value.trigger, WasbBlobSensorTrigger), "Trigger is not a WasbBlobSensorTrigger"
+
+
+@pytest.mark.parametrize(
+    "event",
+    [None, {"status": "success", "message": "Job completed"}],
+)
+def test_wasb_blob_sensor_execute_complete_success(event):
+    """Assert execute_complete log success message when trigger fire with target status"""
+    task = WasbBlobSensorAsync(
+        task_id="wasb_blob_sensor_async",
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        blob_name=TEST_DATA_STORAGE_BLOB_NAME,
+    )
+
+    if not event:
+        with pytest.raises(AirflowException) as exception_info:
+            task.execute_complete(context=None, event=None)
+        assert exception_info.value.args[0] == "Did not receive valid event from the trigerrer"
+    else:
+        with mock.patch.object(task.log, "info") as mock_log_info:
+            task.execute_complete(context={}, event=event)
+        mock_log_info.assert_called_with(event["message"])
+
+
+def test_wasb_blob_sensor_execute_complete_failure():
+    """Assert execute_complete method fail"""
+    task = WasbBlobSensorAsync(
+        task_id="wasb_blob_sensor_async",
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        blob_name=TEST_DATA_STORAGE_BLOB_NAME,
+    )
+    with pytest.raises(AirflowException):
+        task.execute_complete(context={}, event={"status": "error", "message": ""})
+
+
+def test_wasb_prefix_sensor_async(context):
+    """Assert execute method defer for wasb prefix sensor"""
+    task = WasbPrefixSensorAsync(
+        task_id="wasb_prefix_sensor_async",
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        prefix=TEST_DATA_STORAGE_BLOB_PREFIX,
+    )
+    with pytest.raises(TaskDeferred) as exc:
+        task.execute(context)
+    assert isinstance(exc.value.trigger, WasbPrefixSensorTrigger), "Trigger is not a WasbPrefixSensorTrigger"
+
+
+@pytest.mark.parametrize(
+    "event",
+    [None, {"status": "success", "message": "Job completed"}],
+)
+def test_wasb_prefix_sensor_execute_complete_success(event):
+    """Assert execute_complete log success message when trigger fire with target status"""
+    task = WasbPrefixSensorAsync(
+        task_id="wasb_prefix_sensor_async",
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        prefix=TEST_DATA_STORAGE_BLOB_NAME,
+    )
+
+    if not event:
+        with pytest.raises(AirflowException) as exception_info:
+            task.execute_complete(context=None, event=None)
+        assert exception_info.value.args[0] == "Did not receive valid event from the trigerrer"
+    else:
+        with mock.patch.object(task.log, "info") as mock_log_info:
+            task.execute_complete(context={}, event=event)
+        mock_log_info.assert_called_with(event["message"])
+
+
+def test_wasb_prefix_sensor_execute_complete_failure():
+    """Assert execute_complete method fail"""
+    task = WasbPrefixSensorAsync(
+        task_id="wasb_prefix_sensor_async",
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        prefix=TEST_DATA_STORAGE_BLOB_NAME,
+    )
+    with pytest.raises(AirflowException):
+        task.execute_complete(context={}, event={"status": "error", "message": ""})

--- a/tests/microsoft/azure/triggers/test_wasb.py
+++ b/tests/microsoft/azure/triggers/test_wasb.py
@@ -1,0 +1,253 @@
+import asyncio
+from unittest import mock
+
+import pytest
+from airflow.triggers.base import TriggerEvent
+
+from astronomer.providers.microsoft.azure.triggers.wasb import (
+    WasbBlobSensorTrigger,
+    WasbPrefixSensorTrigger,
+)
+
+TEST_DATA_STORAGE_BLOB_NAME = "test_blob_providers_team.txt"
+TEST_DATA_STORAGE_CONTAINER_NAME = "test-container-providers-team"
+TEST_DATA_STORAGE_BLOB_PREFIX = TEST_DATA_STORAGE_BLOB_NAME[:10]
+
+TEST_WASB_CONN_ID = "wasb_default"
+POLL_INTERVAL = 5.0
+
+
+def test_wasb_blob_sensor_trigger_serialization():
+    """
+    Asserts that the WasbBlobSensorTrigger correctly serializes its arguments
+    and classpath.
+    """
+    trigger = WasbBlobSensorTrigger(
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        blob_name=TEST_DATA_STORAGE_BLOB_NAME,
+        wasb_conn_id=TEST_WASB_CONN_ID,
+        poll_interval=POLL_INTERVAL,
+    )
+    classpath, kwargs = trigger.serialize()
+    assert classpath == "astronomer.providers.microsoft.azure.triggers.wasb.WasbBlobSensorTrigger"
+    assert kwargs == {
+        "container_name": TEST_DATA_STORAGE_CONTAINER_NAME,
+        "blob_name": TEST_DATA_STORAGE_BLOB_NAME,
+        "wasb_conn_id": TEST_WASB_CONN_ID,
+        "poll_interval": POLL_INTERVAL,
+        "public_read": False,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "blob_exists",
+    [
+        True,
+        False,
+    ],
+)
+@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_blob")
+async def test_wasb_blob_sensor_trigger_running(mock_check_for_blob, blob_exists):
+    """
+    Test if the task is run in trigger successfully.
+    """
+    mock_check_for_blob.return_value = blob_exists
+    trigger = WasbBlobSensorTrigger(
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        blob_name=TEST_DATA_STORAGE_BLOB_NAME,
+        wasb_conn_id=TEST_WASB_CONN_ID,
+        poll_interval=POLL_INTERVAL,
+    )
+    task = asyncio.create_task(trigger.run().__anext__())
+
+    # TriggerEvent was not returned
+    assert task.done() is False
+    asyncio.get_event_loop().stop()
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_blob")
+async def test_wasb_blob_sensor_trigger_success(mock_check_for_blob):
+    """Tests the success state for that the WasbBlobSensorTrigger."""
+    mock_check_for_blob.return_value = True
+    trigger = WasbBlobSensorTrigger(
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        blob_name=TEST_DATA_STORAGE_BLOB_NAME,
+        wasb_conn_id=TEST_WASB_CONN_ID,
+        poll_interval=POLL_INTERVAL,
+    )
+
+    task = asyncio.create_task(trigger.run().__anext__())
+    await asyncio.sleep(0.5)
+
+    # TriggerEvent was returned
+    assert task.done() is True
+    asyncio.get_event_loop().stop()
+
+    message = f"Blob {TEST_DATA_STORAGE_BLOB_NAME} found in container {TEST_DATA_STORAGE_CONTAINER_NAME}."
+    assert task.result() == TriggerEvent({"status": "success", "message": message})
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_blob")
+async def test_wasb_blob_sensor_trigger_waiting_for_blob(mock_check_for_blob):
+    """Tests the WasbBlobSensorTrigger sleeps waiting for the blob to arrive."""
+    mock_check_for_blob.side_effect = [False, True]
+
+    trigger = WasbBlobSensorTrigger(
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        blob_name=TEST_DATA_STORAGE_BLOB_NAME,
+        wasb_conn_id=TEST_WASB_CONN_ID,
+        poll_interval=POLL_INTERVAL,
+    )
+
+    with mock.patch.object(trigger.log, "info") as mock_log_info:
+        task = asyncio.create_task(trigger.run().__anext__())
+
+    await asyncio.sleep(POLL_INTERVAL + 0.5)
+
+    if not task.done():
+        message = (
+            f"Blob {TEST_DATA_STORAGE_BLOB_NAME} not available yet in container {TEST_DATA_STORAGE_CONTAINER_NAME}."
+            f" Sleeping for {POLL_INTERVAL} seconds"
+        )
+        mock_log_info.assert_called_once_with(message)
+    asyncio.get_event_loop().stop()
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_blob")
+async def test_wasb_blob_sensor_trigger_trigger_exception(mock_check_for_blob):
+    """Tests the WasbBlobSensorTrigger yields an error event if there is an exception."""
+    mock_check_for_blob.side_effect = Exception("Test exception")
+
+    trigger = WasbBlobSensorTrigger(
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        blob_name=TEST_DATA_STORAGE_BLOB_NAME,
+        wasb_conn_id=TEST_WASB_CONN_ID,
+        poll_interval=POLL_INTERVAL,
+    )
+
+    task = [i async for i in trigger.run()]
+    assert len(task) == 1
+    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+
+
+def test_wasb_prefix_sensor_trigger_serialization():
+    """
+    Asserts that the WasbPrefixSensorTrigger correctly serializes its arguments
+    and classpath.
+    """
+    trigger = WasbPrefixSensorTrigger(
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        prefix=TEST_DATA_STORAGE_BLOB_PREFIX,
+        wasb_conn_id=TEST_WASB_CONN_ID,
+        poll_interval=POLL_INTERVAL,
+    )
+    classpath, kwargs = trigger.serialize()
+    assert classpath == "astronomer.providers.microsoft.azure.triggers.wasb.WasbPrefixSensorTrigger"
+    assert kwargs == {
+        "container_name": TEST_DATA_STORAGE_CONTAINER_NAME,
+        "prefix": TEST_DATA_STORAGE_BLOB_PREFIX,
+        "include": None,
+        "delimiter": "/",
+        "wasb_conn_id": TEST_WASB_CONN_ID,
+        "poll_interval": POLL_INTERVAL,
+        "public_read": False,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "prefix_exists",
+    [
+        True,
+        False,
+    ],
+)
+@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_prefix")
+async def test_wasb_prefix_sensor_trigger_running(mock_check_for_prefix, prefix_exists):
+    """
+    Test if the task is run in trigger successfully.
+    """
+    mock_check_for_prefix.return_value = prefix_exists
+    trigger = WasbPrefixSensorTrigger(
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        prefix=TEST_DATA_STORAGE_BLOB_PREFIX,
+        wasb_conn_id=TEST_WASB_CONN_ID,
+        poll_interval=POLL_INTERVAL,
+    )
+    task = asyncio.create_task(trigger.run().__anext__())
+
+    # TriggerEvent was not returned
+    assert task.done() is False
+    asyncio.get_event_loop().stop()
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_prefix")
+async def test_wasb_prefix_sensor_trigger_success(mock_check_for_prefix):
+    """Tests the success state for that the WasbPrefixSensorTrigger."""
+    mock_check_for_prefix.return_value = True
+    trigger = WasbPrefixSensorTrigger(
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        prefix=TEST_DATA_STORAGE_BLOB_PREFIX,
+        wasb_conn_id=TEST_WASB_CONN_ID,
+        poll_interval=POLL_INTERVAL,
+    )
+
+    task = asyncio.create_task(trigger.run().__anext__())
+    await asyncio.sleep(0.5)
+
+    # TriggerEvent was returned
+    assert task.done() is True
+    asyncio.get_event_loop().stop()
+
+    message = f"Prefix {TEST_DATA_STORAGE_BLOB_PREFIX} found in container {TEST_DATA_STORAGE_CONTAINER_NAME}."
+    assert task.result() == TriggerEvent({"status": "success", "message": message})
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_prefix")
+async def test_wasb_prefix_sensor_trigger_waiting_for_blob(mock_check_for_prefix):
+    """Tests the WasbPrefixSensorTrigger sleeps waiting for the blob to arrive."""
+    mock_check_for_prefix.side_effect = [False, True]
+
+    trigger = WasbPrefixSensorTrigger(
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        prefix=TEST_DATA_STORAGE_BLOB_PREFIX,
+        wasb_conn_id=TEST_WASB_CONN_ID,
+        poll_interval=POLL_INTERVAL,
+    )
+
+    with mock.patch.object(trigger.log, "info") as mock_log_info:
+        task = asyncio.create_task(trigger.run().__anext__())
+
+    await asyncio.sleep(POLL_INTERVAL + 0.5)
+
+    if not task.done():
+        message = (
+            f"Prefix {TEST_DATA_STORAGE_BLOB_PREFIX} not available yet in container "
+            f"{TEST_DATA_STORAGE_CONTAINER_NAME}. Sleeping for {POLL_INTERVAL} seconds"
+        )
+        mock_log_info.assert_called_once_with(message)
+    asyncio.get_event_loop().stop()
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_prefix")
+async def test_wasb_prefix_sensor_trigger_trigger_exception(mock_check_for_prefix):
+    """Tests the WasbPrefixSensorTrigger yields an error event if there is an exception."""
+    mock_check_for_prefix.side_effect = Exception("Test exception")
+
+    trigger = WasbPrefixSensorTrigger(
+        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+        prefix=TEST_DATA_STORAGE_BLOB_PREFIX,
+        wasb_conn_id=TEST_WASB_CONN_ID,
+        poll_interval=POLL_INTERVAL,
+    )
+
+    task = [i async for i in trigger.run()]
+    assert len(task) == 1
+    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task


### PR DESCRIPTION
The commit adds the following:
- Implementation for hook, triggers and sensors for `WasbBlobSensorAsync` & `WasbPrefixSensorAsync`
- A self-sufficient example DAG to create a data storage container, upload a test blob, run
  the sensors, delete the uploaded blob and delete the created data storage container in the
  same order. The DAG needs an Azure Storage Account and an Airflow connection to be created
  for the corresponding Azure Storage Account
- Handle exceptions
- Add relevant docstrings for the implementation

closes: #188 