### PR TITLE
Fix mypy issue for token variable of sql_api_generate_jwt.py module

### DIFF
--- a/astronomer/providers/snowflake/hooks/sql_api_generate_jwt.py
+++ b/astronomer/providers/snowflake/hooks/sql_api_generate_jwt.py
@@ -68,7 +68,7 @@ class JWTGenerator(object):
         self.renewal_delay = renewal_delay
         self.private_key = private_key
         self.renew_time = datetime.now(timezone.utc)
-        self.token = None
+        self.token: Optional[str] = None
 
     def prepare_account_name_for_jwt(self, raw_account: Text) -> Text:
         """


### PR DESCRIPTION
Mypy is complaining with the below error:
```
astronomer/providers/snowflake/hooks/sql_api_generate_jwt.py:132: error:
Incompatible types in assignment (expression has type "str", variable has type
"None")  [assignment]
                self.token = token
                             ^
Found 1 error in 1 file (checked 158 source files)
```

The commit is to fix the above error

closes: #520 