### PR TITLE
Handle the Databricks Operator failures

### DIFF
--- a/tests/databricks/triggers/test_databricks.py
+++ b/tests/databricks/triggers/test_databricks.py
@@ -4,7 +4,6 @@ from unittest import mock
 
 import pytest
 from airflow.exceptions import AirflowException
-from airflow.providers.databricks.hooks.databricks import RunState
 from airflow.triggers.base import TriggerEvent
 
 from astronomer.providers.databricks.triggers.databricks import DatabricksTrigger
@@ -15,6 +14,73 @@ RUN_ID = "1"
 RETRY_LIMIT = 2
 RETRY_DELAY = 1.0
 POLLING_PERIOD_SECONDS = 1.0
+MOCK_RUN_RESPONSE_IN_ERROR_1 = {
+    "state": {
+        "life_cycle_state": "TERMINATED",
+        "result_state": "FAILED",
+        "state_message": "Test error",
+    },
+    "tasks": [
+        {
+            "run_id": 2112892,
+            "state": {
+                "life_cycle_state": "INTERNAL_ERROR",
+                "result_state": "FAILED",
+                "user_cancelled_or_timedout": False,
+            },
+        }
+    ],
+}
+MOCK_RUN_RESPONSE_IN_ERROR_2 = {
+    "state": {
+        "life_cycle_state": "TERMINATED",
+        "result_state": "FAILED",
+        "state_message": "Test error",
+    },
+}
+MOCK_RUN_GET_OUTPUT_RESPONSE_IN_ERROR_1 = {
+    "error": "Test error",
+    "metadata": {
+        "state": {
+            "life_cycle_state": "TERMINATED",
+            "result_state": "FAILED",
+            "state_message": "Test error",
+        },
+        "tasks": [
+            {
+                "run_id": 2112892,
+                "state": {
+                    "life_cycle_state": "INTERNAL_ERROR",
+                    "result_state": "FAILED",
+                    "user_cancelled_or_timedout": False,
+                    "state_message": "Test error",
+                },
+                "run_page_url": "https://my-workspace.cloud.databricks.com/#job/39832/run/20",
+            }
+        ],
+    },
+}
+MOCK_RUN_GET_OUTPUT_RESPONSE_IN_ERROR_2 = {
+    "metadata": {
+        "state": {
+            "life_cycle_state": "TERMINATED",
+            "result_state": "FAILED",
+            "state_message": "Test error",
+        },
+        "tasks": [
+            {
+                "run_id": 2112892,
+                "state": {
+                    "life_cycle_state": "INTERNAL_ERROR",
+                    "result_state": "FAILED",
+                    "user_cancelled_or_timedout": False,
+                    "state_message": "Test error",
+                },
+                "run_page_url": "https://my-workspace.cloud.databricks.com/#job/39832/run/20",
+            }
+        ],
+    }
+}
 
 
 def test_databricks_trigger_serialization():
@@ -45,17 +111,20 @@ def test_databricks_trigger_serialization():
 
 
 @pytest.mark.asyncio
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_state_async")
-async def test_databricks_trigger_success(run_state):
+@mock.patch("airflow.providers.databricks.hooks.databricks.RunState")
+@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
+async def test_databricks_trigger_success(mock_run_response, run_state):
     """
     Tests that the DatabricksTrigger only fires once a
     Databricks run reaches a successful state.
     """
-    run_state.return_value = RunState(
-        life_cycle_state="TERMINATED",
-        result_state="SUCCESS",
-        state_message="",
-    )
+    mock_run_response.return_value = {
+        "state": {
+            "life_cycle_state": "TERMINATED",
+            "result_state": "SUCCESS",
+            "state_message": "",
+        }
+    }
     trigger = DatabricksTrigger(
         conn_id=CONN_ID,
         task_id=TASK_ID,
@@ -76,17 +145,21 @@ async def test_databricks_trigger_success(run_state):
 
 
 @pytest.mark.asyncio
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_state_async")
-async def test_databricks_trigger_running(run_state, caplog):
+@mock.patch("airflow.providers.databricks.hooks.databricks.RunState")
+@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
+async def test_databricks_trigger_running(mock_run_response, run_state, caplog):
     """
     Tests that the DatabricksTrigger does not fire while a
     Databricks run has not yet reached a terminated state.
     """
-    run_state.return_value = RunState(
-        life_cycle_state="RUNNING",
-        result_state="",
-        state_message="In run",
-    )
+    mock_run_response.return_value = {
+        "state": {
+            "life_cycle_state": "RUNNING",
+            "result_state": "",
+            "state_message": "In run",
+            "user_cancelled_or_timedout": "False",
+        }
+    }
 
     caplog.set_level(logging.INFO)
 
@@ -116,18 +189,21 @@ async def test_databricks_trigger_running(run_state, caplog):
 
 
 @pytest.mark.asyncio
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_state_async")
-async def test_databricks_trigger_terminated(run_state):
+@mock.patch("airflow.providers.databricks.hooks.databricks.RunState")
+@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
+async def test_databricks_trigger_terminated(mock_run_response, mock_run_state):
     """
     Tests that the DatabricksTrigger does not fire once a
     Databricks run reaches a terminated state.
     Assert that an exception is thrown instead.
     """
-    run_state.return_value = RunState(
-        life_cycle_state="TERMINATED",
-        result_state="TERMINATED",
-        state_message="",
-    )
+    mock_run_response.return_value = {
+        "state": {
+            "life_cycle_state": "TERMINATED",
+            "result_state": "TERMINATED",
+            "state_message": "",
+        }
+    }
 
     trigger = DatabricksTrigger(
         conn_id=CONN_ID,
@@ -145,7 +221,7 @@ async def test_databricks_trigger_terminated(run_state):
             {
                 "status": "error",
                 "message": "databricks_check failed with terminal state: {'life_cycle_state': 'TERMINATED',"
-                " 'result_state': 'TERMINATED', 'state_message': ''}",
+                " 'result_state': 'TERMINATED', 'state_message': ''} and with the error ",
             }
         )
         == actual
@@ -153,7 +229,53 @@ async def test_databricks_trigger_terminated(run_state):
 
 
 @pytest.mark.asyncio
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_state_async")
+@pytest.mark.parametrize(
+    "mock_run_response, mock_get_output_response",
+    [
+        (MOCK_RUN_RESPONSE_IN_ERROR_1, MOCK_RUN_GET_OUTPUT_RESPONSE_IN_ERROR_1),
+        (MOCK_RUN_RESPONSE_IN_ERROR_1, MOCK_RUN_GET_OUTPUT_RESPONSE_IN_ERROR_2),
+        (MOCK_RUN_RESPONSE_IN_ERROR_2, MOCK_RUN_GET_OUTPUT_RESPONSE_IN_ERROR_2),
+    ],
+)
+@mock.patch("airflow.providers.databricks.hooks.databricks.RunState")
+@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_output_response")
+@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
+async def test_databricks_trigger_terminal_status_failed(
+    mock_run_response_func, mock_get_run_output, mock_run_state, mock_run_response, mock_get_output_response
+):
+    """
+    Tests that the DatabricksTrigger does not fire once a
+    Databricks run reaches a terminated state.
+    Assert that an exception is thrown instead.
+    """
+    mock_run_response_func.return_value = mock_run_response
+    mock_get_run_output.return_value = mock_get_output_response
+    trigger = DatabricksTrigger(
+        conn_id=CONN_ID,
+        task_id=TASK_ID,
+        run_id=RUN_ID,
+        retry_limit=RETRY_LIMIT,
+        retry_delay=RETRY_DELAY,
+        polling_period_seconds=POLLING_PERIOD_SECONDS,
+    )
+
+    generator = trigger.run()
+    actual = await generator.asend(None)
+    assert (
+        TriggerEvent(
+            {
+                "status": "error",
+                "message": "databricks_check failed with terminal state: {'life_cycle_state': 'TERMINATED',"
+                " 'result_state': 'FAILED', 'state_message': 'Test error'}"
+                " and with the error Test error",
+            }
+        )
+        == actual
+    )
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
 async def test_databricks_trigger_exception(run_state):
     """
     Tests that the DatabricksTrigger yield error in case of exception


### PR DESCRIPTION
Handled the failure case properly with proper failure message as per in sync version
- In the Jobs API 2.1, we can't call `get_run_output` on the top-level Run ID because it's
not supported by API - we need to call this function on a specific sub-run of the job, even
if it consists of the single task

closes: #643 