### PR TITLE
Add temporary logs to debug intermittent failures of the Dataproc DAG

### DIFF
--- a/astronomer/providers/google/cloud/operators/dataproc.py
+++ b/astronomer/providers/google/cloud/operators/dataproc.py
@@ -97,6 +97,11 @@ class DataprocCreateClusterOperatorAsync(DataprocCreateClusterOperator):
 
         end_time: float = time.monotonic() + self.timeout
 
+        # Add below temporary log to check timestamp values for debugging intermittent failure of the example DAG.
+        self.log.info(
+            "In Dataproc Operator: End time is %s, monotonic time is %s", end_time, time.monotonic()
+        )
+
         self.defer(
             trigger=DataprocCreateClusterTrigger(
                 project_id=self.project_id,

--- a/astronomer/providers/google/cloud/triggers/dataproc.py
+++ b/astronomer/providers/google/cloud/triggers/dataproc.py
@@ -73,7 +73,22 @@ class DataprocCreateClusterTrigger(BaseTrigger, ABC):
 
     async def run(self) -> AsyncIterator["TriggerEvent"]:  # type: ignore[override]
         """Check the status of cluster until reach the terminal state"""
+        # Add below temporary log to check timestamp values for debugging intermittent failure of the example DAG.
+        self.log.info(
+            "Creating Dataproc cluster: Before entering while loop, end time: %s, monotonic time: %s",
+            self.end_time,
+            time.monotonic(),
+        )
+
         while self.end_time > time.monotonic():
+
+            # Add below temporary log to check timestamp values for debugging intermittent failure of the example DAG.
+            self.log.info(
+                "Creating Dataproc cluster: In while loop, end time: %s , monotonic time: %s",
+                self.end_time,
+                time.monotonic(),
+            )
+
             try:
                 cluster = await self._get_cluster()
                 if cluster.status.state == cluster.status.State.RUNNING:


### PR DESCRIPTION
The Dataproc DAG has been failing intermittently due to timeout
error. The Timeout error is a custom error returned by the trigger
when the end_time value passed to the trigger is greater than the
default timeout value of 3600 seconds set when the cluster creation
is triggered. We want to check why is the end_time condition check
failing for the DAG by checking its set value when the DAG fails.

part of #512 