### PR TITLE
Custom S3 Backend

### DIFF
--- a/astronomer/providers/amazon/aws/xcom_backends/s3.py
+++ b/astronomer/providers/amazon/aws/xcom_backends/s3.py
@@ -16,9 +16,9 @@ class S3XComBackend(BaseXCom):
     `astronomer.providers.amazon.aws.xcom_backends.s3.S3XComBackend`
     """
 
-    PREFIX = os.getenv("PREFIX", "S3XCOM_")
+    PREFIX = os.getenv("PREFIX", "s3_xcom_")
     AWS_CONN_ID = os.getenv("CONNECTION_NAME", "aws_default")
-    BUCKET_NAME = os.getenv("XCOM_BACKEND_BUCKET_NAME", "some_bucket_name")
+    BUCKET_NAME = os.getenv("XCOM_BACKEND_BUCKET_NAME", "airflow_xcom_backend_default_bucket")
 
     @staticmethod
     def write_and_upload_value(value: Any) -> str:
@@ -59,9 +59,8 @@ class S3XComBackend(BaseXCom):
 
     def orm_deserialize_value(self) -> str:
         """
-        Deserialize amethod which is used to reconstruct ORM XCom object.
-        This method should be overridden in custom XCom backends to avoid
-        unnecessary request or other resource consuming operations when
-        creating XCom ORM model.
+        Deserialize method which is used to reconstruct ORM XCom object.
+        This method help to avoid unnecessary request or other
+        resource-consuming operations when creating XCom ORM model.
         """
         return f"XCOM is uploaded into S3 bucket: {S3XComBackend.BUCKET_NAME}"

--- a/astronomer/providers/amazon/aws/xcom_backends/s3.py
+++ b/astronomer/providers/amazon/aws/xcom_backends/s3.py
@@ -22,7 +22,7 @@ class S3XComBackend(BaseXCom):
 
     @staticmethod
     def write_and_upload_value(value: Any) -> str:
-        """Convert to string and upload to GCS"""
+        """Convert to string and upload to S3"""
         key_str = S3XComBackend.PREFIX + str(uuid.uuid4())
         hook = S3Hook(aws_conn_id=S3XComBackend.AWS_CONN_ID)
         if isinstance(value, list):

--- a/astronomer/providers/amazon/aws/xcom_backends/s3.py
+++ b/astronomer/providers/amazon/aws/xcom_backends/s3.py
@@ -1,0 +1,67 @@
+import json
+import os
+import uuid
+from typing import Any, Union
+
+import pandas as pd
+from airflow.models.xcom import BaseXCom
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+
+
+class S3XComBackend(BaseXCom):
+    """
+    Custom XCom persistence class extends base to support various datatypes.
+    To use this XCom Backend, add the environment variable `AIRFLOW__CORE__XCOM_BACKEND`
+    to your environment and set it to
+    `astronomer.providers.amazon.aws.xcom_backends.s3.S3XComBackend`
+    """
+
+    PREFIX = os.getenv("PREFIX", "S3XCOM_")
+    AWS_CONN_ID = os.getenv("CONNECTION_NAME", "aws_default")
+    BUCKET_NAME = os.getenv("XCOM_BACKEND_BUCKET_NAME", "some_bucket_name")
+
+    @staticmethod
+    def write_and_upload_value(value: Any) -> str:
+        """Convert to string and upload to GCS"""
+        key_str = S3XComBackend.PREFIX + str(uuid.uuid4())
+        hook = S3Hook(aws_conn_id=S3XComBackend.AWS_CONN_ID)
+        if isinstance(value, list):
+            value = str(value)
+        elif isinstance(value, dict):
+            value = json.dumps(value)
+        elif isinstance(value, pd.DataFrame):
+            value = value.to_json()
+        hook.load_string(bucket_name=S3XComBackend.BUCKET_NAME, key=key_str, string_data=value)
+        return key_str
+
+    @staticmethod
+    def read_value(filepath: str) -> Union[str, bytes]:
+        """Download the file from S3"""
+        # Here we download the file from S3
+        hook = S3Hook(aws_conn_id=S3XComBackend.AWS_CONN_ID)
+        data = hook.download_file(bucket_name=S3XComBackend.BUCKET_NAME, key=filepath)
+        return data
+
+    @staticmethod
+    def serialize_value(value: Any) -> Any:  # type: ignore[override]
+        """Custom XCOM for S3 to serialize the data"""
+        value = S3XComBackend.write_and_upload_value(value)
+        return BaseXCom.serialize_value(value)
+
+    @staticmethod
+    def deserialize_value(result: Any) -> Any:
+        """Custom XCOM for S3 to deserialize the data"""
+        result = BaseXCom.deserialize_value(result)
+        # Check if result is string and has the configured XCom prefix
+        if isinstance(result, str) and result.startswith(S3XComBackend.PREFIX):
+            return S3XComBackend.read_value(result)
+        return result
+
+    def orm_deserialize_value(self) -> str:
+        """
+        Deserialize amethod which is used to reconstruct ORM XCom object.
+        This method should be overridden in custom XCom backends to avoid
+        unnecessary request or other resource consuming operations when
+        creating XCom ORM model.
+        """
+        return f"XCOM is uploaded into S3 bucket: {S3XComBackend.BUCKET_NAME}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ project = "Astronomer Providers"
 author = "Astronomer Inc."
 
 # The full version, including alpha/beta/rc tags
-release = "1.9.0"
+release = "1.10.0.dev1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = astronomer-providers
-version = 1.9.0
+version = 1.10.0.dev1
 url = https://github.com/astronomer/astronomer-providers/
 author = Astronomer
 author_email = humans@astronomer.io

--- a/tests/amazon/aws/xcom_backends/test_s3.py
+++ b/tests/amazon/aws/xcom_backends/test_s3.py
@@ -25,7 +25,7 @@ def test_custom_xcom_s3_serialize(mock_write):
 )
 @mock.patch("uuid.uuid4")
 @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.load_string")
-def test_custom_xcom_gcs_write_and_upload(mock_upload, mock_uuid, job_id):
+def test_custom_xcom_s3_write_and_upload(mock_upload, mock_uuid, job_id):
     """
     Asserts that custom xcom is upload and returns key
     """
@@ -39,7 +39,7 @@ def test_custom_xcom_gcs_write_and_upload(mock_upload, mock_uuid, job_id):
     ["s3_xcom__1234", "1234"],
 )
 @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.download_file")
-def test_custom_xcom_gcs_deserialize(mock_download, job_id):
+def test_custom_xcom_s3_deserialize(mock_download, job_id):
     """
     Asserts that custom xcom is deserialized and check for data
     """
@@ -49,7 +49,7 @@ def test_custom_xcom_gcs_deserialize(mock_download, job_id):
     assert result == job_id
 
 
-def test_custom_xcom_gcs_orm_deserialize_value():
+def test_custom_xcom_s3_orm_deserialize_value():
     """
     Asserts that custom xcom has called the orm deserialized
     value method and check for data.

--- a/tests/amazon/aws/xcom_backends/test_s3.py
+++ b/tests/amazon/aws/xcom_backends/test_s3.py
@@ -31,12 +31,12 @@ def test_custom_xcom_gcs_write_and_upload(mock_upload, mock_uuid, job_id):
     """
     mock_uuid.return_value = "12345667890"
     result = S3XComBackend.write_and_upload_value(job_id)
-    assert result == "S3XCOM_" + "12345667890"
+    assert result == "s3_xcom_" + "12345667890"
 
 
 @pytest.mark.parametrize(
     "job_id",
-    ["S3XCOM_1234", "1234"],
+    ["s3_xcom__1234", "1234"],
 )
 @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.download_file")
 def test_custom_xcom_gcs_deserialize(mock_download, job_id):
@@ -55,4 +55,4 @@ def test_custom_xcom_gcs_orm_deserialize_value():
     value method and check for data.
     """
     result = S3XComBackend().orm_deserialize_value()
-    assert result == "XCOM is uploaded into S3 bucket: some_bucket_name"
+    assert result == "XCOM is uploaded into S3 bucket: airflow_xcom_backend_default_bucket"

--- a/tests/amazon/aws/xcom_backends/test_s3.py
+++ b/tests/amazon/aws/xcom_backends/test_s3.py
@@ -1,0 +1,58 @@
+import json
+from unittest import mock
+
+import pandas as pd
+import pytest
+from airflow.models.xcom import BaseXCom
+
+from astronomer.providers.amazon.aws.xcom_backends.s3 import S3XComBackend
+
+
+@mock.patch("astronomer.providers.amazon.aws.xcom_backends.s3.S3XComBackend.write_and_upload_value")
+def test_custom_xcom_s3_serialize(mock_write):
+    """
+    Asserts that custom xcom is serialize or not
+    """
+    real_job_id = "12345_hash"
+    mock_write.return_value = real_job_id
+    result = S3XComBackend.serialize_value(real_job_id)
+    assert result == json.dumps(real_job_id).encode("UTF-8")
+
+
+@pytest.mark.parametrize(
+    "job_id",
+    ["1234567890", {"a": "b"}, ["123"], pd.DataFrame({"numbers": [1], "colors": ["red"]})],
+)
+@mock.patch("uuid.uuid4")
+@mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.load_string")
+def test_custom_xcom_gcs_write_and_upload(mock_upload, mock_uuid, job_id):
+    """
+    Asserts that custom xcom is upload and returns key
+    """
+    mock_uuid.return_value = "12345667890"
+    result = S3XComBackend.write_and_upload_value(job_id)
+    assert result == "S3XCOM_" + "12345667890"
+
+
+@pytest.mark.parametrize(
+    "job_id",
+    ["S3XCOM_1234", "1234"],
+)
+@mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.download_file")
+def test_custom_xcom_gcs_deserialize(mock_download, job_id):
+    """
+    Asserts that custom xcom is deserialized and check for data
+    """
+    mock_download.return_value = job_id
+    real_job_id = BaseXCom(value=json.dumps(job_id).encode("UTF-8"))
+    result = S3XComBackend.deserialize_value(real_job_id)
+    assert result == job_id
+
+
+def test_custom_xcom_gcs_orm_deserialize_value():
+    """
+    Asserts that custom xcom has called the orm deserialized
+    value method and check for data.
+    """
+    result = S3XComBackend().orm_deserialize_value()
+    assert result == "XCOM is uploaded into S3 bucket: some_bucket_name"


### PR DESCRIPTION
Custom XCOM to upload xcom values to the S3 bucket for the given name.
Adding ENV AIRFLOW__CORE__XCOM_BACKEND: astronomer.providers.amazon.aws.xcom_backends.s3.S3XComBackend in the docker-compose.yaml or where the airflow is running will enable the custom XCOM forS3.

closes #559