### PR TITLE
Implement Open lineage extractor for RedshiftAsync Operators

### DIFF
--- a/astronomer/providers/amazon/aws/extractors/redshift.py
+++ b/astronomer/providers/amazon/aws/extractors/redshift.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from airflow.models.taskinstance import TaskInstance
 from openlineage.airflow.extractors.redshift_data_extractor import RedshiftDataExtractor
@@ -16,7 +16,7 @@ class RedshiftAsyncExtractor(RedshiftDataExtractor):
         """Returns the list of operators this extractor works on."""
         return ["RedshiftDataOperatorAsync", "RedshiftSQLOperatorAsync"]
 
-    def _get_xcom_redshift_job_id(self, task_instance: TaskInstance) -> str:
+    def _get_xcom_redshift_job_id(self, task_instance: TaskInstance) -> Optional[str]:
         """Get query ids from XCOM"""
         redshift_job_id: List[str]
         redshift_job_id = task_instance.xcom_pull(task_ids=task_instance.task_id, key="return_value")

--- a/astronomer/providers/amazon/aws/extractors/redshift.py
+++ b/astronomer/providers/amazon/aws/extractors/redshift.py
@@ -20,7 +20,5 @@ class RedshiftAsyncExtractor(RedshiftDataExtractor):
         """Get query ids from XCOM"""
         redshift_job_id: List[str]
         redshift_job_id = task_instance.xcom_pull(task_ids=task_instance.task_id, key="return_value")
-        print("redhsift job id", redshift_job_id)
         if len(redshift_job_id) > 0:
             return redshift_job_id[0]
-        return None

--- a/astronomer/providers/amazon/aws/extractors/redshift.py
+++ b/astronomer/providers/amazon/aws/extractors/redshift.py
@@ -17,7 +17,7 @@ from openlineage.common.sql import DbTableMeta, SqlMeta, parse
 SCHEMA_URI = "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json"
 
 
-class RedshiftAsyncDataExtractor(BaseExtractor):
+class RedshiftAsyncExtractor(BaseExtractor):
     """This extractor provides visibility on the metadata of a RedshiftDataOperatorAsync"""
 
     default_schema = "public"
@@ -25,7 +25,7 @@ class RedshiftAsyncDataExtractor(BaseExtractor):
     @classmethod
     def get_operator_classnames(cls) -> List[str]:
         """Returns the list of operators this extractor works on."""
-        return ["RedshiftDataOperatorAsync"]
+        return ["RedshiftDataOperatorAsync", "RedshiftSQLOperatorAsync"]
 
     def extract(self) -> Optional[TaskMetadata]:
         """Empty extract implementation for the abstractmethod of the ``BaseExtractor`` class."""

--- a/astronomer/providers/amazon/aws/extractors/redshift.py
+++ b/astronomer/providers/amazon/aws/extractors/redshift.py
@@ -1,24 +1,12 @@
-import logging
-import traceback
-from typing import Any, Dict, List, Optional
+from typing import List
 
-import attr
 from airflow.models.taskinstance import TaskInstance
-from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
-from openlineage.airflow.utils import get_job_name
-from openlineage.client.facet import (
-    BaseFacet,
-    OutputStatisticsOutputDatasetFacet,
-    SqlJobFacet,
-)
-from openlineage.common.dataset import Dataset, Source
-from openlineage.common.models import DbColumn, DbTableSchema
-from openlineage.common.sql import DbTableMeta, SqlMeta, parse
+from openlineage.airflow.extractors.redshift_data_extractor import RedshiftDataExtractor
 
 SCHEMA_URI = "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json"
 
 
-class RedshiftAsyncExtractor(BaseExtractor):
+class RedshiftAsyncExtractor(RedshiftDataExtractor):
     """This extractor provides visibility on the metadata of a RedshiftDataOperatorAsync"""
 
     default_schema = "public"
@@ -28,208 +16,11 @@ class RedshiftAsyncExtractor(BaseExtractor):
         """Returns the list of operators this extractor works on."""
         return ["RedshiftDataOperatorAsync", "RedshiftSQLOperatorAsync"]
 
-    def extract(self) -> Optional[TaskMetadata]:
-        """Empty extract implementation for the abstractmethod of the ``BaseExtractor`` class."""
-        return None
-
-    def extract_on_complete(self, task_instance: TaskInstance) -> Optional[TaskMetadata]:
-        """
-        Callback on task completion to fetch metadata extraction details that are to be pushed to the Lineage server.
-
-        :param task_instance: Instance of the Airflow task whose metadata needs to be extracted.
-        """
-        self.log.debug("extract_on_complete(%s)", task_instance)
-        job_facets = {"sql": SqlJobFacet(self.operator.sql)}
-
-        self.log.debug("Sending SQL to parser: %s", self.operator.sql)
-        sql_meta: Optional[SqlMeta] = parse(self.operator.sql, self.default_schema)
-        self.log.debug("Got meta %s", sql_meta)
-        try:
-            redshift_job_id = self._get_xcom_redshift_job_id(task_instance)
-            if redshift_job_id is None:
-                raise Exception("Xcom could not resolve Redshift job id. Job may have failed.")
-        except Exception:
-            return TaskMetadata(
-                name=get_job_name(task=self.operator),
-                run_facets={},
-                job_facets=job_facets,
-            )
-
-        client = self.operator.hook.conn
-
-        redshift_details = [
-            "database",
-            "cluster_identifier",
-            "db_user",
-            "secret_arn",
-            "region",
-        ]
-
-        connection_details = {detail: getattr(self.operator, detail) for detail in redshift_details}
-
-        stats = RedshiftDataDatasetsProvider(client=client, connection_details=connection_details).get_facets(
-            job_id=redshift_job_id[0],
-            inputs=sql_meta.in_tables if sql_meta else [],
-            outputs=sql_meta.out_tables if sql_meta else [],
-        )
-
-        return TaskMetadata(
-            name=get_job_name(task=self.operator),
-            inputs=[ds.to_openlineage_dataset() for ds in stats.inputs],
-            outputs=[ds.to_openlineage_dataset() for ds in stats.output],
-            run_facets=stats.run_facets,
-            job_facets={"sql": SqlJobFacet(self.operator.sql)},
-        )
-
-    def _get_xcom_redshift_job_id(self, task_instance: TaskInstance) -> List[str]:
+    def _get_xcom_redshift_job_id(self, task_instance: TaskInstance) -> str:
         """Get query ids from XCOM"""
         redshift_job_id: List[str]
-        redshift_job_id = task_instance.xcom_pull(task_ids=task_instance.task_id, key="query_ids")
-
-        self.log.debug("redshift job id: %s", redshift_job_id)
-        return redshift_job_id
-
-
-# To be removed once redshift extractors are released in openlineage
-@attr.s
-class ErrorMessageRunFacet(BaseFacet):
-    """This facet represents an error message that was the result of a job run"""
-
-    message: str = attr.ib()
-    programmingLanguage: str = attr.ib()
-    stackTrace: Optional[str] = attr.ib(default=None)
-
-    @staticmethod
-    def _get_schema() -> str:
-        return SCHEMA_URI + "#/definitions/ErrorMessageRunFacet"
-
-
-# To be removed once redshift extractors are released in openlineage
-@attr.s
-class RedshiftFacets:
-    """This facet represents a RedshiftFacets"""
-
-    run_facets: Dict[str, BaseFacet] = attr.ib()
-    inputs: List[Dataset] = attr.ib()
-    output: List[Dataset] = attr.ib()
-
-
-# To be removed once redshift extractors are released in openlineage
-class RedshiftDataDatasetsProvider:
-    """RedshiftDataDatasetsProvider"""
-
-    from botocore import client
-
-    def __init__(
-        self,
-        client: client,
-        connection_details: Dict[str, Any],
-        logger: Optional[logging.Logger] = None,
-    ):
-        if logger is None:
-            self.logger: logging.Logger = logging.getLogger(__name__)
-        else:
-            self.logger = logger
-        self.connection_details = connection_details
-        self.client = client
-
-    def get_facets(
-        self, job_id: str, inputs: List[DbTableMeta], outputs: List[DbTableMeta]
-    ) -> RedshiftFacets:
-        """Gets all the facets needed for redshift"""
-        ds_inputs = []
-        ds_outputs = []
-        run_facets = {}
-        dataset_stat_facet = None
-
-        source = Source(
-            scheme="redshift",
-            authority=self._get_authority(),
-        )
-        try:
-            properties = self.client.describe_statement(Id=job_id)
-            dataset_stat_facet = self._get_output_statistics(properties)
-        except Exception as e:
-            run_facets.update(
-                {
-                    "errorMessage": ErrorMessageRunFacet(
-                        message=f"Cannot retrieve job details from Redshift Data client. {e}",
-                        programmingLanguage="PYTHON",
-                        stackTrace=f"{e}: {traceback.format_exc()}",
-                    )
-                }
-            )
-
-        ds_inputs = self._get_dataset_from_tables(inputs, source)
-        ds_outputs = self._get_dataset_from_tables(outputs, source)
-
-        for ds_output in ds_outputs:
-            ds_output.custom_facets.update({"stats": dataset_stat_facet})
-
-        return RedshiftFacets(run_facets, ds_inputs, ds_outputs)
-
-    def _get_output_statistics(self, properties: Dict[str, Any]) -> OutputStatisticsOutputDatasetFacet:
-        return OutputStatisticsOutputDatasetFacet(
-            rowCount=properties.get("ResultRows"),
-            size=properties.get("ResultSize"),
-        )
-
-    def _get_dataset_from_tables(self, tables: List[DbTableMeta], source: Source) -> Dataset:
-        try:
-            return [
-                Dataset.from_table_schema(
-                    source=source,
-                    table_schema=table_schema,
-                    database_name=self.connection_details.get("database"),
-                )
-                for table_schema in self._get_table_schemas(tables)
-            ]
-        except Exception:
-            return [Dataset.from_table(source, table.name) for table in tables]
-
-    def _get_authority(self) -> str:
-        return (
-            f"{self.connection_details['cluster_identifier']}."
-            f"{self.connection_details.get('region')}:5439"
-        )
-
-    def _get_table_safely(self, output_table_name: str) -> Optional[str]:
-        try:
-            return self._get_table(output_table_name)
-        except Exception:
-            return None
-
-    def _get_table_schemas(self, tables: List[DbTableMeta]) -> List[DbTableSchema]:
-        if not tables:
-            return []
-        return [self._get_table(table) for table in tables]
-
-    def _get_table(self, table: DbTableMeta) -> Optional[DbTableSchema]:
-        kwargs: Dict[str, Any] = {
-            "ClusterIdentifier": self.connection_details.get("cluster_identifier"),
-            "Database": table.database or self.connection_details.get("database"),
-            "Table": table.name,
-            "DbUser": self.connection_details.get("db_user"),
-            "SecretArn": self.connection_details.get("secret_arn"),
-            "Schema": table.schema,
-        }
-        filter_values = {key: val for key, val in kwargs.items() if val is not None}
-        redshift_table = self.client.describe_table(**filter_values)
-        fields = redshift_table.get("ColumnList")
-        if not fields:
-            return None
-        schema_name = fields[0]["schemaName"]
-        columns = [
-            DbColumn(
-                name=fields[i].get("name"),
-                type=fields[i].get("typeName"),
-                ordinal_position=i,
-            )
-            for i in range(len(fields))
-        ]
-
-        return DbTableSchema(
-            schema_name=schema_name,
-            table_name=DbTableMeta(redshift_table.get("TableName")),
-            columns=columns,
-        )
+        redshift_job_id = task_instance.xcom_pull(task_ids=task_instance.task_id, key="return_value")
+        print("redhsift job id", redshift_job_id)
+        if len(redshift_job_id) > 0:
+            return redshift_job_id[0]
+        return None

--- a/astronomer/providers/amazon/aws/extractors/redshift.py
+++ b/astronomer/providers/amazon/aws/extractors/redshift.py
@@ -22,3 +22,4 @@ class RedshiftAsyncExtractor(RedshiftDataExtractor):
         redshift_job_id = task_instance.xcom_pull(task_ids=task_instance.task_id, key="return_value")
         if len(redshift_job_id) > 0:
             return redshift_job_id[0]
+        return None

--- a/astronomer/providers/amazon/aws/extractors/redshift_data.py
+++ b/astronomer/providers/amazon/aws/extractors/redshift_data.py
@@ -1,0 +1,233 @@
+import logging
+import traceback
+from typing import Any, Dict, List, Optional
+
+import attr
+from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
+from openlineage.airflow.utils import get_job_name
+from openlineage.client.facet import (
+    BaseFacet,
+    OutputStatisticsOutputDatasetFacet,
+    SqlJobFacet,
+)
+from openlineage.common.dataset import Dataset, Source
+from openlineage.common.models import DbColumn, DbTableSchema
+from openlineage.common.sql import DbTableMeta, SqlMeta, parse
+
+SCHEMA_URI = "https://raw.githubusercontent.com/OpenLineage/OpenLineage/main/spec/OpenLineage.json"
+
+
+class RedshiftAsyncDataExtractor(BaseExtractor):
+    """This extractor provides visibility on the metadata of a RedshiftDataOperatorAsync"""
+
+    default_schema = "public"
+
+    @classmethod
+    def get_operator_classnames(cls) -> List[str]:
+        """Returns the list of operators this extractor works on."""
+        return ["RedshiftDataOperatorAsync"]
+
+    def extract(self) -> Optional[TaskMetadata]:
+        """Empty extract implementation for the abstractmethod of the ``BaseExtractor`` class."""
+        return None
+
+    def extract_on_complete(self, task_instance) -> Optional[TaskMetadata]:
+        """
+        Callback on task completion to fetch metadata extraction details that are to be pushed to the Lineage server.
+
+        :param task_instance: Instance of the Airflow task whose metadata needs to be extracted.
+        """
+        self.log.debug("extract_on_complete(%s)", task_instance)
+        job_facets = {"sql": SqlJobFacet(self.operator.sql)}
+
+        self.log.debug("Sending SQL to parser: %s", self.operator.sql)
+        sql_meta: Optional[SqlMeta] = parse(self.operator.sql, self.default_schema)
+        self.log.debug("Got meta %s", sql_meta)
+        try:
+            redshift_job_id = self._get_xcom_redshift_job_id(task_instance)
+            if redshift_job_id is None:
+                raise Exception("Xcom could not resolve Redshift job id. Job may have failed.")
+        except Exception:
+            return TaskMetadata(
+                name=get_job_name(task=self.operator),
+                run_facets={},
+                job_facets=job_facets,
+            )
+
+        client = self.operator.hook.conn
+
+        redshift_details = [
+            "database",
+            "cluster_identifier",
+            "db_user",
+            "secret_arn",
+            "region",
+        ]
+
+        connection_details = {detail: getattr(self.operator, detail) for detail in redshift_details}
+
+        stats = RedshiftDataDatasetsProvider(client=client, connection_details=connection_details).get_facets(
+            job_id=redshift_job_id,
+            inputs=sql_meta.in_tables if sql_meta else [],
+            outputs=sql_meta.out_tables if sql_meta else [],
+        )
+
+        return TaskMetadata(
+            name=get_job_name(task=self.operator),
+            inputs=[ds.to_openlineage_dataset() for ds in stats.inputs],
+            outputs=[ds.to_openlineage_dataset() for ds in stats.output],
+            run_facets=stats.run_facets,
+            job_facets={"sql": SqlJobFacet(self.operator.sql)},
+        )
+
+    def _get_xcom_redshift_job_id(self, task_instance):
+        """Get query id from XCOM"""
+        redshift_job_id = task_instance.xcom_pull(task_ids=task_instance.task_id, key="query_ids")
+
+        self.log.debug("redshift job id: %s", redshift_job_id)
+        return redshift_job_id
+
+
+# To be removed once redshift extractors are released in openlineage
+@attr.s
+class ErrorMessageRunFacet(BaseFacet):
+    """This facet represents an error message that was the result of a job run"""
+
+    message: str = attr.ib()
+    programmingLanguage: str = attr.ib()
+    stackTrace: Optional[str] = attr.ib(default=None)
+
+    @staticmethod
+    def _get_schema() -> str:
+        return SCHEMA_URI + "#/definitions/ErrorMessageRunFacet"
+
+
+# To be removed once redshift extractors are released in openlineage
+@attr.s
+class RedshiftFacets:
+    """This facet represents a RedshiftFacets"""
+
+    run_facets: Dict[str, BaseFacet] = attr.ib()
+    inputs: List[Dataset] = attr.ib()
+    output: List[Dataset] = attr.ib()
+
+
+# To be removed once redshift extractors are released in openlineage
+class RedshiftDataDatasetsProvider:
+    """RedshiftDataDatasetsProvider"""
+
+    import botocore
+
+    def __init__(
+        self,
+        client: botocore.client,
+        connection_details: Dict[str, Any],
+        logger: Optional[logging.Logger] = None,
+    ):
+        if logger is None:
+            self.logger: logging.Logger = logging.getLogger(__name__)
+        else:
+            self.logger = logger
+        self.connection_details = connection_details
+        self.client = client
+
+    def get_facets(
+        self, job_id: str, inputs: List[DbTableMeta], outputs: List[DbTableMeta]
+    ) -> RedshiftFacets:
+        """Gets all the facets needed for redshift"""
+        ds_inputs = []
+        ds_outputs = []
+        run_facets = {}
+        dataset_stat_facet = None
+
+        source = Source(
+            scheme="redshift",
+            authority=self._get_authority(),
+        )
+        try:
+            properties = self.client.describe_statement(Id=job_id)
+            dataset_stat_facet = self._get_output_statistics(properties)
+        except Exception as e:
+            run_facets.update(
+                {
+                    "errorMessage": ErrorMessageRunFacet(
+                        message=f"Cannot retrieve job details from Redshift Data client. {e}",
+                        programmingLanguage="PYTHON",
+                        stackTrace=f"{e}: {traceback.format_exc()}",
+                    )
+                }
+            )
+
+        ds_inputs = self._get_dataset_from_tables(inputs, source)
+        ds_outputs = self._get_dataset_from_tables(outputs, source)
+
+        for ds_output in ds_outputs:
+            ds_output.custom_facets.update({"stats": dataset_stat_facet})
+
+        return RedshiftFacets(run_facets, ds_inputs, ds_outputs)
+
+    def _get_output_statistics(self, properties) -> OutputStatisticsOutputDatasetFacet:
+        return OutputStatisticsOutputDatasetFacet(
+            rowCount=properties.get("ResultRows"),
+            size=properties.get("ResultSize"),
+        )
+
+    def _get_dataset_from_tables(self, tables: List[DbTableMeta], source: Source) -> Dataset:
+        try:
+            return [
+                Dataset.from_table_schema(
+                    source=source,
+                    table_schema=table_schema,
+                    database_name=self.connection_details.get("database"),
+                )
+                for table_schema in self._get_table_schemas(tables)
+            ]
+        except Exception:
+            return [Dataset.from_table(source, table.name) for table in tables]
+
+    def _get_authority(self) -> str:
+        return (
+            f"{self.connection_details['cluster_identifier']}."
+            f"{self.connection_details.get('region')}:5439"
+        )
+
+    def _get_table_safely(self, output_table_name):
+        try:
+            return self._get_table(output_table_name)
+        except Exception:
+            return None
+
+    def _get_table_schemas(self, tables: List[DbTableMeta]) -> List[DbTableSchema]:
+        if not tables:
+            return []
+        return [self._get_table(table) for table in tables]
+
+    def _get_table(self, table: DbTableMeta) -> Optional[DbTableSchema]:
+        kwargs: Dict[str, Any] = {
+            "ClusterIdentifier": self.connection_details.get("cluster_identifier"),
+            "Database": table.database or self.connection_details.get("database"),
+            "Table": table.name,
+            "DbUser": self.connection_details.get("db_user"),
+            "SecretArn": self.connection_details.get("secret_arn"),
+            "Schema": table.schema,
+        }
+        filter_values = {key: val for key, val in kwargs.items() if val is not None}
+        redshift_table = self.client.describe_table(**filter_values)
+        fields = redshift_table.get("ColumnList")
+        if not fields:
+            return None
+        schema_name = fields[0]["schemaName"]
+        columns = [
+            DbColumn(
+                name=fields[i].get("name"),
+                type=fields[i].get("typeName"),
+                ordinal_position=i,
+            )
+            for i in range(len(fields))
+        ]
+
+        return DbTableSchema(
+            schema_name=schema_name,
+            table_name=DbTableMeta(redshift_table.get("TableName")),
+            columns=columns,
+        )

--- a/astronomer/providers/amazon/aws/extractors/redshift_data.py
+++ b/astronomer/providers/amazon/aws/extractors/redshift_data.py
@@ -67,7 +67,7 @@ class RedshiftAsyncDataExtractor(BaseExtractor):
         connection_details = {detail: getattr(self.operator, detail) for detail in redshift_details}
 
         stats = RedshiftDataDatasetsProvider(client=client, connection_details=connection_details).get_facets(
-            job_id=redshift_job_id,
+            job_id=redshift_job_id[0],
             inputs=sql_meta.in_tables if sql_meta else [],
             outputs=sql_meta.out_tables if sql_meta else [],
         )
@@ -116,11 +116,11 @@ class RedshiftFacets:
 class RedshiftDataDatasetsProvider:
     """RedshiftDataDatasetsProvider"""
 
-    import botocore
+    from botocore import client
 
     def __init__(
         self,
-        client: botocore.client,
+        client: client,
         connection_details: Dict[str, Any],
         logger: Optional[logging.Logger] = None,
     ):

--- a/astronomer/providers/amazon/aws/operators/redshift_data.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_data.py
@@ -42,7 +42,7 @@ class RedshiftDataOperatorAsync(RedshiftDataOperator):
         self.log.info("Query IDs %s", query_ids)
         if response.get("status") == "error":
             self.execute_complete(context, event=response)
-        context["ti"].xcom_push(key="query_ids", value=query_ids)
+        context["ti"].xcom_push(key="return_value", value=query_ids)
         self.defer(
             timeout=self.execution_timeout,
             trigger=RedshiftDataTrigger(

--- a/astronomer/providers/amazon/aws/operators/redshift_data.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_data.py
@@ -42,6 +42,7 @@ class RedshiftDataOperatorAsync(RedshiftDataOperator):
         self.log.info("Query IDs %s", query_ids)
         if response.get("status") == "error":
             self.execute_complete(context, event=response)
+        context["ti"].xcom_push(key="query_ids", value=query_ids)
         self.defer(
             timeout=self.execution_timeout,
             trigger=RedshiftDataTrigger(

--- a/astronomer/providers/amazon/aws/operators/redshift_sql.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_sql.py
@@ -40,7 +40,7 @@ class RedshiftSQLOperatorAsync(RedshiftSQLOperator):
         if response.get("status") == "error":
             self.execute_complete({}, response)
             return
-        context["ti"].xcom_push(key="query_ids", value=query_ids)
+        context["ti"].xcom_push(key="return_value", value=query_ids)
         self.defer(
             timeout=self.execution_timeout,
             trigger=RedshiftSQLTrigger(

--- a/astronomer/providers/amazon/aws/operators/redshift_sql.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_sql.py
@@ -40,6 +40,7 @@ class RedshiftSQLOperatorAsync(RedshiftSQLOperator):
         if response.get("status") == "error":
             self.execute_complete({}, response)
             return
+        context["ti"].xcom_push(key="query_ids", value=query_ids)
         self.defer(
             timeout=self.execution_timeout,
             trigger=RedshiftSQLTrigger(

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -23,7 +23,8 @@ x-airflow-common:
     AIRFLOW__LINEAGE__BACKEND: openlineage.lineage_backend.OpenLineageBackend
     OPENLINEAGE_URL: http://host.docker.internal:5050/
     OPENLINEAGE_EXTRACTORS: "astronomer.providers.google.cloud.extractors.bigquery.BigQueryAsyncExtractor;\
-                            astronomer.providers.snowflake.extractors.snowflake.SnowflakeAsyncExtractor"
+                            astronomer.providers.snowflake.extractors.snowflake.SnowflakeAsyncExtractor;\
+                            astronomer.providers.amazon.aws.extractors.redshift.RedshiftAsyncDataExtractor"
   volumes:
     - ./dags:/usr/local/airflow/dags
     - ./logs:/usr/local/airflow/logs

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ snowflake =
     apache-airflow-providers-snowflake
 # If in future we move Openlineage extractors out of the repo, this dependency should be removed
 openlineage =
-    openlineage-airflow>=0.9.0
+    openlineage-airflow>=0.12.0
 
 docs =
     sphinx
@@ -126,7 +126,7 @@ all =
     gcloud-aio-storage
     kubernetes_asyncio
     impyla
-    openlineage-airflow>=0.9.0
+    openlineage-airflow>=0.12.0
     paramiko
     protobuf<=3.20.0  # Bigquery provider isn't compatible with it. Details in https://github.com/apache/airflow/commit/25a9ae3b2eec85dfd500b0a921045fc95ab8ffd6
 

--- a/tests/amazon/aws/extractors/test_redshift.py
+++ b/tests/amazon/aws/extractors/test_redshift.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+from unittest import mock
+
+import pytest
+from airflow.models import DAG, TaskInstance
+from airflow.models.dagrun import DagRun
+from airflow.utils.dates import days_ago
+from airflow.utils.types import DagRunType
+
+from astronomer.providers.amazon.aws.extractors.redshift import RedshiftAsyncExtractor
+from astronomer.providers.amazon.aws.operators.redshift_data import (
+    RedshiftDataOperatorAsync,
+)
+
+REDSHIFT_DATABASE = "dev"
+
+REDSHIFT_QUERY = """
+CREATE TABLE IF NOT EXISTS fruit (
+            fruit_id INTEGER,
+            name VARCHAR NOT NULL,
+            color VARCHAR NOT NULL
+            );
+            """
+DAG_ID = "email_discounts"
+DAG_OWNER = "datascience"
+DAG_DEFAULT_ARGS = {
+    "owner": DAG_OWNER,
+    "depends_on_past": False,
+    "start_date": days_ago(7),
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "email": ["datascience@example.com"],
+}
+
+
+@pytest.fixture
+def context():
+    """
+    Creates an empty context.
+    """
+    context = {"ti": {"xcom_push": {}}}
+    yield context
+
+
+def create_context(task):
+    dag = DAG(dag_id=DAG_ID)
+    logical_date = datetime(2022, 1, 1, 0, 0, 0)
+    dag_run = DagRun(
+        dag_id=dag.dag_id,
+        execution_date=logical_date,
+        run_id=DagRun.generate_run_id(DagRunType.MANUAL, logical_date),
+    )
+    task_instance = TaskInstance(task=task)
+    task_instance.dag_run = dag_run
+    task_instance.dag_id = dag.dag_id
+    return {
+        "dag": dag,
+        "run_id": dag_run.run_id,
+        "task": task,
+        "ti": task_instance,
+        "task_instance": task_instance,
+        "logical_date": logical_date,
+    }
+
+
+TASK_ID = "select"
+TASK = RedshiftDataOperatorAsync(
+    task_id=TASK_ID,
+    sql=REDSHIFT_QUERY,
+    database=REDSHIFT_DATABASE,
+)
+
+
+def test_get_operator_classnames():
+    extractor = RedshiftAsyncExtractor(TASK)
+    class_name = extractor.get_operator_classnames()
+    assert class_name == ["RedshiftDataOperatorAsync", "RedshiftSQLOperatorAsync"]
+
+
+@mock.patch("airflow.models.taskinstance.TaskInstance.xcom_pull")
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.execute_query")
+def test__get_xcom_redshift_job_id_none(mock_execute, mock_context):
+    mock_execute.return_value = [], {}
+    mock_context.return_value = {}
+    extractor = RedshiftAsyncExtractor(TASK)
+    redshift_job_id = extractor._get_xcom_redshift_job_id(mock_context)
+    assert redshift_job_id is None

--- a/tests/amazon/aws/operators/test_redshift_data.py
+++ b/tests/amazon/aws/operators/test_redshift_data.py
@@ -1,7 +1,12 @@
+import datetime
 from unittest import mock
 
 import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
+from airflow.models.dag import DAG
+from airflow.models.dagrun import DagRun
+from airflow.models.taskinstance import TaskInstance
+from airflow.utils.types import DagRunType
 
 from astronomer.providers.amazon.aws.operators.redshift_data import (
     RedshiftDataOperatorAsync,
@@ -19,11 +24,34 @@ def context():
     """
     Creates an empty context.
     """
-    yield
+    context = {}
+    yield context
+
+
+def create_context(task, dag):
+    execution_date = datetime.datetime(2022, 1, 1, 0, 0, 0)
+    dag_run = DagRun(
+        dag_id=dag.dag_id,
+        execution_date=execution_date,
+        run_id=DagRun.generate_run_id(DagRunType.MANUAL, execution_date),
+    )
+    task_instance = TaskInstance(task=task)
+    task_instance.dag_run = dag_run
+    task_instance.dag_id = dag.dag_id
+    task_instance.xcom_push = mock.Mock()
+    return {
+        "dag": dag,
+        "run_id": dag_run.run_id,
+        "task": task,
+        "ti": task_instance,
+        "task_instance": task_instance,
+    }
 
 
 @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.execute_query")
 def test_redshift_data_op_async(mock_execute):
+    args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
+    dag = DAG("test_redshift_data_async_execute_complete", default_args=args)
     mock_execute.return_value = [], {}
     task = RedshiftDataOperatorAsync(
         task_id=TEST_TASK_ID,
@@ -31,7 +59,7 @@ def test_redshift_data_op_async(mock_execute):
         database=TEST_DATABASE,
     )
     with pytest.raises(TaskDeferred) as exc:
-        task.execute(context)
+        task.execute(create_context(task, dag))
     assert isinstance(exc.value.trigger, RedshiftDataTrigger), "Trigger is not a RedshiftDataTrigger"
 
 

--- a/tests/amazon/aws/operators/test_redshift_sql.py
+++ b/tests/amazon/aws/operators/test_redshift_sql.py
@@ -1,7 +1,12 @@
+import datetime
 from unittest import mock
 
 import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
+from airflow.models.dag import DAG
+from airflow.models.dagrun import DagRun
+from airflow.models.taskinstance import TaskInstance
+from airflow.utils.types import DagRunType
 
 from astronomer.providers.amazon.aws.operators.redshift_sql import (
     RedshiftSQLOperatorAsync,
@@ -18,11 +23,34 @@ def context():
     """
     Creates an empty context.
     """
-    yield
+    context = {}
+    yield context
+
+
+def create_context(task, dag):
+    execution_date = datetime.datetime(2022, 1, 1, 0, 0, 0)
+    dag_run = DagRun(
+        dag_id=dag.dag_id,
+        execution_date=execution_date,
+        run_id=DagRun.generate_run_id(DagRunType.MANUAL, execution_date),
+    )
+    task_instance = TaskInstance(task=task)
+    task_instance.dag_run = dag_run
+    task_instance.dag_id = dag.dag_id
+    task_instance.xcom_push = mock.Mock()
+    return {
+        "dag": dag,
+        "run_id": dag_run.run_id,
+        "task": task,
+        "ti": task_instance,
+        "task_instance": task_instance,
+    }
 
 
 @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.execute_query")
 def test_redshiftsql_op_async(mock_execute):
+    args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
+    dag = DAG("test_redshift_sql_async_execute_complete", default_args=args)
     mock_execute.return_value = [], {}
     task = RedshiftSQLOperatorAsync(
         task_id=TEST_TASK_ID,
@@ -30,7 +58,7 @@ def test_redshiftsql_op_async(mock_execute):
         params=TEST_PARAMATERS,
     )
     with pytest.raises(TaskDeferred) as exc:
-        task.execute(context)
+        task.execute(create_context(task, dag))
     assert isinstance(exc.value.trigger, RedshiftSQLTrigger), "Trigger is not a RedshiftSQLTrigger"
 
 


### PR DESCRIPTION
Export query_ids as XCOM for the Redshift async operators
and add an OpenLineage custom extractor for the same.
Some additional OpenLineage specific environment variables
need to be set which are included as part of the
docker-compose.yaml file change in the commit.
Also adds unit tests for the custom extractor.

Closes #462 