### PR TITLE
Add provider entry_points for airflow UI

### DIFF
--- a/astronomer/providers/package.py
+++ b/astronomer/providers/package.py
@@ -1,12 +1,13 @@
 import configparser
 from pathlib import Path
+from typing import Any, Dict
 
 config = configparser.ConfigParser(strict=False)
 _REPO_DIR = Path(__file__).parent.parent.parent
 config.read(_REPO_DIR / "setup.cfg")
 
 
-def get_provider_info() -> dict:
+def get_provider_info() -> Dict[str, Any]:
     """Return provider metadata to Airflow"""
     return {
         # Required.

--- a/astronomer/providers/package.py
+++ b/astronomer/providers/package.py
@@ -1,0 +1,20 @@
+import configparser
+from pathlib import Path
+
+config = configparser.ConfigParser(strict=False)
+_REPO_DIR = Path(__file__).parent.parent.parent
+config.read(_REPO_DIR / "setup.cfg")
+
+
+def get_provider_info() -> dict:
+    """Return provider metadata to Airflow"""
+    return {
+        # Required.
+        "package-name": "astronomer-providers",
+        "name": "Astro SQL Provider",
+        "description": config["metadata"]["description"],
+        "versions": [config["metadata"]["version"]],
+        # Optional.
+        "hook-class-names": [],
+        "extra-links": [],
+    }

--- a/astronomer/providers/package.py
+++ b/astronomer/providers/package.py
@@ -12,7 +12,7 @@ def get_provider_info() -> Dict[str, Any]:
     return {
         # Required.
         "package-name": "astronomer-providers",
-        "name": "Astro SQL Provider",
+        "name": "Astronomer Providers",
         "description": config["metadata"]["description"],
         "versions": [config["metadata"]["version"]],
         # Optional.

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,6 +134,10 @@ all =
 include =
     astronomer.*
 
+[options.entry_points]
+apache_airflow_provider=
+  provider_info=astronomer.providers.package:get_provider_info
+
 [flake8]
 enable-extensions=G
 exclude = venv/*,tox/*,specs/*


### PR DESCRIPTION
This PR is an attempt to add an entry point in the provider so that Airflow can display the astronomer-provider metadata in UI

<img width="1164" alt="Screenshot 2022-09-08 at 3 39 47 AM" src="https://user-images.githubusercontent.com/98807258/188992539-932dff46-d05b-4969-a922-2076db2e44dd.png">


closes: https://github.com/astronomer/astronomer-providers/issues/610


