### PR TITLE
Nuke GCP resources.

### DIFF
--- a/astronomer/providers/google/cloud/example_dags/example_gcp_nuke.py
+++ b/astronomer/providers/google/cloud/example_dags/example_gcp_nuke.py
@@ -16,7 +16,7 @@ default_args = {
 }
 
 
-def gcloud_nuke_callable():
+def gcloud_nuke_callable() -> None:
     """Deletes stale GCP resources."""
     import json
     import logging
@@ -59,9 +59,9 @@ def gcloud_nuke_callable():
             subprocess.getoutput(f"echo 'Y' | gcloud compute instances delete {instance_name}")
 
         # Delete storage buckets.
-        buckets = subprocess.getoutput("gcloud alpha storage ls")
-        if buckets != "ERROR: (gcloud.alpha.storage.ls) One or more URLs matched no objects.":
-            buckets = buckets.split("\n")
+        buckets_ls = subprocess.getoutput("gcloud alpha storage ls")
+        if buckets_ls != "ERROR: (gcloud.alpha.storage.ls) One or more URLs matched no objects.":
+            buckets = buckets_ls.split("\n")
             for bucket in buckets:
                 logging.info("Deleting bucket %s", bucket)
                 subprocess.getoutput(f"gcloud alpha storage rm --recursive {bucket}")

--- a/astronomer/providers/google/cloud/example_dags/example_gcp_nuke.py
+++ b/astronomer/providers/google/cloud/example_dags/example_gcp_nuke.py
@@ -7,6 +7,7 @@ from airflow.operators.python import PythonOperator
 from airflow.utils.timezone import datetime
 
 REGION = os.getenv("GCP_LOCATION", "us-central1")
+GCP_PROJECT_NAME = os.getenv("GCP_PROJECT_NAME", "astronomer-airflow-providers")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
 default_args = {
@@ -32,7 +33,7 @@ def gcloud_nuke_callable() -> None:
 
         # Authenticate with GCP using service account file.
         subprocess.getoutput(f"gcloud auth activate-service-account --key-file={sa_file_name}")
-        subprocess.getoutput("gcloud config set project astronomer-airflow-providers")
+        subprocess.getoutput(f"gcloud config set project {GCP_PROJECT_NAME}")
 
         # Delete GKE clusters.
         gke_clusters = json.loads(subprocess.getoutput("gcloud beta container clusters list --format=json"))

--- a/astronomer/providers/google/cloud/example_dags/example_gcp_nuke.py
+++ b/astronomer/providers/google/cloud/example_dags/example_gcp_nuke.py
@@ -1,0 +1,79 @@
+import os
+from datetime import timedelta
+
+from airflow import DAG
+from airflow.models.variable import Variable
+from airflow.operators.python import PythonOperator
+from airflow.utils.timezone import datetime
+
+REGION = os.getenv("GCP_LOCATION", "us-central1")
+EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
+
+default_args = {
+    "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
+}
+
+
+def gcloud_nuke_callable():
+    """Deletes stale GCP resources."""
+    import json
+    import logging
+    import subprocess
+    import tempfile
+
+    sa_json = Variable.get("gcp_nuke_sa_json", deserialize_json=True)
+
+    with tempfile.NamedTemporaryFile("w+") as temp_file:
+        json.dump(sa_json, temp_file)
+        temp_file.flush()
+        sa_file_name = temp_file.name
+
+        # Authenticate with GCP using service account file.
+        subprocess.getoutput(f"gcloud auth activate-service-account --key-file={sa_file_name}")
+        subprocess.getoutput("gcloud config set project astronomer-airflow-providers")
+
+        # Delete GKE clusters.
+        gke_clusters = json.loads(subprocess.getoutput("gcloud beta container clusters list --format=json"))
+        for cluster in gke_clusters:
+            cluster_link = cluster["selfLink"]
+            logging.info("Deleting GKE cluster %s", cluster_link)
+            subprocess.getoutput(
+                f"echo 'Y' | gcloud beta container clusters delete {cluster_link} --region={REGION}"
+            )
+
+        # Delete Dataproc clusters.
+        subprocess.getoutput(f"gcloud config set dataproc/region {REGION}")
+        dataproc_clusters = json.loads(subprocess.getoutput("gcloud dataproc clusters list --format=json"))
+        for cluster in dataproc_clusters:
+            cluster_name = cluster["clusterName"]
+            logging.info("Deleting Dataproc cluster %s", cluster_name)
+            subprocess.getoutput(f"echo 'Y' | gcloud dataproc clusters delete {cluster_name}")
+
+        # Delete compute instances.
+        compute_instances = json.loads(subprocess.getoutput("gcloud compute instances list --format=json"))
+        for instance in compute_instances:
+            instance_name = instance["name"]
+            logging.info("Deleting compute instance %s", instance_name)
+            subprocess.getoutput(f"echo 'Y' | gcloud compute instances delete {instance_name}")
+
+        # Delete storage buckets.
+        buckets = subprocess.getoutput("gcloud alpha storage ls")
+        if buckets != "ERROR: (gcloud.alpha.storage.ls) One or more URLs matched no objects.":
+            buckets = buckets.split("\n")
+            for bucket in buckets:
+                logging.info("Deleting bucket %s", bucket)
+                subprocess.getoutput(f"gcloud alpha storage rm --recursive {bucket}")
+
+
+with DAG(
+    dag_id="example_gcp_nuke",
+    start_date=datetime(2022, 1, 1),
+    schedule_interval="30 20 * * *",
+    catchup=False,
+    default_args=default_args,
+    tags=["example", "gcp", "nuke"],
+    is_paused_upon_creation=False,
+) as dag:
+    gcloud_nuke = PythonOperator(task_id="gcloud_nuke", python_callable=gcloud_nuke_callable)

--- a/astronomer/providers/google/cloud/example_dags/example_kubernetes_engine.py
+++ b/astronomer/providers/google/cloud/example_dags/example_kubernetes_engine.py
@@ -15,7 +15,7 @@ from astronomer.providers.google.cloud.operators.kubernetes_engine import (
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 PROJECT_ID = os.getenv("GCP_PROJECT_ID", "astronomer-airflow-providers")
 GCP_CONN_ID = os.getenv("GCP_CONN_ID", "google_cloud_default")
-LOCATION = os.getenv("GCP_GKE_LOCATION", "us-west1")
+LOCATION = os.getenv("GCP_GKE_LOCATION", "us-central1")
 GKE_CLUSTER_NAME = os.getenv("GKE_CLUSTER_NAME", "provider-team-gke-cluster")
 GKE_NAMESPACE = os.getenv("GKE_NAMESPACE", "default")
 


### PR DESCRIPTION
Use `gcloud sdk` within `PythonOperator` to terminate resources created
in the example DAGs including `GKE clusters`, `Dataproc clusters`,
`Compute instances` and `Storage buckets`.
For authentication, it needs a service account file which is
temporarily created by reading the stringified service account json
stored as variable in Airflow UI.

part of: #44 