### PR TITLE
Update `sql_alchemy_conn` in docker compose

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -12,7 +12,7 @@ x-airflow-common:
     &airflow-common-env
     DB_BACKEND: postgres
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
-    AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
+    AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
     AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@postgres:5432/airflow
     AIRFLOW__CELERY__BROKER_URL: redis://:@redis:6379/0
     AIRFLOW__CORE__FERNET_KEY: ''


### PR DESCRIPTION
`AIRFLOW__CORE__SQL_ALCHEMY_CONN` has been deprecated so we should consider using the new env `AIRFLOW__DATABASE__SQL_ALCHEMY_CONN`