### PR TITLE
Fix GCP Dataproc DAG failed with timeout error

### DIFF
--- a/astronomer/providers/google/cloud/operators/dataproc.py
+++ b/astronomer/providers/google/cloud/operators/dataproc.py
@@ -181,7 +181,7 @@ class DataprocDeleteClusterOperatorAsync(DataprocDeleteClusterOperator):
             metadata=self.metadata,
         )
 
-        end_time: float = time.monotonic() + self.timeout
+        end_time: float = time.time() + self.timeout
 
         self.defer(
             trigger=DataprocDeleteClusterTrigger(
@@ -354,7 +354,7 @@ class DataprocUpdateClusterOperatorAsync(DataprocUpdateClusterOperator):
             metadata=self.metadata,
         )
 
-        end_time: float = time.monotonic() + self.timeout
+        end_time: float = time.time() + self.timeout
 
         self.defer(
             trigger=DataprocCreateClusterTrigger(

--- a/astronomer/providers/google/cloud/operators/dataproc.py
+++ b/astronomer/providers/google/cloud/operators/dataproc.py
@@ -95,12 +95,7 @@ class DataprocCreateClusterOperatorAsync(DataprocCreateClusterOperator):
                 raise
             self.log.info("Cluster already exists.")
 
-        end_time: float = time.monotonic() + self.timeout
-
-        # Add below temporary log to check timestamp values for debugging intermittent failure of the example DAG.
-        self.log.info(
-            "In Dataproc Operator: End time is %s, monotonic time is %s", end_time, time.monotonic()
-        )
+        end_time: float = time.time() + self.timeout
 
         self.defer(
             trigger=DataprocCreateClusterTrigger(

--- a/astronomer/providers/google/cloud/triggers/dataproc.py
+++ b/astronomer/providers/google/cloud/triggers/dataproc.py
@@ -132,7 +132,7 @@ class DataprocCreateClusterTrigger(BaseTrigger, ABC):
         )
 
     async def _wait_for_deleting(self) -> None:
-        while self.end_time > time.monotonic():
+        while self.end_time > time.time():
             try:
                 cluster = await self._get_cluster()
                 if cluster.status.State.DELETING:
@@ -228,7 +228,7 @@ class DataprocDeleteClusterTrigger(BaseTrigger, ABC):
     async def run(self) -> AsyncIterator["TriggerEvent"]:  # type: ignore[override]
         """Wait until cluster is deleted completely"""
         hook = DataprocHookAsync(gcp_conn_id=self.gcp_conn_id)
-        while self.end_time > time.monotonic():
+        while self.end_time > time.time():
             try:
                 cluster = await hook.get_cluster(
                     region=self.region,  # type: ignore[arg-type]

--- a/astronomer/providers/google/cloud/triggers/dataproc.py
+++ b/astronomer/providers/google/cloud/triggers/dataproc.py
@@ -73,22 +73,7 @@ class DataprocCreateClusterTrigger(BaseTrigger, ABC):
 
     async def run(self) -> AsyncIterator["TriggerEvent"]:  # type: ignore[override]
         """Check the status of cluster until reach the terminal state"""
-        # Add below temporary log to check timestamp values for debugging intermittent failure of the example DAG.
-        self.log.info(
-            "Creating Dataproc cluster: Before entering while loop, end time: %s, monotonic time: %s",
-            self.end_time,
-            time.monotonic(),
-        )
-
-        while self.end_time > time.monotonic():
-
-            # Add below temporary log to check timestamp values for debugging intermittent failure of the example DAG.
-            self.log.info(
-                "Creating Dataproc cluster: In while loop, end time: %s , monotonic time: %s",
-                self.end_time,
-                time.monotonic(),
-            )
-
+        while self.end_time > time.time():
             try:
                 cluster = await self._get_cluster()
                 if cluster.status.state == cluster.status.State.RUNNING:

--- a/tests/google/cloud/triggers/test_dataproc.py
+++ b/tests/google/cloud/triggers/test_dataproc.py
@@ -193,7 +193,7 @@ async def test_run_running(mock_get_cluster):
         region=TEST_REGION,
         cluster_name="test_cluster",
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() + 100,
+        end_time=time.time() + 100,
         metadata=(),
     )
 
@@ -218,7 +218,7 @@ async def test_run_pending(mock_get_cluster):
         region=TEST_REGION,
         cluster_name="test_cluster",
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() + 100,
+        end_time=time.time() + 100,
         metadata=(),
     )
 
@@ -240,7 +240,7 @@ async def test_run_exception(mock_get_cluster):
         region=TEST_REGION,
         cluster_name="test_cluster",
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() + 100,
+        end_time=time.time() + 100,
         metadata=(),
     )
 
@@ -257,7 +257,7 @@ async def test_run_timeout():
         region=TEST_REGION,
         cluster_name="test_cluster",
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() - 100,
+        end_time=time.time() - 100,
         metadata=(),
     )
 
@@ -273,7 +273,7 @@ def test__create_cluster(mock_create_cluster):
         region=TEST_REGION,
         cluster_name=TEST_CLUSTER_NAME,
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() - 100,
+        end_time=time.time() - 100,
         metadata=(),
     )
     trigger._create_cluster()
@@ -296,7 +296,7 @@ def test__diagnose_cluster(mock_diagnose_cluster):
         region=TEST_REGION,
         cluster_name=TEST_CLUSTER_NAME,
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() - 100,
+        end_time=time.time() - 100,
         metadata=(),
     )
     trigger._diagnose_cluster()
@@ -317,7 +317,7 @@ def test__delete_cluster(mock_delete_cluster):
         region=TEST_REGION,
         cluster_name=TEST_CLUSTER_NAME,
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() - 100,
+        end_time=time.time() - 100,
         metadata=(),
     )
     trigger._delete_cluster()
@@ -344,7 +344,7 @@ async def test__wait_for_deleting(mock_get_cluster):
         region=TEST_REGION,
         cluster_name="test_cluster",
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() + 100,
+        end_time=time.time() + 100,
         metadata=(),
     )
 
@@ -366,7 +366,7 @@ async def test_wait_for_deleting_success(mock__get_cluster):
         region=TEST_REGION,
         cluster_name="test_cluster",
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() + 100,
+        end_time=time.time() + 100,
         metadata=(),
     )
     assert await trigger._wait_for_deleting() is None
@@ -382,7 +382,7 @@ async def test_wait_for_deleting_exception(mock__get_cluster):
         region=TEST_REGION,
         cluster_name="test_cluster",
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() + 100,
+        end_time=time.time() + 100,
         metadata=(),
     )
     with pytest.raises(Exception):
@@ -421,7 +421,7 @@ async def test__handle_error(
         region=TEST_REGION,
         cluster_name="test_cluster",
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() + 100,
+        end_time=time.time() + 100,
         metadata=(),
         delete_on_error=delete_on_error,
     )
@@ -442,7 +442,7 @@ async def test__handle_error_with_no_error():
         region=TEST_REGION,
         cluster_name="test_cluster",
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() + 100,
+        end_time=time.time() + 100,
         metadata=(),
     )
 
@@ -490,7 +490,7 @@ async def test_delete_cluster_run_pending(mock_get_cluster):
         region=TEST_REGION,
         cluster_name="test_cluster",
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() + 100,
+        end_time=time.time() + 100,
         metadata=(),
     )
 
@@ -513,7 +513,7 @@ async def test_delete_run_success(mock_get_cluster):
         region=TEST_REGION,
         cluster_name="test_cluster",
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() + 100,
+        end_time=time.time() + 100,
         metadata=(),
     )
     generator = trigger.run()
@@ -532,7 +532,7 @@ async def test_delete_run_exception(mock_get_cluster):
         region=TEST_REGION,
         cluster_name="test_cluster",
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() + 100,
+        end_time=time.time() + 100,
         metadata=(),
     )
     generator = trigger.run()
@@ -568,7 +568,7 @@ async def test_run_deleting(mock_get_cluster, mock_wait_for_deleting, mock_creat
         region=TEST_REGION,
         cluster_name="test_cluster",
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() + 100,
+        end_time=time.time() + 100,
         metadata=(),
     )
     asyncio.create_task(trigger.run().__anext__())
@@ -590,7 +590,7 @@ async def test_delete_run_timeout(mock_get_cluster):
         region=TEST_REGION,
         cluster_name="test_cluster",
         polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.monotonic() - 100,
+        end_time=time.time() - 100,
         metadata=(),
     )
     generator = trigger.run()


### PR DESCRIPTION
`time.monotonic()` was having a larger time than end time at times. Attaching screenshot for reference
<img width="1698" alt="Screenshot 2022-08-16 at 1 49 54 PM" src="https://user-images.githubusercontent.com/92459020/185081959-f57c2f82-17bf-4d87-9ba0-d5112bf84a57.png">
So replacing `time.monotonic()`  with `time.time()`
Closes #512 