### PR TITLE
Remove log line in ``SnowflakeHookAsync``

### DIFF
--- a/astronomer/providers/snowflake/hooks/snowflake.py
+++ b/astronomer/providers/snowflake/hooks/snowflake.py
@@ -65,8 +65,6 @@ class SnowflakeHookAsync(SnowflakeHook):
             with closing(conn.cursor(DictCursor)) as cur:
 
                 for sql_statement in sql:
-
-                    self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
                     if parameters:
                         cur.execute_async(sql_statement, parameters)
                     else:


### PR DESCRIPTION
Remove a log line in `SnowflakeHookAsync`. A customer has their AWS key/secret key included in their query, and this line prints it to the logs. Possibly of note: this line has been removed on the current main branch of the regular SnowflakeHook

Closes #573 