### PR TITLE
Fix mypy errors

### DIFF
--- a/astronomer/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/astronomer/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -50,10 +50,10 @@ class KubernetesHookAsync(KubernetesHook):  # noqa: D101
             return client.ApiClient()
 
         if kubeconfig is not None:
-            async with aiofiles.tempfile.NamedTemporaryFile() as temp_config:  # type: ignore[attr-defined]
+            async with aiofiles.tempfile.NamedTemporaryFile() as temp_config:
                 self.log.debug("loading kube_config from: connection kube_config")
-                temp_config.write(kubeconfig.encode())
-                temp_config.flush()
+                await temp_config.write(kubeconfig.encode())
+                await temp_config.flush()
                 await config.load_kube_config(
                     config_file=temp_config.name,
                     client_configuration=self.client_configuration,


### PR DESCRIPTION
This should fix failing errors on main - https://app.circleci.com/pipelines/github/astronomer/astronomer-providers/2333/workflows/b7300908-21d3-426b-860d-7cbe1df09412/jobs/9108

```
mypy 0.961
(compiled:
yes)
astronomer/providers/cncf/kubernetes/hooks/kubernetes.py:53: error: Unused
"type: ignore" comment
                async with aiofiles.tempfile.NamedTemporaryFile() as temp_...
                ^
astronomer/providers/cncf/kubernetes/hooks/kubernetes.py: note: In member "_load_config" of class "KubernetesHookAsync":
astronomer/providers/cncf/kubernetes/hooks/kubernetes.py:55: error: Value of
type "Coroutine[Any, Any, int]" must be used  [unused-coroutine]
                    temp_config.write(kubeconfig.encode())
                    ^
astronomer/providers/cncf/kubernetes/hooks/kubernetes.py:55: note: Are you missing an await?
astronomer/providers/cncf/kubernetes/hooks/kubernetes.py:56: error: Value of
type "Coroutine[Any, Any, None]" must be used  [unused-coroutine]
                    temp_config.flush()
                    ^
astronomer/providers/cncf/kubernetes/hooks/kubernetes.py:56: note: Are you missing an await?
Found 3 errors in 1 file (checked 155 source files)

Exited with code exit status 1

```