### PR TITLE
Add fallback value for config metadata

### DIFF
--- a/astronomer/providers/package.py
+++ b/astronomer/providers/package.py
@@ -13,8 +13,8 @@ def get_provider_info() -> Dict[str, Any]:
         # Required.
         "package-name": "astronomer-providers",
         "name": "Astronomer Providers",
-        "description": config["metadata"]["description"],
-        "versions": [config["metadata"]["version"]],
+        "description": config.get("metadata", "description", fallback=""),
+        "versions": [config.get("metadata", "version", fallback="")],
         # Optional.
         "hook-class-names": [],
         "extra-links": [],


### PR DESCRIPTION
Recently we encounter that the new astro-cloud instances were failing with an error. Here, I'm adding a fallback for the metadata so that server will not crash.

```
  File "/usr/local/lib/python3.9/site-packages/astronomer/providers/package.py", line 16, in get_provider_info
    "description": config["metadata"]["description"],
  File "/usr/local/lib/python3.9/configparser.py", line 963, in __getitem__
    raise KeyError(key)
KeyError: 'metadata'
```