### PR TITLE
Fix dead links in repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -116,13 +116,13 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+https://www.contributor-covenant.org/version/2/0/code_of_conduct/.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
+enforcement ladder](https://github.com/mozilla/inclusion).
 
-[homepage]: https://www.contributor-covenant.org
+[homepage]: https://www.contributor-covenant.org/
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+https://www.contributor-covenant.org/faq/. Translations are available at
+https://www.contributor-covenant.org/translations/.


### PR DESCRIPTION
The pre-Commit hook failed for dead links. Below are the dead links found.
 ERROR: 5 dead links found!
  [✖] https://www.contributor-covenant.org → Status: 0
  [✖] https://www.contributor-covenant.org/version/2/0/code_of_conduct.html → Status: 0
  [✖] https://github.com/mozilla/diversity → Status: 0
  [✖] https://www.contributor-covenant.org/faq → Status: 0
  [✖] https://www.contributor-covenant.org/translations → Status: 0