### PR TITLE
Update base url for API docs to fix broken links

### DIFF
--- a/docs/_ext/traverse_operators_sensors.py
+++ b/docs/_ext/traverse_operators_sensors.py
@@ -17,7 +17,7 @@ BASE_IMPORT_PATH = "astronomer.providers"
 CURRENT_FILE_PATH = Path(__file__)
 ASTRONOMER_PROVIDERS_PATH = CURRENT_FILE_PATH.parent.parent.parent / "astronomer" / "providers"
 
-BASE_CLASS_DEF_URL = "/astronomer-providers/docs/_build/html/_api/"
+BASE_CLASS_DEF_URL = "/en/stable/_api/"
 
 
 def collect_elements(


### PR DESCRIPTION
Correct the base URL for https://astronomer-providers.readthedocs.io/
so that class def links from operators & sensors list page work
correctly.

closes: #566 