### PR TITLE
Upgrade base Airflow image to latest release

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -1,5 +1,5 @@
 # Deploy from astro runtime image
-FROM quay.io/astronomer/astro-runtime:5.0.5-base
+FROM quay.io/astronomer/astro-runtime:5.0.6-base
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0

--- a/.circleci/integration-tests/Dockerfile.gen_1
+++ b/.circleci/integration-tests/Dockerfile.gen_1
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/ap-airflow:2.3.2-1
+FROM quay.io/astronomer/ap-airflow:2.3.3-1
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.5-base"
+ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.6-base"
 FROM ${IMAGE_NAME}
 
 USER root

--- a/dev/Dockerfile.aws
+++ b/dev/Dockerfile.aws
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.5-base"
+ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.6-base"
 FROM ${IMAGE_NAME}
 
 USER root

--- a/dev/Dockerfile.emr_eks_container
+++ b/dev/Dockerfile.emr_eks_container
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.5-base"
+ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.6-base"
 FROM ${IMAGE_NAME}
 
 USER root

--- a/dev/Dockerfile.google_cloud
+++ b/dev/Dockerfile.google_cloud
@@ -1,4 +1,4 @@
-ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.5-base"
+ARG IMAGE_NAME="quay.io/astronomer/astro-runtime:5.0.6-base"
 FROM ${IMAGE_NAME}
 
 USER root


### PR DESCRIPTION
astro-runtime:5.0.6 and ap-airflow:2.3.3-1 is released on
11th July 2022. The commit updates our Dockerfile to reference these
as the base images.