### PR TITLE
Fix `see also` link mentioned in Document

### DIFF
--- a/astronomer/providers/amazon/aws/hooks/batch_client.py
+++ b/astronomer/providers/amazon/aws/hooks/batch_client.py
@@ -34,10 +34,11 @@ class BatchClientHookAsync(BatchClientHook, AwsBaseHookAsync):
         delay .  It is generally recommended that random jitter is added to API requests.
         A convenience method is provided for this, e.g. to get a random delay of
         10 sec +/- 5 sec: ``delay = BatchClient.add_jitter(10, width=5, minima=0)``
-    .. see also::
-        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html
-        - https://docs.aws.amazon.com/general/latest/gr/api-retries.html
-        - https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+
+    .. seealso::
+        - `Batch <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html>`_
+        - `Retries <https://docs.aws.amazon.com/general/latest/gr/api-retries.html>`_
+        - `Exponential Backoff And Jitter <https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/>`_
     """
 
     def __init__(self, job_id: Optional[str], waiters: Any = None, *args: Any, **kwargs: Any) -> None:

--- a/astronomer/providers/amazon/aws/operators/batch.py
+++ b/astronomer/providers/amazon/aws/operators/batch.py
@@ -1,11 +1,11 @@
 """
 A Deferrable Airflow operator for AWS Batch services
 
-.. see also::
+.. seealso::
 
-    - http://boto3.readthedocs.io/en/latest/guide/configuration.html
-    - http://boto3.readthedocs.io/en/latest/reference/services/batch.html
-    - https://docs.aws.amazon.com/batch/latest/APIReference/Welcome.html
+    - `Configuration <http://boto3.readthedocs.io/en/latest/guide/configuration.html>`_
+    - `Batch <http://boto3.readthedocs.io/en/latest/reference/services/batch.html>`_
+    - `Welcome <https://docs.aws.amazon.com/batch/latest/APIReference/Welcome.html>`_
 """
 from typing import Any, Dict
 

--- a/astronomer/providers/apache/livy/hooks/livy.py
+++ b/astronomer/providers/apache/livy/hooks/livy.py
@@ -22,9 +22,9 @@ class LivyHookAsync(HttpHookAsync, LoggingMixin):
             For example, ``run(json=obj)`` is passed as ``aiohttp.ClientSession().get(json=obj)``
     :param extra_headers: A dictionary of headers passed to the HTTP request to livy.
 
-    .. see also::
+    .. seealso::
         For more details refer to the Apache Livy API reference:
-        https://livy.apache.org/docs/latest/rest-api.html
+        `Apache Livy API reference <https://livy.apache.org/docs/latest/rest-api.html>`_
     """
 
     TERMINAL_STATES = {


### PR DESCRIPTION
- Before whatever link mention in `see also` in doc sting was not showing up in document page now  fixed it

closes: #560
<img width="1498" alt="Screenshot 2022-07-28 at 9 22 53 PM" src="https://user-images.githubusercontent.com/94612827/181582598-9c2b3abb-7f7c-423a-bc9c-e0a7d773dd51.png">
