### PR TITLE
Fix metadata description

### DIFF
--- a/astronomer/providers/package.py
+++ b/astronomer/providers/package.py
@@ -13,7 +13,7 @@ def get_provider_info() -> Dict[str, Any]:
         # Required.
         "package-name": "astronomer-providers",
         "name": "Astronomer Providers",
-        "description": config.get("metadata", "description", fallback=""),
+        "description": (config.get("metadata", "description", fallback="")),
         "versions": [config.get("metadata", "version", fallback="")],
         # Optional.
         "hook-class-names": [],


### PR DESCRIPTION
Look like `description` param in response of `get_provider_info` should be tuple