### PR TITLE
Fix example DAG for failing bigquery integration test

### DIFF
--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_queries.py
@@ -34,7 +34,7 @@ TABLE_2 = "table2"
 SCHEMA = [
     {"name": "value", "type": "INTEGER", "mode": "REQUIRED"},
     {"name": "name", "type": "STRING", "mode": "NULLABLE"},
-    {"name": "ds", "type": "DATE", "mode": "NULLABLE"},
+    {"name": "ds", "type": "STRING", "mode": "NULLABLE"},
 ]
 
 DATASET = DATASET_NAME


### PR DESCRIPTION
The type for schema field is not matching with the query field value.
The query field value is of type string and hence we're making the
field type to string too to fix the failing example DAG.