### PR TITLE
Add pre-commit hook to check for dead links in markdown files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,11 @@ repos:
       - id: forbid-tabs
       - id: remove-tabs
 
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.10.2
+    hooks:
+      - id: markdown-link-check
+
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:


### PR DESCRIPTION
The pre-commit hook checks that there are no dead links in the
markdown files of the repo.

Reference: https://github.com/tcort/markdown-link-check

closes: #511 