### PR TITLE
Fix Provider entrypoint for Airflow

### DIFF
--- a/.circleci/scripts/pre_commit_sync_version_desc_package.py
+++ b/.circleci/scripts/pre_commit_sync_version_desc_package.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Pre-commit hook to sync the "version" & "description" in setup.cfg and astronomer/providers/package.py."""
+import configparser
+import re
+from pathlib import Path
+
+repo_dir = Path(__file__).parent.parent.parent
+
+config = configparser.ConfigParser(strict=False)
+config.read(repo_dir / "setup.cfg")
+
+version_in_setup_cfg = config["metadata"]["version"]
+description_in_setup_cfg = config["metadata"]["description"]
+
+package_py = repo_dir / "astronomer/providers/package.py"
+
+with open(package_py, "r") as f:
+    package_py_contents = f.read()
+
+new_text = re.sub(
+    r'versions": (.*)', f'versions": "{version_in_setup_cfg}",', package_py_contents, flags=re.MULTILINE
+)
+
+new_text = re.sub(
+    r'description": (.*)', f'description": "{description_in_setup_cfg}",', new_text, flags=re.MULTILINE
+)
+
+with open(package_py, "w") as f:
+    f.write(new_text)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,6 +124,12 @@ repos:
         files: ^setup.cfg$|^docs/conf.py$
         pass_filenames: false
         entry: .circleci/scripts/pre_commit_sync_version_docs.py
+      - id: sync-version-desc-setup.cfg-package
+        name: Sync "version" & "description" of the package in setup.cfg and astronomer/providers/package.py
+        language: python
+        files: ^setup.cfg$|^astronomer/providers/package.py$
+        pass_filenames: false
+        entry: .circleci/scripts/pre_commit_sync_version_desc_package.py
       - id: changelog-update
         name: Verify changelog is updated when releasing a new version
         language: python

--- a/astronomer/providers/package.py
+++ b/astronomer/providers/package.py
@@ -1,12 +1,4 @@
-import configparser
-from pathlib import Path
 from typing import Any, Dict
-
-config = configparser.ConfigParser(strict=False)
-_REPO_DIR = Path(__file__).parent.parent.parent
-config.read(_REPO_DIR / "setup.cfg")
-_description = config.get("metadata", "description", fallback="")
-_description_link = f"`{_description} <https://github.com/astronomer/astronomer-providers/>`__"
 
 
 def get_provider_info() -> Dict[str, Any]:
@@ -15,8 +7,8 @@ def get_provider_info() -> Dict[str, Any]:
         # Required.
         "package-name": "astronomer-providers",
         "name": "Astronomer Providers",
-        "description": (_description_link),
-        "versions": [config.get("metadata", "version", fallback="")],
+        "description": "Apache Airflow Providers containing Deferrable Operators & Sensors from Astronomer",
+        "versions": "1.10.0.dev1",
         # Optional.
         "hook-class-names": [],
         "extra-links": [],


### PR DESCRIPTION
There was an attempt to fix it in https://github.com/astronomer/astronomer-providers/pull/635 from @pankajastro  but that file (setup.cfg) won't exist once the package is packaged, hence it will always fallback to an empty value.

This PR/commit fixes it by making `astronomer/providers/package.py` file static and uses  pre-commit hook to sync version and description from setup.cfg to it

**Before**:

<img width="1128" alt="image" src="https://user-images.githubusercontent.com/8811558/192066972-585419a7-bc0c-417b-ae00-7a48d4e29a42.png">
