### PR TITLE
Add missing example DAG in documentation

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_batch.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_batch.py
@@ -280,14 +280,14 @@ with DAG(
         task_id="list_jobs",
         python_callable=list_jobs_func,
     )
-    # [START howto_batch_sensor_async]
+    # [START howto_sensor_batch_async]
     batch_job_sensor = BatchSensorAsync(
         task_id="sense_job",
         job_id="{{ task_instance.xcom_pull(task_ids='list_jobs', dag_id='example_async_batch', key='return_value') }}",
         aws_conn_id=AWS_CONN_ID,
         region_name=AWS_DEFAULT_REGION,
     )
-    # [END howto_batch_sensor_async]
+    # [END howto_sensor_batch_async]
 
     update_compute_environment = PythonOperator(
         task_id="update_compute_environment",

--- a/docs/providers/amazon/aws/sensors/batch.rst
+++ b/docs/providers/amazon/aws/sensors/batch.rst
@@ -1,0 +1,12 @@
+Batch Sensor Async
+""""""""""""""""""
+
+
+To wait asynchronously for AWS Batch job to complete
+:class:`~astronomer.providers.amazon.aws.sensors.batch.BatchSensorAsync`.
+
+.. exampleinclude:: /../astronomer/providers/amazon/aws/example_dags/example_batch.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_sensor_batch_async]
+    :end-before: [END howto_sensor_batch_async]

--- a/docs/providers/amazon/index.rst
+++ b/docs/providers/amazon/index.rst
@@ -5,6 +5,7 @@ AWS Example DAG
   :hidden:
   :maxdepth: 2
 
+    Batch Sensor <aws/sensors/batch>
     EMR Senor <aws/sensors/emr>
     Redshift Sensor DAG <aws/sensors/redshift_cluster>
     S3 Sensor <aws/sensors/s3>
@@ -14,6 +15,7 @@ AWS Example DAG
     Batch Operator <aws/operators/redshift_sql>
 
 
+* `Batch Sensor <aws/sensors/batch.html>`_
 * `EMR Sensor <aws/sensors/emr.html>`_
 * `Redshift Cluster Sensor <aws/sensors/redshift_cluster.html>`_
 * `S3 Sensor <aws/sensors/s3.html>`_

--- a/docs/providers/microsoft/azure/sensors/wasb.rst
+++ b/docs/providers/microsoft/azure/sensors/wasb.rst
@@ -2,7 +2,7 @@ WASB Blob Sensor Async
 """"""""""""""""""""""
 
 
-To polls asynchronously for the existence of a blob in a WASB container
+To poll asynchronously for the existence of a blob in a WASB container.
 :class:`~astronomer.providers.microsoft.azure.sensors.wasb.WasbBlobSensorAsync`.
 
 .. exampleinclude:: /../astronomer/providers/microsoft/azure/example_dags/example_wasb_sensors.py
@@ -12,7 +12,7 @@ To polls asynchronously for the existence of a blob in a WASB container
     :end-before: [END howto_sensor_wasb_blob_sensor_async]
 
 
-To polls asynchronously for the existence of a blob having the given prefix in a WASB container
+To poll asynchronously for the existence of a blob having the given prefix in a WASB container
 :class:`~astronomer.providers.microsoft.azure.sensors.wasb.WasbPrefixSensorAsync`.
 
 .. exampleinclude:: /../astronomer/providers/microsoft/azure/example_dags/example_wasb_sensors.py

--- a/docs/providers/microsoft/azure/sensors/wasb.rst
+++ b/docs/providers/microsoft/azure/sensors/wasb.rst
@@ -1,0 +1,22 @@
+WASB Blob Sensor Async
+""""""""""""""""""""""
+
+
+To polls asynchronously for the existence of a blob in a WASB container
+:class:`~astronomer.providers.microsoft.azure.sensors.wasb.WasbBlobSensorAsync`.
+
+.. exampleinclude:: /../astronomer/providers/microsoft/azure/example_dags/example_wasb_sensors.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_sensor_wasb_blob_sensor_async]
+    :end-before: [END howto_sensor_wasb_blob_sensor_async]
+
+
+To polls asynchronously for the existence of a blob having the given prefix in a WASB container
+:class:`~astronomer.providers.microsoft.azure.sensors.wasb.WasbPrefixSensorAsync`.
+
+.. exampleinclude:: /../astronomer/providers/microsoft/azure/example_dags/example_wasb_sensors.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_sensor_wasb_prefix_sensor_async]
+    :end-before: [END howto_sensor_wasb_prefix_sensor_async]

--- a/docs/providers/microsoft/index.rst
+++ b/docs/providers/microsoft/index.rst
@@ -7,7 +7,9 @@ Microsoft Example DAG
 
     ADF Operators <azure/operators/data_factory>
     ADF Sensors <azure/sensors/data_factory>
+    WASB Blob Sensors <azure/sensors/wasb>
 
 
+* `WASB Blob Sensors <azure/sensors/wasb.html>`_
 * `ADF Operators <azure/operators/data_factory.html>`_
 * `ADF Sensors <azure/Sensors/data_factory.html>`_


### PR DESCRIPTION
closes: #490 

Here, I'm documenting an example DAG for recently merged PR going forward we will try to include example DAG documentation in the operator/sensor implementation PR itself