### PR TITLE
Remove redundant code in BigQueryHookAsync

### DIFF
--- a/astronomer/providers/google/cloud/extractors/bigquery.py
+++ b/astronomer/providers/google/cloud/extractors/bigquery.py
@@ -11,7 +11,7 @@ from openlineage.client.facet import SqlJobFacet
 from openlineage.common.provider.bigquery import BigQueryDatasetsProvider
 from openlineage.common.sql import parse
 
-from astronomer.providers.google.cloud.hooks.bigquery import _BigQueryHook
+from astronomer.providers.google.cloud.hooks.bigquery import BigQueryHook
 from astronomer.providers.google.cloud.operators.bigquery import (
     BigQueryCheckOperatorAsync,
     BigQueryGetDataOperatorAsync,
@@ -56,7 +56,7 @@ class BigQueryAsyncExtractor(BaseExtractor):
         The method checks whether a connection hook is available with the Airflow configuration for the operator, and
         if yes, returns the same connection. Otherwise, returns the Client instance of``google.cloud.bigquery``.
         """
-        hook = _BigQueryHook(gcp_conn_id=self.operator.gcp_conn_id)
+        hook = BigQueryHook(gcp_conn_id=self.operator.gcp_conn_id)
         return hook.get_client(project_id=hook.project_id, location=hook.location)
 
     def _get_xcom_bigquery_job_id(self, task_instance: TaskInstance) -> Any:

--- a/astronomer/providers/google/cloud/extractors/bigquery.py
+++ b/astronomer/providers/google/cloud/extractors/bigquery.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional, Union
 import attr
 from airflow.exceptions import AirflowException
 from airflow.models.taskinstance import TaskInstance
+from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from google.cloud.bigquery import Client
 from openlineage.airflow.extractors.base import BaseExtractor, TaskMetadata
 from openlineage.airflow.utils import get_job_name
@@ -11,7 +12,6 @@ from openlineage.client.facet import SqlJobFacet
 from openlineage.common.provider.bigquery import BigQueryDatasetsProvider
 from openlineage.common.sql import parse
 
-from astronomer.providers.google.cloud.hooks.bigquery import BigQueryHook
 from astronomer.providers.google.cloud.operators.bigquery import (
     BigQueryCheckOperatorAsync,
     BigQueryGetDataOperatorAsync,

--- a/astronomer/providers/google/cloud/hooks/bigquery.py
+++ b/astronomer/providers/google/cloud/hooks/bigquery.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Optional, Union, cast
 from aiohttp import ClientSession as ClientSession
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
-from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 from gcloud.aio.bigquery import Job, Table
 from google.cloud.bigquery import CopyJob, ExtractJob, LoadJob, QueryJob
 from requests import Session
@@ -13,71 +12,10 @@ from astronomer.providers.google.common.hooks.base_google import GoogleBaseHookA
 BigQueryJob = Union[CopyJob, QueryJob, LoadJob, ExtractJob]
 
 
-class _BigQueryHook(BigQueryHook):
-    @GoogleBaseHook.fallback_to_default_project_id
-    def insert_job(
-        self,
-        configuration: Dict[str, Any],
-        job_id: Optional[str] = None,
-        project_id: Optional[str] = None,
-        location: Optional[str] = None,
-        nowait: bool = False,
-    ) -> BigQueryJob:
-        """
-        Executes a BigQuery job. Initiates the job and returns job id.
-
-        See here: https://cloud.google.com/bigquery/docs/reference/v2/jobs
-
-        :param configuration: The configuration parameter maps directly to
-            BigQuery's configuration field in the job object. See
-            https://cloud.google.com/bigquery/docs/reference/v2/jobs for
-            details.
-        :param job_id: The ID of the job. The ID must contain only letters (a-z, A-Z),
-            numbers (0-9), underscores (_), or dashes (-). The maximum length is 1,024
-            characters. If not provided then uuid will be generated.
-        :param project_id: Google Cloud Project where the job is running
-        :param location: location the job is running
-        :param nowait: specify whether to insert job without waiting for the result
-        """
-        location = location or self.location
-        job_id = job_id or self._custom_job_id(configuration)
-
-        client = self.get_client(project_id=project_id, location=location)
-        job_data = {
-            "configuration": configuration,
-            "jobReference": {"jobId": job_id, "projectId": project_id, "location": location},
-        }
-
-        supported_jobs = {
-            LoadJob._JOB_TYPE: LoadJob,
-            CopyJob._JOB_TYPE: CopyJob,
-            ExtractJob._JOB_TYPE: ExtractJob,
-            QueryJob._JOB_TYPE: QueryJob,
-        }
-
-        job = None
-        for job_type, job_object in supported_jobs.items():
-            if job_type in configuration:
-                job = job_object
-                break
-
-        if not job:
-            raise AirflowException(f"Unknown job type. Supported types: {supported_jobs.keys()}")
-        job = job.from_api_repr(job_data, client)
-        self.log.info("Inserting job %s", job.job_id)
-        if nowait:
-            # Initiate the job and don't wait for it to complete.
-            job._begin()
-        else:
-            # Start the job and wait for it to complete and get the result.
-            job.result()
-        return job
-
-
 class BigQueryHookAsync(GoogleBaseHookAsync):
-    """Big query async hook inherits from GoogleBaseHookAsync class and connects to the google Big query"""
+    """Big query async hook inherits from GoogleBaseHookAsync class and connects to the Google Big Query"""
 
-    sync_hook_class = _BigQueryHook
+    sync_hook_class = BigQueryHook
 
     async def get_job_instance(
         self, project_id: Optional[str], job_id: Optional[str], session: ClientSession

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -14,7 +14,7 @@ from airflow.providers.google.cloud.operators.bigquery import (
 from airflow.utils.context import Context
 from google.api_core.exceptions import Conflict
 
-from astronomer.providers.google.cloud.hooks.bigquery import _BigQueryHook
+from astronomer.providers.google.cloud.hooks.bigquery import BigQueryHook
 from astronomer.providers.google.cloud.triggers.bigquery import (
     BigQueryCheckTrigger,
     BigQueryGetDataTrigger,
@@ -72,18 +72,8 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
     :param cancel_on_kill: Flag which indicates whether cancel the hook's job or not, when on_kill is called
     """
 
-    def _submit_job(self, hook: _BigQueryHook, job_id: str) -> BigQueryJob:  # type: ignore[override]
-        """Submit a new job and get the job id for polling the status using Triggerer."""
-        return hook.insert_job(
-            configuration=self.configuration,
-            project_id=self.project_id,
-            location=self.location,
-            job_id=job_id,
-            nowait=True,
-        )
-
     def execute(self, context: Context) -> None:  # noqa: D102
-        hook = _BigQueryHook(gcp_conn_id=self.gcp_conn_id)
+        hook = BigQueryHook(gcp_conn_id=self.gcp_conn_id)
 
         self.hook = hook
         job_id = self.hook.generate_job_id(
@@ -152,7 +142,7 @@ class BigQueryCheckOperatorAsync(BigQueryCheckOperator):
 
     def _submit_job(
         self,
-        hook: _BigQueryHook,
+        hook: BigQueryHook,
         job_id: str,
     ) -> BigQueryJob:
         """Submit a new job and get the job id for polling the status using Trigger."""
@@ -167,7 +157,7 @@ class BigQueryCheckOperatorAsync(BigQueryCheckOperator):
         )
 
     def execute(self, context: Context) -> None:  # noqa: D102
-        hook = _BigQueryHook(
+        hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
         )
         job = self._submit_job(hook, job_id="")
@@ -250,7 +240,7 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
 
     def _submit_job(
         self,
-        hook: _BigQueryHook,
+        hook: BigQueryHook,
         job_id: str,
         configuration: Dict[str, Any],
     ) -> BigQueryJob:
@@ -280,7 +270,7 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
         get_query = self.generate_query()
         configuration = {"query": {"query": get_query}}
 
-        hook = _BigQueryHook(
+        hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             location=self.location,
@@ -349,7 +339,7 @@ class BigQueryIntervalCheckOperatorAsync(BigQueryIntervalCheckOperator):
 
     def _submit_job(
         self,
-        hook: _BigQueryHook,
+        hook: BigQueryHook,
         sql: str,
         job_id: str,
     ) -> BigQueryJob:
@@ -365,7 +355,7 @@ class BigQueryIntervalCheckOperatorAsync(BigQueryIntervalCheckOperator):
 
     def execute(self, context: Context) -> None:
         """Execute the job in sync mode and defers the trigger with job id to poll for the status"""
-        hook = _BigQueryHook(gcp_conn_id=self.gcp_conn_id)
+        hook = BigQueryHook(gcp_conn_id=self.gcp_conn_id)
         self.log.info("Using ratio formula: %s", self.ratio_formula)
 
         self.log.info("Executing SQL check: %s", self.sql1)
@@ -410,7 +400,7 @@ class BigQueryIntervalCheckOperatorAsync(BigQueryIntervalCheckOperator):
 class BigQueryValueCheckOperatorAsync(BigQueryValueCheckOperator):  # noqa: D101
     def _submit_job(
         self,
-        hook: _BigQueryHook,
+        hook: BigQueryHook,
         job_id: str,
     ) -> BigQueryJob:
         """Submit a new job and get the job id for polling the status using Triggerer."""
@@ -432,7 +422,7 @@ class BigQueryValueCheckOperatorAsync(BigQueryValueCheckOperator):  # noqa: D101
         )
 
     def execute(self, context: Context) -> None:  # noqa: D102
-        hook = _BigQueryHook(gcp_conn_id=self.gcp_conn_id)
+        hook = BigQueryHook(gcp_conn_id=self.gcp_conn_id)
 
         job = self._submit_job(hook, job_id="")
         context["ti"].xcom_push(key="job_id", value=job.job_id)

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 
 from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator
-from airflow.providers.google.cloud.hooks.bigquery import BigQueryJob
+from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook, BigQueryJob
 from airflow.providers.google.cloud.operators.bigquery import (
     BigQueryCheckOperator,
     BigQueryGetDataOperator,
@@ -14,7 +14,6 @@ from airflow.providers.google.cloud.operators.bigquery import (
 from airflow.utils.context import Context
 from google.api_core.exceptions import Conflict
 
-from astronomer.providers.google.cloud.hooks.bigquery import BigQueryHook
 from astronomer.providers.google.cloud.triggers.bigquery import (
     BigQueryCheckTrigger,
     BigQueryGetDataTrigger,

--- a/tests/google/cloud/extractors/test_bigquery.py
+++ b/tests/google/cloud/extractors/test_bigquery.py
@@ -93,8 +93,8 @@ def create_context(task):
     }
 
 
-@mock.patch("astronomer.providers.google.cloud.extractors.bigquery._BigQueryHook")
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
+@mock.patch("astronomer.providers.google.cloud.extractors.bigquery.BigQueryHook")
+@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
 @mock.patch("airflow.models.TaskInstance.xcom_pull")
 @mock.patch("openlineage.common.provider.bigquery.BigQueryDatasetsProvider.get_facets")
 def test_extract_on_complete(mock_bg_dataset_provider, mock_xcom_pull, mock_hook, mock_extractor_hook):
@@ -157,7 +157,7 @@ def test_extractor_works_on_operator():
     assert type(operator).__name__ in BigQueryAsyncExtractor.get_operator_classnames()
 
 
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
+@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
 def test_unavailable_xcom_raises_exception(mock_hook):
     """
     Tests that an exception is raised when the custom extractor is not available to retrieve required XCOM for the

--- a/tests/google/cloud/operators/test_bigquery.py
+++ b/tests/google/cloud/operators/test_bigquery.py
@@ -40,7 +40,7 @@ def context():
     yield context
 
 
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
+@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
 def test_bigquery_insert_job_operator_async(mock_hook):
     """
     Asserts that a task is deferred and a BigQueryInsertJobTrigger will be fired
@@ -143,7 +143,7 @@ def test_bigquery_insert_job_operator_execute_complete():
     mock_log_info.assert_called_with("%s completed with response %s ", "insert_query_job", "Job completed")
 
 
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
+@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
 def test_bigquery_insert_job_operator_with_job_id_generate(mock_hook):
     job_id = "123456"
     hash_ = "hash"
@@ -187,7 +187,7 @@ def test_bigquery_insert_job_operator_with_job_id_generate(mock_hook):
     )
 
 
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
+@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
 def test_execute_reattach(mock_hook):
     job_id = "123456"
     hash_ = "hash"
@@ -231,7 +231,7 @@ def test_execute_reattach(mock_hook):
     job._begin.assert_called_once_with()
 
 
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
+@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
 def test_execute_force_rerun(mock_hook):
     job_id = "123456"
     hash_ = "hash"
@@ -281,7 +281,7 @@ def test_execute_force_rerun(mock_hook):
     )
 
 
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
+@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
 def test_bigquery_check_operator_async(mock_hook):
     """
     Asserts that a task is deferred and a BigQueryCheckTrigger will be fired
@@ -391,7 +391,7 @@ def test_bigquery_interval_check_operator_execute_failure(context):
         operator.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
 
 
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
+@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
 def test_bigquery_interval_check_operator_async(mock_hook):
     """
     Asserts that a task is deferred and a BigQueryIntervalCheckTrigger will be fired
@@ -418,7 +418,7 @@ def test_bigquery_interval_check_operator_async(mock_hook):
     ), "Trigger is not a BigQueryIntervalCheckTrigger"
 
 
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
+@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
 def test_bigquery_get_data_operator_async_with_selected_fields(mock_hook):
     """
     Asserts that a task is deferred and a BigQuerygetDataTrigger will be fired
@@ -444,7 +444,7 @@ def test_bigquery_get_data_operator_async_with_selected_fields(mock_hook):
     assert isinstance(exc.value.trigger, BigQueryGetDataTrigger), "Trigger is not a BigQueryGetDataTrigger"
 
 
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
+@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
 def test_bigquery_get_data_operator_async_without_selected_fields(mock_hook):
     """
     Asserts that a task is deferred and a BigQuerygetDataTrigger will be fired
@@ -511,7 +511,7 @@ def _get_value_check_async_operator(use_legacy_sql: bool = False):
     )
 
 
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery._BigQueryHook")
+@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
 def test_bigquery_value_check_async(mock_hook):
     """
     Asserts that a task is deferred and a BigQueryValueCheckTrigger will be fired


### PR DESCRIPTION
This PR addresses the code changes needed to use the OSS BigQueryHook within the repo instead of using a vendored hook

- Remove _BigQueryHook usage
- Change the tests accordingly for the google async hooks and operators

Closes: #52