### PR TITLE
Fix RedshiftSQL Operator DAG failure

### DIFF
--- a/astronomer/providers/amazon/aws/hooks/redshift_sql.py
+++ b/astronomer/providers/amazon/aws/hooks/redshift_sql.py
@@ -19,7 +19,13 @@ class RedshiftSQLHookAsync(RedshiftDataHook):
         :param query_ids: list of query ids
         """
         try:
-            client = await sync_to_async(self.get_conn)()
+            try:
+                # for apache-airflow-providers-amazon>=3.0.0
+                client = await sync_to_async(self.get_conn)()
+            except ValueError:
+                # for apache-airflow-providers-amazon>=4.1.0
+                self.resource_type = None
+                client = await sync_to_async(self.get_conn)()
             completed_ids: List[str] = []
             for qid in query_ids:
                 while await self.is_still_running(qid):
@@ -48,7 +54,13 @@ class RedshiftSQLHookAsync(RedshiftDataHook):
         return False
         """
         try:
-            client = await sync_to_async(self.get_conn)()
+            try:
+                # for apache-airflow-providers-amazon>=3.0.0
+                client = await sync_to_async(self.get_conn)()
+            except ValueError:
+                # for apache-airflow-providers-amazon>=4.1.0
+                self.resource_type = None
+                client = await sync_to_async(self.get_conn)()
             desc = client.describe_statement(Id=qid)
             if desc["Status"] in ["PICKED", "STARTED", "SUBMITTED"]:
                 return True

--- a/tests/amazon/aws/hooks/test_redshift_data.py
+++ b/tests/amazon/aws/hooks/test_redshift_data.py
@@ -149,6 +149,41 @@ def test_execute_query_exception_exception_with_none_sql():
         hook.execute_query(None, params=None)
 
 
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.get_conn")
+async def test_get_query_status_value_error(mock_client):
+    hook = RedshiftDataHook()
+    mock_client.side_effect = ValueError("Test value error")
+    with pytest.raises(ValueError):
+        await hook.get_query_status(["uuid"])
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.get_conn")
+async def test_is_still_running_value_error(mock_client):
+    hook = RedshiftDataHook()
+    mock_client.side_effect = ValueError("Test value error")
+    with pytest.raises(ValueError):
+        await hook.is_still_running("uuid")
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.get_conn")
+async def test_execute_query_value_error(mock_client):
+    hook = RedshiftDataHook()
+    mock_client.side_effect = ValueError("Test value error")
+    with pytest.raises(ValueError):
+        hook.execute_query("select * from table", params=None)
+
+
+@pytest.mark.asyncio
+@mock.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook.__init__")
+async def test_redshift_data_hook_value_error(mock_client):
+    mock_client.side_effect = ValueError("Test value error")
+    with pytest.raises(ValueError):
+        RedshiftDataHook()
+
+
 @pytest.mark.parametrize(
     "sql,expected_response,expected_query_ids",
     [

--- a/tests/amazon/aws/hooks/test_redshift_sql.py
+++ b/tests/amazon/aws/hooks/test_redshift_sql.py
@@ -67,6 +67,21 @@ async def test_is_still_running(mock_client, query_id, describe_statement_respon
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query_id, describe_statement_response, expected_result",
+    [("uuid", {"Status": "FINISHED"}, False)],
+)
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHookAsync.get_conn")
+async def test_is_still_running_value_error(
+    mock_client, query_id, describe_statement_response, expected_result
+):
+    hook = RedshiftSQLHookAsync()
+    mock_client.side_effect = ValueError("Test value error")
+    with pytest.raises(ValueError):
+        await hook.is_still_running(query_id)
+
+
+@pytest.mark.asyncio
 @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHookAsync.get_conn")
 @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHookAsync.is_still_running")
 async def test_get_query_status_exception(mock_is_still_running, mock_conn):
@@ -95,6 +110,15 @@ async def test_get_query_status_exception(mock_is_still_running, mock_conn):
         "redshift-data operation: Details/context around the exception or error",
         "type": "ERROR",
     }
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHookAsync.get_conn")
+async def test_get_query_status_value_error(mock_client):
+    hook = RedshiftSQLHookAsync()
+    mock_client.side_effect = ValueError("Test value error")
+    with pytest.raises(ValueError):
+        await hook.get_query_status(["uuid"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Instead of giving both resource type and client type, it works with only client type
- Tested this change with both version
`apache-airflow-providers-amazon>=3.0.0` and latest `apache-airflow-providers-amazon==4.1.0rc1`
- Fixed for RedshiftDataOperatorAsync hook
- Added try, except for backwards and forwards-compatible without bumping the dependency

closes #523