### PR TITLE
Async Databricks Operator: raise exception instead of return in case of user error

### DIFF
--- a/astronomer/providers/databricks/hooks/databricks.py
+++ b/astronomer/providers/databricks/hooks/databricks.py
@@ -116,8 +116,10 @@ class DatabricksHookAsync(DatabricksHook):
                 except ClientResponseError as e:
                     if not self._retryable_error_async(e):
                         # In this case, the user probably made a mistake.
-                        # Don't retry.
-                        return {"Response": {e.message}, "Status Code": {e.status}}
+                        # Don't retry rather raise exception
+                        error_message = "{Response:" + {e.message} + "Status Code:" + e.status + "}"
+                        self.log.info(error_message)
+                        raise AirflowException(error_message)
                     self._log_request_error(attempt_num, str(e))
 
                 if attempt_num == self.retry_limit:

--- a/astronomer/providers/databricks/hooks/databricks.py
+++ b/astronomer/providers/databricks/hooks/databricks.py
@@ -117,9 +117,7 @@ class DatabricksHookAsync(DatabricksHook):
                     if not self._retryable_error_async(e):
                         # In this case, the user probably made a mistake.
                         # Don't retry rather raise exception
-                        error_message = "{Response:" + {e.message} + "Status Code:" + e.status + "}"
-                        self.log.info(error_message)
-                        raise AirflowException(error_message)
+                        raise AirflowException(str(e))
                     self._log_request_error(attempt_num, str(e))
 
                 if attempt_num == self.retry_limit:

--- a/tests/databricks/hooks/test_databricks.py
+++ b/tests/databricks/hooks/test_databricks.py
@@ -139,9 +139,8 @@ async def test_do_api_call_async_non_retryable_error(aioresponse):
         status=400,
     )
 
-    response = await hook._do_api_call_async(GET_RUN_ENDPOINT, params)
-
-    assert response == {"Response": {"Bad Request"}, "Status Code": {400}}
+    with pytest.raises(AirflowException):
+        await hook._do_api_call_async(GET_RUN_ENDPOINT, params)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
currently, `_do_api_call_async` of databricks does not raise an exception in case of user error instead it returns a Dict because of this the caller of this method might not be aware that the API call was successful or not and the code execution will break in an unexpected way. in this PR I'm modifying this to raise an exception instead of returning Dict. 
https://github.com/astronomer/astronomer-providers/blob/main/astronomer/providers/databricks/hooks/databricks.py#L53