### PR TITLE
Remove werkzeug dep

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,10 +40,6 @@ install_requires =
     asgiref
     typing_extensions; python_version < "3.8"
     markupsafe>=1.1.1
-    # werkzeug 2.2.0 breaks flask-login. see https://github.com/maxcountryman/flask-login/issues/686 for details.
-    # It causes ImportError: cannot import name 'parse_rule' from 'werkzeug.routing'
-    # we need werkzeug<2.2 limitation until flask_login can handle it
-    werkzeug>=2.0,<2.2
 zip_safe = false
 
 [options.extras_require]


### PR DESCRIPTION
Since https://github.com/maxcountryman/flask-login/issues/686 is fixed and Airflow 2.4 (alpha at the moment) won't need it, we are good to remove it from our setup.cfg