### PR TITLE
Add support for Python3.10 for Databricks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ cncf.kubernetes =
     kubernetes_asyncio
 databricks =
     apache-airflow-providers-databricks>=2.2.0
+    databricks-sql-connector>=2.0.4;python_version>='3.10'
 google =
     apache-airflow-providers-google>=8.1.0
     gcloud-aio-storage
@@ -123,6 +124,7 @@ all =
     apache-airflow-providers-http
     apache-airflow-providers-snowflake
     apache-airflow-providers-microsoft-azure
+    databricks-sql-connector>=2.0.4;python_version>='3.10'
     gcloud-aio-bigquery
     gcloud-aio-storage
     kubernetes_asyncio


### PR DESCRIPTION
Databricks was unable to install on python3.10 due to `databricks-sql-connector ` didn't have support for it till 2.0.3 release.
This PR adds the new version of `databricks-sql-connector`  to add support for python3.10.