### PR TITLE
Remove EMR Conn from example

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
@@ -18,7 +18,6 @@ from astronomer.providers.amazon.aws.sensors.emr import (
 JOB_FLOW_ROLE = os.getenv("EMR_JOB_FLOW_ROLE", "EMR_EC2_DefaultRole")
 SERVICE_ROLE = os.getenv("EMR_SERVICE_ROLE", "EMR_DefaultRole")
 AWS_CONN_ID = os.getenv("ASTRO_AWS_CONN_ID", "aws_default")
-EMR_CONN_ID = os.getenv("ASTRO_EMR_CONN_ID", "emr_default")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 SPARK_STEPS = [
@@ -72,7 +71,7 @@ with DAG(
     cluster_creator = EmrCreateJobFlowOperator(
         task_id="create_job_flow",
         job_flow_overrides=JOB_FLOW_OVERRIDES,
-        emr_conn_id=EMR_CONN_ID,
+        aws_conn_id=AWS_CONN_ID,
     )
     # [END howto_operator_emr_create_job_flow_steps_tasks]
 

--- a/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
@@ -67,6 +67,7 @@ with DAG(
     tags=["example", "async", "emr"],
     catchup=False,
 ) as dag:
+    # apache-airflow-providers-amazon < 4.1.0 you will also have to pass emr_conn_id param
     # [START howto_operator_emr_create_job_flow_steps_tasks]
     cluster_creator = EmrCreateJobFlowOperator(
         task_id="create_job_flow",

--- a/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
@@ -67,7 +67,7 @@ with DAG(
     tags=["example", "async", "emr"],
     catchup=False,
 ) as dag:
-    # apache-airflow-providers-amazon < 4.1.0 you will also have to pass emr_conn_id param
+    # For apache-airflow-providers-amazon < 4.1.0 you will also have to pass emr_conn_id param
     # [START howto_operator_emr_create_job_flow_steps_tasks]
     cluster_creator = EmrCreateJobFlowOperator(
         task_id="create_job_flow",


### PR DESCRIPTION
Now `emr_conn_id` is optional in EmrCreateJobFlowOperator since the configuration we pass using param `job_flow_overrides` so the `emr_conn_id` is no longer require. We can merge this once the provider for June is released `apache-airflow-providers-amazon==4.1.0`
OSS PR: https://github.com/apache/airflow/pull/24306