### PR TITLE
Use astro-runtime:5.0.8-base for integration tests

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -1,5 +1,5 @@
 # Deploy from astro runtime image
-FROM quay.io/astronomer/astro-runtime:5.0.7-base
+FROM quay.io/astronomer/astro-runtime:5.0.8-base
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq (run-mypy,$(firstword $(MAKECMDGOALS)))
   $(eval $(RUN_ARGS):;@:)
 endif
 
-ASTRO_RUNTIME_IMAGE_NAME = "quay.io/astronomer/astro-runtime:5.0.7-base"
+ASTRO_RUNTIME_IMAGE_NAME = "quay.io/astronomer/astro-runtime:5.0.8-base"
 
 dev: ## Create a development Environment using `docker compose` file.
 	IMAGE_NAME=$(ASTRO_RUNTIME_IMAGE_NAME) docker compose -f dev/docker-compose.yaml up -d


### PR DESCRIPTION
Since 5.0.8 got released, this PR updates the `astro-runtime` version to use for our integration tests