### PR TITLE
Upgrade astro runtime image to latest release 5.0.7

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -1,5 +1,5 @@
 # Deploy from astro runtime image
-FROM quay.io/astronomer/astro-runtime:5.0.6-base
+FROM quay.io/astronomer/astro-runtime:5.0.7-base
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0

--- a/.circleci/integration-tests/Dockerfile.gen_1
+++ b/.circleci/integration-tests/Dockerfile.gen_1
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/ap-airflow:2.3.3-1
+FROM quay.io/astronomer/ap-airflow:2.3.3-2
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq (run-mypy,$(firstword $(MAKECMDGOALS)))
   $(eval $(RUN_ARGS):;@:)
 endif
 
-ASTRO_RUNTIME_IMAGE_NAME = "quay.io/astronomer/astro-runtime:5.0.6-base"
+ASTRO_RUNTIME_IMAGE_NAME = "quay.io/astronomer/astro-runtime:5.0.7-base"
 
 dev: ## Create a development Environment using `docker compose` file.
 	IMAGE_NAME=$(ASTRO_RUNTIME_IMAGE_NAME) docker compose -f dev/docker-compose.yaml up -d


### PR DESCRIPTION
New release 5.0.7 for astro runtime was out on 16th August. Upgrade to the same.