### PR TITLE
Add check for PEM exists for Hive and Livy DAG.

### DIFF
--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Any, List
 
 from airflow import DAG, settings
+from airflow.exceptions import AirflowException
 from airflow.models import Connection, Variable
 from airflow.operators.python import PythonOperator
 from airflow.providers.amazon.aws.operators.emr import (
@@ -220,6 +221,10 @@ def create_key_pair() -> None:
 
     # write private key to file with 400 permissions
     os.chmod(f"/tmp/{PEM_FILENAME}.pem", 0o400)
+    # check if the PEM file exists or not.
+    if not os.path.exists(f"/tmp/{PEM_FILENAME}.pem"):
+        # if it doesn't exists raise an error.
+        raise AirflowException("PEM file wasn't copied properly.")
 
 
 def ssh_and_run_command(task_instance: Any, **kwargs: Any) -> None:

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from typing import Any, List
 
 from airflow import DAG, settings
+from airflow.exceptions import AirflowException
 from airflow.models import Connection, Variable
 from airflow.operators.python import PythonOperator
 from airflow.providers.amazon.aws.operators.emr import (
@@ -183,6 +184,10 @@ def create_key_pair() -> None:
 
     # write private key to file with 400 permissions
     os.chmod(f"/tmp/{PEM_FILENAME}.pem", 0o400)
+    # check if the PEM file exists or not.
+    if not os.path.exists(f"/tmp/{PEM_FILENAME}.pem"):
+        # if it doesn't exists raise an error.
+        raise AirflowException("PEM file wasn't copied properly.")
 
 
 def ssh_and_run_command(task_instance: Any, **kwargs: Any) -> None:

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -169,10 +169,11 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
             raise error
 
 
-def create_key_pair() -> None:
+def ssh_and_run_command(task_instance: Any, **kwargs: Any) -> None:
     """
     Load the private_key from airflow variable and creates a pem_file
-    at /tmp/.
+    at /tmp/. SSH into the machine and execute the bash script from the list
+    of commands.
     """
     # remove the file if it exists
     if os.path.exists(f"/tmp/{PEM_FILENAME}.pem"):
@@ -189,12 +190,6 @@ def create_key_pair() -> None:
         # if it doesn't exists raise an error.
         raise AirflowException("PEM file wasn't copied properly.")
 
-
-def ssh_and_run_command(task_instance: Any, **kwargs: Any) -> None:
-    """
-    SSH into the machine and execute the bash script from the list
-    of commands.
-    """
     import paramiko
 
     key = paramiko.RSAKey.from_private_key_file(kwargs["path_to_pem_file"])
@@ -262,13 +257,6 @@ with DAG(
     default_args=default_args,
     tags=["example", "async", "livy"],
 ) as dag:
-    # [START howto_create_key_pair_file]
-    create_key_pair_file = PythonOperator(
-        task_id="create_key_pair_file",
-        python_callable=create_key_pair,
-    )
-    # [END howto_create_key_pair_file]
-
     # [START howto_operator_emr_create_job_flow]
     cluster_creator = EmrCreateJobFlowOperator(
         task_id="cluster_creator",
@@ -334,8 +322,7 @@ with DAG(
     # [END howto_operator_emr_terminate_job_flow]
 
     (
-        create_key_pair_file
-        >> cluster_creator
+        cluster_creator
         >> describe_created_cluster
         >> get_and_add_ip_address_for_inbound_rules
         >> ssh_and_copy_pifile_to_hdfs


### PR DESCRIPTION
While running hive or livy dag where we use ssh to login into the machine pem file was missing in /tmp folder.
Now PEM is downloaded into /tmp in SSH task so PEM is available at the same worker node. 
This PR checks whether the file exists or not while copying the pem into /tmp and downloading before SSH into the machine.
If it doesn't exist then it will raise an exception.

closes: #620 