### PR TITLE
Add copy button to Code Blocks in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "exampleinclude",
+    "sphinx_copybutton",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,7 @@ openlineage =
 docs =
     sphinx
     sphinx-autoapi
+    sphinx-copybutton
 tests =
     aioresponses
     asynctest


### PR DESCRIPTION
With this change, users will be able to copy code-blocks with one click as shown in the video below.

https://user-images.githubusercontent.com/8811558/178005659-cded8d0f-a384-4648-bfbc-acd7e3ab6082.mp4

