### PR TITLE
Fix import error for snowflake extractor

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -22,9 +22,8 @@ x-airflow-common:
     ASTRONOMER_ENVIRONMENT: local
     AIRFLOW__LINEAGE__BACKEND: openlineage.lineage_backend.OpenLineageBackend
     OPENLINEAGE_URL: http://host.docker.internal:5050/
-    OPENLINEAGE_EXTRACTORS: >-
-      astronomer.providers.google.cloud.extractors.bigquery.BigQueryAsyncExtractor;
-      astronomer.providers.snowflake.extractors.snowflake.SnowflakeAsyncExtractor
+    OPENLINEAGE_EXTRACTORS: "astronomer.providers.google.cloud.extractors.bigquery.BigQueryAsyncExtractor;\
+                            astronomer.providers.snowflake.extractors.snowflake.SnowflakeAsyncExtractor"
   volumes:
     - ./dags:/usr/local/airflow/dags
     - ./logs:/usr/local/airflow/logs


### PR DESCRIPTION
look like `>-` in YAML put a space at the end for multiline string because of that import was failing in dev container for the snowflake extractor 

closes: https://github.com/astronomer/astronomer-providers/issues/606