### PR TITLE
Add make target to use pinned provider depedencies for testing an RC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: dev clean stop build build-run docs restart restart-all run-mypy run-tests run-static-checks help
+.PHONY: dev logs stop clean build build-emr_eks_container_example_dag-image build-aws build-google-cloud build-run docs
+.PHONY: restart restart-all run-tests run-static-checks run-mypy run-local-lineage-server test-rc-dependencies help
 
 # If the first argument is "run"...
 ifeq (run-mypy,$(firstword $(MAKECMDGOALS)))
@@ -69,6 +70,14 @@ run-mypy: ## Run MyPy in Container
 
 run-local-lineage-server: ## Run flask based local Lineage server
 	FLASK_APP=dev/local_flask_lineage_server.py flask run --host 0.0.0.0 --port 5050
+
+test-rc-dependencies: ## Tests providers RC by building an image with given dependencies and running the master DAG
+	python3 dev/scripts/replace_dependencies.py '$(RC_PROVIDER_PACKAGES)'
+	cd ".circleci/integration-tests/" && \
+	 bash script.sh 'astro-cloud' '$(DOCKER_REGISTRY)' '$(ORGANIZATION_ID)' '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' '$(ASTRONOMER_KEY_SECRET)'
+	echo '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' '$(ASTRONOMER_KEY_SECRET)'
+	python3 dev/scripts/trigger_master_dag.py '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' ' $(ASTRONOMER_KEY_SECRET)'
+	git checkout setup.cfg
 
 help: ## Prints this message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-41s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: dev logs stop clean build build-emr_eks_container_example_dag-image build-aws build-google-cloud build-run docs
-.PHONY: restart restart-all run-tests run-static-checks run-mypy run-local-lineage-server test-rc-dependencies help
+.PHONY: restart restart-all run-tests run-static-checks run-mypy run-local-lineage-server test-rc-deps help
 
 # If the first argument is "run"...
 ifeq (run-mypy,$(firstword $(MAKECMDGOALS)))
@@ -71,7 +71,7 @@ run-mypy: ## Run MyPy in Container
 run-local-lineage-server: ## Run flask based local Lineage server
 	FLASK_APP=dev/local_flask_lineage_server.py flask run --host 0.0.0.0 --port 5050
 
-test-rc-dependencies: ## Tests providers RC by building an image with given dependencies and running the master DAG
+test-rc-deps: ## Test providers RC by building an image with given dependencies and running the master DAG
 	python3 dev/scripts/replace_dependencies.py '$(RC_PROVIDER_PACKAGES)'
 	cd ".circleci/integration-tests/" && \
 	 bash script.sh 'astro-cloud' '$(DOCKER_REGISTRY)' '$(ORGANIZATION_ID)' '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' '$(ASTRONOMER_KEY_SECRET)'

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ test-rc-dependencies: ## Tests providers RC by building an image with given depe
 	python3 dev/scripts/replace_dependencies.py '$(RC_PROVIDER_PACKAGES)'
 	cd ".circleci/integration-tests/" && \
 	 bash script.sh 'astro-cloud' '$(DOCKER_REGISTRY)' '$(ORGANIZATION_ID)' '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' '$(ASTRONOMER_KEY_SECRET)'
-	echo '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' '$(ASTRONOMER_KEY_SECRET)'
 	python3 dev/scripts/trigger_master_dag.py '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' ' $(ASTRONOMER_KEY_SECRET)'
 	git checkout setup.cfg
 

--- a/dev/scripts/replace_dependencies.py
+++ b/dev/scripts/replace_dependencies.py
@@ -1,0 +1,33 @@
+import argparse
+import fileinput
+from re import search, sub
+from typing import List
+
+
+def update_setup_cfg(rc_provider_packages: List[str]):
+    """
+    Replaces the given provider packages in the setup.cfg with the given pinned RC versions.
+    :param rc_provider_packages: list of RC provider packages to be replaced
+    """
+    for package in rc_provider_packages:
+        pinned_package = package.strip()
+        if not search("==", pinned_package):
+            raise Exception(
+                f"Invalid package {package} provided. It needs to be pinned to a specific version."
+            )
+        package_name_to_search = pinned_package.split("==")[0]
+        with fileinput.FileInput("setup.cfg", inplace=True) as setup_file:
+            for line in setup_file:
+                print(sub(f"{package_name_to_search}.*", pinned_package, line), end="")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "rc_provider_packages",
+        help="Comma separated list of provider packages with their pinned versions to test the the RC."
+        " e.g. 'apache-airflow-providers-amazon>=3.0.0, apache-airflow-providers-google>=8.1.0'",
+    )
+    args = parser.parse_args()
+    rc_provider_packages_list = args.rc_provider_packages.split(",")
+    update_setup_cfg(rc_provider_packages_list)

--- a/dev/scripts/replace_dependencies.py
+++ b/dev/scripts/replace_dependencies.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "rc_provider_packages",
         help="Comma separated list of provider packages with their pinned versions to test the the RC."
-        " e.g. 'apache-airflow-providers-amazon>=3.0.0, apache-airflow-providers-google>=8.1.0'",
+        " e.g. 'apache-airflow-providers-amazon==4.0.0rc1, apache-airflow-providers-google==8.1.0rc2'",
     )
     args = parser.parse_args()
     rc_provider_packages_list = args.rc_provider_packages.split(",")

--- a/dev/scripts/trigger_master_dag.py
+++ b/dev/scripts/trigger_master_dag.py
@@ -1,0 +1,54 @@
+import argparse
+
+import requests
+
+MASTER_DAG_ID = "example_master_dag"
+
+
+def get_access_token(api_key_id: str, api_key_secret: str) -> str:
+    """
+    Gets bearer access token for the Astro Cloud deployment needed for REST API authentication.
+
+    :param api_key_id: API key ID of the Astro Cloud deployment
+    :param api_key_secret: API key secret of the Astro Cloud deployment
+    """
+    request_json = {
+        "client_id": api_key_id,
+        "client_secret": api_key_secret,
+        "audience": "astronomer-ee",
+        "grant_type": "client_credentials",
+    }
+    response = requests.post("https://auth.astronomer.io/oauth/token", json=request_json)
+    response_json = response.json()
+    return response_json["access_token"]
+
+
+def trigger_master_dag_run(deployment_id: str, bearer_token: str):
+    """
+    Triggers the master DAG using Airflow REST API.
+
+    :param deployment_id: ID of the Astro Cloud deployment. Using this, we generate the short deployment ID needed
+        for the construction of Airflow endpoint to hit
+    :param bearer_token: bearer token to be used for authentication with the Airflow REST API
+    """
+    short_deployment_id = f"d{deployment_id[-7:]}"
+    integration_tests_deployment_url = f"https://astronomer.astronomer.run/{short_deployment_id}"
+    master_dag_trigger_url = f"{integration_tests_deployment_url}/api/v1/dags/{MASTER_DAG_ID}/dagRuns"
+    headers = {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+        "Authorization": f"Bearer {bearer_token}",
+    }
+    print(master_dag_trigger_url, headers)
+    response = requests.post(master_dag_trigger_url, headers=headers, json={})
+    print(response.json())
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("deployment_id", help="ID of the deployment in Astro Cloud")
+    parser.add_argument("astronomer_key_id", help="Key ID of the Astro Cloud deployment")
+    parser.add_argument("astronomer_key_secret", help="Key secret of the Astro Cloud deployment")
+    args = parser.parse_args()
+    token = get_access_token(args.astronomer_key_id.strip(), args.astronomer_key_secret.strip())
+    trigger_master_dag_run(args.deployment_id, token)

--- a/dev/scripts/trigger_master_dag.py
+++ b/dev/scripts/trigger_master_dag.py
@@ -1,6 +1,11 @@
 import argparse
+import logging
+import sys
 
 import requests
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+
 
 MASTER_DAG_ID = "example_master_dag"
 
@@ -39,9 +44,8 @@ def trigger_master_dag_run(deployment_id: str, bearer_token: str):
         "Cache-Control": "no-cache",
         "Authorization": f"Bearer {bearer_token}",
     }
-    print(master_dag_trigger_url, headers)
     response = requests.post(master_dag_trigger_url, headers=headers, json={})
-    print(response.json())
+    logging.info("Response for master DAG trigger is %s", response.json())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The commit adds a make target `test-rc-dependencies` along with a
couple of python scripts to do the following:
 1. Update setup.cfg to reflect given pinned provider dependencies
 2. Build an image with updated setup.cfg and deploy it to existing
    Astro Cloud deployment
 3. Trigger master DAG by calling the Airflow REST API
 4. Checkout from git local changes made to setup.cfg

closes: #472 