### PR TITLE
Fix async databricks job failure due to new airflow provider release

### DIFF
--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -29,7 +29,7 @@ class DatabricksSubmitRunOperatorAsync(DatabricksSubmitRunOperator):  # noqa: D1
             hook = self._get_hook()
         except TypeError:
             # for apache-airflow-providers-databricks>=3.2.0
-            hook = self._get_hook(caller="DatabricksSubmitRunOperatorAsync")
+            hook = self._get_hook(caller="DatabricksSubmitRunOperatorAsync")  # type: ignore[call-arg]
         self.run_id = hook.submit_run(self.json)
         job_id = hook.get_job_id(self.run_id)
 
@@ -85,7 +85,7 @@ class DatabricksRunNowOperatorAsync(DatabricksRunNowOperator):  # noqa: D101
             hook = self._get_hook()
         except TypeError:
             # for apache-airflow-providers-databricks>=3.2.0
-            hook = self._get_hook(caller="DatabricksRunNowOperatorAsync")
+            hook = self._get_hook(caller="DatabricksRunNowOperatorAsync")  # type: ignore[call-arg]
         self.run_id = hook.run_now(self.json)
 
         if self.do_xcom_push:

--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -24,7 +24,12 @@ class DatabricksSubmitRunOperatorAsync(DatabricksSubmitRunOperator):  # noqa: D1
         # Note: This hook makes non-async calls.
         # It is imported from the Databricks base class.
         # Async calls (i.e. polling) are handled in the Trigger.
-        hook = self._get_hook()
+        try:
+            # for apache-airflow-providers-databricks<=3.2.0
+            hook = self._get_hook()
+        except TypeError:
+            # for apache-airflow-providers-databricks>=3.2.0
+            hook = self._get_hook(caller="DatabricksSubmitRunOperatorAsync")
         self.run_id = hook.submit_run(self.json)
         job_id = hook.get_job_id(self.run_id)
 
@@ -75,7 +80,12 @@ class DatabricksRunNowOperatorAsync(DatabricksRunNowOperator):  # noqa: D101
         """
         # Note: This hook makes non-async calls.
         # It is from the Databricks base class.
-        hook = self._get_hook()
+        try:
+            # for apache-airflow-providers-databricks<=3.2.0
+            hook = self._get_hook()
+        except TypeError:
+            # for apache-airflow-providers-databricks>=3.2.0
+            hook = self._get_hook(caller="DatabricksRunNowOperatorAsync")
         self.run_id = hook.run_now(self.json)
 
         if self.do_xcom_push:

--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -25,7 +25,7 @@ class DatabricksSubmitRunOperatorAsync(DatabricksSubmitRunOperator):  # noqa: D1
         # It is imported from the Databricks base class.
         # Async calls (i.e. polling) are handled in the Trigger.
         try:
-            # for apache-airflow-providers-databricks<=3.2.0
+            # for apache-airflow-providers-databricks<3.2.0
             hook = self._get_hook()
         except TypeError:
             # for apache-airflow-providers-databricks>=3.2.0
@@ -81,7 +81,7 @@ class DatabricksRunNowOperatorAsync(DatabricksRunNowOperator):  # noqa: D101
         # Note: This hook makes non-async calls.
         # It is from the Databricks base class.
         try:
-            # for apache-airflow-providers-databricks<=3.2.0
+            # for apache-airflow-providers-databricks<3.2.0
             hook = self._get_hook()
         except TypeError:
             # for apache-airflow-providers-databricks>=3.2.0

--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -29,6 +29,7 @@ class DatabricksSubmitRunOperatorAsync(DatabricksSubmitRunOperator):  # noqa: D1
             hook = self._get_hook()
         except TypeError:
             # for apache-airflow-providers-databricks>=3.2.0
+            # TODO remove the ignore[call-arg] once databrick version 3.2.0 is released.
             hook = self._get_hook(caller="DatabricksSubmitRunOperatorAsync")  # type: ignore[call-arg]
         self.run_id = hook.submit_run(self.json)
         job_id = hook.get_job_id(self.run_id)
@@ -85,6 +86,7 @@ class DatabricksRunNowOperatorAsync(DatabricksRunNowOperator):  # noqa: D101
             hook = self._get_hook()
         except TypeError:
             # for apache-airflow-providers-databricks>=3.2.0
+            # TODO remove the ignore[call-arg] once databrick version 3.2.0 is released.
             hook = self._get_hook(caller="DatabricksRunNowOperatorAsync")  # type: ignore[call-arg]
         self.run_id = hook.run_now(self.json)
 

--- a/tests/databricks/operators/test_databricks.py
+++ b/tests/databricks/operators/test_databricks.py
@@ -241,7 +241,7 @@ def test_databricks_run_now_operator_async_hook(mock_get_hook):
         operator.execute(context=create_context(operator))
 
 
-@mock.patch("airflow.providers.databricks.operators.databricks.DatabricksRunNowOperator._get_hook")
+@mock.patch("airflow.providers.databricks.operators.databricks.DatabricksSubmitRunOperator._get_hook")
 def test_databricks_submit_run_operator_async_hook(mock_get_hook):
     """
     Asserts that a hooks is raising an type error for apache-airflow-providers-databricks>=3.2.0

--- a/tests/databricks/operators/test_databricks.py
+++ b/tests/databricks/operators/test_databricks.py
@@ -228,7 +228,7 @@ def test_databricks_run_now_execute_complete_success(submit_run_response, get_ru
 @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksRunNowOperator._get_hook")
 def test_databricks_run_now_operator_async_hook(mock_get_hook):
     """
-    Asserts that a hooks is raising an type error for apache-airflow-providers-databricks>=3.2.0
+    Asserts that the hook raises TypeError for apache-airflow-providers-databricks>=3.2.0
     when the DatabricksRunNowOperatorAsync is executed.
     """
     mock_get_hook.side_effect = TypeError("test exception")
@@ -244,7 +244,7 @@ def test_databricks_run_now_operator_async_hook(mock_get_hook):
 @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksSubmitRunOperator._get_hook")
 def test_databricks_submit_run_operator_async_hook(mock_get_hook):
     """
-    Asserts that a hooks is raising an type error for apache-airflow-providers-databricks>=3.2.0
+    Asserts that the hook raises TypeError for apache-airflow-providers-databricks>=3.2.0
     when the DatabricksSubmitRunOperatorAsync is executed.
     """
     mock_get_hook.side_effect = TypeError("test exception")

--- a/tests/databricks/operators/test_databricks.py
+++ b/tests/databricks/operators/test_databricks.py
@@ -223,3 +223,37 @@ def test_databricks_run_now_execute_complete_success(submit_run_response, get_ru
         )
         is None
     )
+
+
+@mock.patch("airflow.providers.databricks.operators.databricks.DatabricksRunNowOperator._get_hook")
+def test_databricks_run_now_operator_async_hook(mock_get_hook):
+    """
+    Asserts that a hooks is raising an type error for apache-airflow-providers-databricks>=3.2.0
+    when the DatabricksRunNowOperatorAsync is executed.
+    """
+    mock_get_hook.side_effect = TypeError("test exception")
+    operator = DatabricksRunNowOperatorAsync(
+        task_id="run_now",
+        databricks_conn_id=CONN_ID,
+    )
+
+    with pytest.raises(TypeError):
+        operator.execute(context=create_context(operator))
+
+
+@mock.patch("airflow.providers.databricks.operators.databricks.DatabricksRunNowOperator._get_hook")
+def test_databricks_submit_run_operator_async_hook(mock_get_hook):
+    """
+    Asserts that a hooks is raising an type error for apache-airflow-providers-databricks>=3.2.0
+    when the DatabricksSubmitRunOperatorAsync is executed.
+    """
+    mock_get_hook.side_effect = TypeError("test exception")
+    operator = DatabricksSubmitRunOperatorAsync(
+        task_id="submit_run",
+        databricks_conn_id=CONN_ID,
+        existing_cluster_id="xxxx-xxxxxx-xxxxxx",
+        notebook_task={"notebook_path": "/Users/test@astronomer.io/Quickstart Notebook"},
+    )
+
+    with pytest.raises(TypeError):
+        operator.execute(context=create_context(operator))


### PR DESCRIPTION
A new version of Databricks `apache-airflow-providers-databricks==3.2.0rc3` while running dag it fails due to TypeError: _get_hook() missing 1 required positional argument: 'caller'. The OSS PR link which caused the issue can be found [here](https://github.com/apache/airflow/pull/25115/files#diff-30731826b25d422cb6069898701e34f8ef23b2a32b7782444793a14bc52b0cb1)
So this PR fixes the error by adding the argument caller and also supports backward compatibility for the previous version as well.

Closes #581 