### PR TITLE
Fix flake8 failure and failure test cases.

### DIFF
--- a/astronomer/providers/amazon/aws/triggers/emr.py
+++ b/astronomer/providers/amazon/aws/triggers/emr.py
@@ -1,5 +1,4 @@
 import asyncio
-from abc import ABC
 from typing import Any, AsyncIterator, Dict, Iterable, List, Optional, Tuple
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
@@ -11,7 +10,7 @@ from astronomer.providers.amazon.aws.hooks.emr import (
 )
 
 
-class EmrContainerBaseTrigger(BaseTrigger, ABC):
+class EmrContainerBaseTrigger(BaseTrigger):
     """
     Poll for the status of EMR container until reaches terminal state
 

--- a/astronomer/providers/google/cloud/hooks/dataproc.py
+++ b/astronomer/providers/google/cloud/hooks/dataproc.py
@@ -1,5 +1,4 @@
 import warnings
-from abc import ABC
 from typing import Any, Optional, Sequence, Tuple, Union
 
 from airflow.providers.google.common.consts import CLIENT_INFO
@@ -17,7 +16,7 @@ from google.cloud.dataproc_v1.types import clusters
 JobType = Union[Job, Any]
 
 
-class DataprocHookAsync(GoogleBaseHook, ABC):
+class DataprocHookAsync(GoogleBaseHook):
     """Async Hook for Google Cloud Dataproc APIs"""
 
     def get_cluster_client(

--- a/astronomer/providers/google/cloud/triggers/dataproc.py
+++ b/astronomer/providers/google/cloud/triggers/dataproc.py
@@ -1,6 +1,5 @@
 import asyncio
 import time
-from abc import ABC
 from typing import Any, AsyncIterator, Dict, Optional, Sequence, Tuple, Union
 
 from airflow.exceptions import AirflowException
@@ -13,7 +12,7 @@ from google.cloud.dataproc_v1.types import JobStatus, clusters
 from astronomer.providers.google.cloud.hooks.dataproc import DataprocHookAsync
 
 
-class DataprocCreateClusterTrigger(BaseTrigger, ABC):
+class DataprocCreateClusterTrigger(BaseTrigger):
     """
     Asynchronously check the status of a cluster
 
@@ -177,7 +176,7 @@ class DataprocCreateClusterTrigger(BaseTrigger, ABC):
         )
 
 
-class DataprocDeleteClusterTrigger(BaseTrigger, ABC):
+class DataprocDeleteClusterTrigger(BaseTrigger):
     """
     Asynchronously check the status of a cluster
 

--- a/astronomer/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/astronomer/providers/snowflake/hooks/snowflake_sql_api.py
@@ -1,5 +1,4 @@
 import uuid
-from abc import ABC
 from datetime import timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -14,7 +13,7 @@ from cryptography.hazmat.primitives import serialization
 from astronomer.providers.snowflake.hooks.sql_api_generate_jwt import JWTGenerator
 
 
-class SnowflakeSqlApiHookAsync(SnowflakeHook, ABC):
+class SnowflakeSqlApiHookAsync(SnowflakeHook):
     """
     A client to interact with Snowflake using SQL API  and allows submitting
     multiple SQL statements in a single request. In combination with aiohttp, make post request to submit SQL

--- a/tests/google/cloud/hooks/test_bigquery.py
+++ b/tests/google/cloud/hooks/test_bigquery.py
@@ -1,3 +1,4 @@
+import logging
 from unittest import mock
 
 import pytest
@@ -58,6 +59,7 @@ async def test_get_job_status_oserror(mock_job_instance):
 @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_instance")
 async def test_get_job_status_exception(mock_job_instance, caplog):
     """Assets that the logging is done correctly when BigQueryHookAsync raises Exception"""
+    caplog.set_level(logging.INFO)
     mock_job_instance.return_value.result.side_effect = Exception()
     hook = BigQueryHookAsync()
     await hook.get_job_status(job_id=JOB_ID, project_id=PROJECT_ID)


### PR DESCRIPTION
This PR is to resolve flake8 issues where an abstract decorator has to be used if a class is inherited from ABC.

In python, caplog logging has to be set before using it. So the test cases were failing. So now I have set the log level before doing assertion.