### PR TITLE
Fix KPO unitest

### DIFF
--- a/tests/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -102,7 +102,6 @@ def test_get_logs_not_running(
     cleanup,
     mock_client,
 ):
-
     pod = MagicMock()
     find_pod.return_value = pod
     mock_client.return_value = {}


### PR DESCRIPTION
mock Kubernetes default client in cncf kubenetes operator test