### PR TITLE
Fix error in docstring

### DIFF
--- a/astronomer/providers/http/triggers/http.py
+++ b/astronomer/providers/http/triggers/http.py
@@ -63,7 +63,7 @@ class HttpTrigger(BaseTrigger):
 
     async def run(self) -> AsyncIterator["TriggerEvent"]:  # type: ignore[override]
         """
-        Makes a series of asynchronous http calls via a Databrick hook. It yields a Trigger if
+        Makes a series of asynchronous http calls via an http hook. It yields a Trigger if
         response is a 200 and run_state is successful, will retry the call up to the retry limit
         if the error is 'retryable', otherwise it throws an exception.
         """


### PR DESCRIPTION
The `HttpTrigger.run()` docstring mentions "Databricks" while this should be http.