### PR TITLE
Add 15 mins sleep between deploying image & triggering master DAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ test-rc-deps: ## Test providers RC by building an image with given dependencies 
 	 bash script.sh 'astro-cloud' '$(DOCKER_REGISTRY)' '$(ORGANIZATION_ID)' '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' '$(ASTRONOMER_KEY_SECRET)'
 	$(eval current_timestamp := $(shell date))
 	echo "Current timestamp is" $(current_timestamp)
-	echo "Sleeping for 900 seconds (15 mins) so that the image is updated across all Airflow components.."
+	echo "Sleeping for 900 seconds (15 mins) allowing the deployed image to be updated across all Airflow components.."
 	sleep 900
 	python3 dev/scripts/trigger_master_dag.py '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' ' $(ASTRONOMER_KEY_SECRET)'
 	git checkout setup.cfg

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ test-rc-deps: ## Test providers RC by building an image with given dependencies 
 	 bash script.sh 'astro-cloud' '$(DOCKER_REGISTRY)' '$(ORGANIZATION_ID)' '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' '$(ASTRONOMER_KEY_SECRET)'
 	$(eval current_timestamp := $(shell date))
 	echo "Current timestamp is" $(current_timestamp)
-	echo "Sleeping for 900 seconds (15 mins) so that the image is updated by all Airflow components.."
+	echo "Sleeping for 900 seconds (15 mins) so that the image is updated across all Airflow components.."
 	sleep 900
 	python3 dev/scripts/trigger_master_dag.py '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' ' $(ASTRONOMER_KEY_SECRET)'
 	git checkout setup.cfg

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,10 @@ test-rc-deps: ## Test providers RC by building an image with given dependencies 
 	python3 dev/scripts/replace_dependencies.py '$(RC_PROVIDER_PACKAGES)'
 	cd ".circleci/integration-tests/" && \
 	 bash script.sh 'astro-cloud' '$(DOCKER_REGISTRY)' '$(ORGANIZATION_ID)' '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' '$(ASTRONOMER_KEY_SECRET)'
+	$(eval current_timestamp := $(shell date))
+	echo "Current timestamp is" $(current_timestamp)
+	echo "Sleeping for 900 seconds (15 mins) so that the image is updated by all Airflow components.."
+	sleep 900
 	python3 dev/scripts/trigger_master_dag.py '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' ' $(ASTRONOMER_KEY_SECRET)'
 	git checkout setup.cfg
 


### PR DESCRIPTION
It is observed on Astro Cloud that when a new image is deployed it
takes certain time to update the image on all Airflow component pods.
Currently, there is no programatic way to know whether the image
has been updated across all components. Hence, once the image is
deployed as part of the RC test make target, we are introducing
a sleep of 15 mins to allow the image to be updated across all
Airflow component pods before triggering the master DAG.

closes: #518 