### PR TITLE
Compare timeouts in ADF triggerer realtime

### DIFF
--- a/astronomer/providers/microsoft/azure/operators/data_factory.py
+++ b/astronomer/providers/microsoft/azure/operators/data_factory.py
@@ -1,4 +1,3 @@
-import time
 from typing import Any, Dict
 
 from airflow.exceptions import AirflowException

--- a/astronomer/providers/microsoft/azure/operators/data_factory.py
+++ b/astronomer/providers/microsoft/azure/operators/data_factory.py
@@ -69,7 +69,7 @@ class AzureDataFactoryRunPipelineOperatorAsync(AzureDataFactoryRunPipelineOperat
                 resource_group_name=self.resource_group_name,
                 factory_name=self.factory_name,
                 check_interval=self.check_interval,
-                end_time=end_time,
+                end_time=self.timeout,
             ),
             method_name="execute_complete",
         )

--- a/astronomer/providers/microsoft/azure/operators/data_factory.py
+++ b/astronomer/providers/microsoft/azure/operators/data_factory.py
@@ -68,7 +68,7 @@ class AzureDataFactoryRunPipelineOperatorAsync(AzureDataFactoryRunPipelineOperat
                 resource_group_name=self.resource_group_name,
                 factory_name=self.factory_name,
                 check_interval=self.check_interval,
-                end_time=self.timeout,
+                timeout=self.timeout,
             ),
             method_name="execute_complete",
         )

--- a/astronomer/providers/microsoft/azure/operators/data_factory.py
+++ b/astronomer/providers/microsoft/azure/operators/data_factory.py
@@ -59,8 +59,7 @@ class AzureDataFactoryRunPipelineOperatorAsync(AzureDataFactoryRunPipelineOperat
             parameters=self.parameters,
         )
         run_id = vars(response)["run_id"]
-        context["ti"].xcom_push(key="run_id", value=run_id)
-        end_time = time.time() + self.timeout
+        context["ti"].xcom_push(key="run_id", value=run_id)        
         self.defer(
             timeout=self.execution_timeout,
             trigger=AzureDataFactoryTrigger(

--- a/astronomer/providers/microsoft/azure/triggers/data_factory.py
+++ b/astronomer/providers/microsoft/azure/triggers/data_factory.py
@@ -84,7 +84,7 @@ class AzureDataFactoryTrigger(BaseTrigger):
 
     :param run_id: Run id of a Azure data pipeline run job.
     :param azure_data_factory_conn_id: The connection identifier for connecting to Azure Data Factory.
-    :param end_time: Time in seconds when triggers will timeout.
+    :param timeout: Time in seconds when triggers will timeout.
     :param resource_group_name: The resource group name.
     :param factory_name: The data factory name.
     :param wait_for_termination: Flag to wait on a pipeline run's termination.
@@ -107,7 +107,7 @@ class AzureDataFactoryTrigger(BaseTrigger):
         self,
         run_id: str,
         azure_data_factory_conn_id: str,
-        end_time: float,
+        timeout: int,
         resource_group_name: Optional[str] = None,
         factory_name: Optional[str] = None,
         wait_for_termination: bool = True,
@@ -120,7 +120,7 @@ class AzureDataFactoryTrigger(BaseTrigger):
         self.wait_for_termination = wait_for_termination
         self.resource_group_name = resource_group_name
         self.factory_name = factory_name
-        self.end_time = end_time
+        self.timeout = timeout
 
     def serialize(self) -> Tuple[str, Dict[str, Any]]:
         """Serializes AzureDataFactoryTrigger arguments and classpath."""
@@ -133,7 +133,7 @@ class AzureDataFactoryTrigger(BaseTrigger):
                 "wait_for_termination": self.wait_for_termination,
                 "resource_group_name": self.resource_group_name,
                 "factory_name": self.factory_name,
-                "end_time": self.end_time,
+                "timeout": self.timeout,
             },
         )
 
@@ -146,8 +146,9 @@ class AzureDataFactoryTrigger(BaseTrigger):
                 resource_group_name=self.resource_group_name,
                 factory_name=self.factory_name,
             )
+            start_time = time.monotonic()
             if self.wait_for_termination:
-                while self.end_time > time.time():
+                while self.timeout > time.monotonic() - start_time:
                     pipeline_status = await hook.get_adf_pipeline_run_status(
                         run_id=self.run_id,
                         resource_group_name=self.resource_group_name,

--- a/tests/microsoft/azure/triggers/test_data_factory.py
+++ b/tests/microsoft/azure/triggers/test_data_factory.py
@@ -20,7 +20,7 @@ AZ_PIPELINE_RUN_ID = "123"
 AZ_RESOURCE_GROUP_NAME = "test-rg"
 AZ_FACTORY_NAME = "test-factory"
 AZ_DATA_FACTORY_CONN_ID = "test-conn"
-AZ_PIPELINE_END_TIME = time.time() + 60 * 60 * 24 * 7
+AZ_PIPELINE_END_TIMEOUT = 60 * 60 * 24 * 7
 
 
 def test_adf_pipeline_run_status_sensors_trigger_serialization():
@@ -158,7 +158,7 @@ def test_azure_data_factory_trigger_serialization():
         resource_group_name=AZ_RESOURCE_GROUP_NAME,
         factory_name=AZ_FACTORY_NAME,
         azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
-        end_time=AZ_PIPELINE_END_TIME,
+        timeout=AZ_PIPELINE_END_TIMEOUT,
     )
 
     classpath, kwargs = trigger.serialize()
@@ -168,7 +168,7 @@ def test_azure_data_factory_trigger_serialization():
         "resource_group_name": AZ_RESOURCE_GROUP_NAME,
         "factory_name": AZ_FACTORY_NAME,
         "azure_data_factory_conn_id": AZ_DATA_FACTORY_CONN_ID,
-        "end_time": AZ_PIPELINE_END_TIME,
+        "timeout": AZ_PIPELINE_END_TIMEOUT,
         "wait_for_termination": True,
         "check_interval": 60,
     }
@@ -187,7 +187,7 @@ async def test_azure_data_factory_trigger_run_without_wait(mock_pipeline_run_sta
         factory_name=AZ_FACTORY_NAME,
         azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
         wait_for_termination=False,
-        end_time=AZ_PIPELINE_END_TIME,
+        timeout=AZ_PIPELINE_END_TIMEOUT,
     )
     generator = trigger.run()
     actual = await generator.asend(None)
@@ -221,7 +221,7 @@ async def test_azure_data_factory_trigger_run_pending(mock_pipeline_run_status, 
         resource_group_name=AZ_RESOURCE_GROUP_NAME,
         factory_name=AZ_FACTORY_NAME,
         azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
-        end_time=AZ_PIPELINE_END_TIME,
+        timeout=AZ_PIPELINE_END_TIMEOUT,
     )
     task = asyncio.create_task(trigger.run().__anext__())
     await asyncio.sleep(0.5)
@@ -243,7 +243,7 @@ async def test_azure_data_factory_trigger_run_success(mock_pipeline_run_status):
         resource_group_name=AZ_RESOURCE_GROUP_NAME,
         factory_name=AZ_FACTORY_NAME,
         azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
-        end_time=AZ_PIPELINE_END_TIME,
+        timeout=AZ_PIPELINE_END_TIMEOUT,
     )
     generator = trigger.run()
     actual = await generator.asend(None)
@@ -276,7 +276,7 @@ async def test_azure_data_factory_trigger_run_fail(mock_pipeline_run_status, sta
         resource_group_name=AZ_RESOURCE_GROUP_NAME,
         factory_name=AZ_FACTORY_NAME,
         azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
-        end_time=AZ_PIPELINE_END_TIME,
+        timeout=AZ_PIPELINE_END_TIMEOUT,
     )
     generator = trigger.run()
     actual = await generator.asend(None)
@@ -302,7 +302,7 @@ async def test_azure_data_factory_trigger_run_exception(mock_pipeline_run_status
         resource_group_name=AZ_RESOURCE_GROUP_NAME,
         factory_name=AZ_FACTORY_NAME,
         azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
-        end_time=AZ_PIPELINE_END_TIME,
+        timeout=AZ_PIPELINE_END_TIMEOUT,
     )
     task = [i async for i in trigger.run()]
     response = TriggerEvent(
@@ -321,14 +321,14 @@ async def test_azure_data_factory_trigger_run_exception(mock_pipeline_run_status
     "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status"
 )
 async def test_azure_data_factory_trigger_run_timeout(mock_pipeline_run_status):
-    """Assert that run timeout after end_time elapsed"""
+    """Assert that run timeout after timeout elapsed"""
     mock_pipeline_run_status.return_value = AzureDataFactoryTrigger.QUEUED
     trigger = AzureDataFactoryTrigger(
         run_id=AZ_PIPELINE_RUN_ID,
         resource_group_name=AZ_RESOURCE_GROUP_NAME,
         factory_name=AZ_FACTORY_NAME,
         azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
-        end_time=time.time(),
+        timeout=time.time(),
     )
     generator = trigger.run()
     actual = await generator.asend(None)

--- a/tests/microsoft/azure/triggers/test_data_factory.py
+++ b/tests/microsoft/azure/triggers/test_data_factory.py
@@ -328,7 +328,7 @@ async def test_azure_data_factory_trigger_run_timeout(mock_pipeline_run_status):
         resource_group_name=AZ_RESOURCE_GROUP_NAME,
         factory_name=AZ_FACTORY_NAME,
         azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
-        timeout=time.time(),
+        timeout=0,
     )
     generator = trigger.run()
     actual = await generator.asend(None)

--- a/tests/microsoft/azure/triggers/test_data_factory.py
+++ b/tests/microsoft/azure/triggers/test_data_factory.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 from unittest import mock
 
 import pytest


### PR DESCRIPTION
Currently, the design assumes that the triggerer process and the worker process are working in the same execution context(pod/vm etc).

While monotonic time functions are the right way to compare timeouts, they are required to have the same reference point during time comparison.

For this reason, this PR looks at moving away from the `end_time` parameter in the Triggerer and passes the task's timeout value directly to the Triggerer so that the time comparison can be done in the triggerer process.