### PR TITLE
Modify test RC dependency automation to create a PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ run-local-lineage-server: ## Run flask based local Lineage server
 	FLASK_APP=dev/local_flask_lineage_server.py flask run --host 0.0.0.0 --port 5050
 
 test-rc-deps: ## Test providers RC by building an image with given dependencies and running the master DAG
+	@which gh > /dev/null || (echo "ERROR: Github CLI is required. Refer https://github.com/cli/cli for installation."; exit 1)
 	git checkout main && git pull origin main
 	$(eval current_timestamp := $(shell date +%Y-%m-%dT%H-%M-%S%Z))
 	echo "Current timestamp is" $(current_timestamp)


### PR DESCRIPTION
Currently, we only modify the setup.cfg with the RC providers, build the image, deploy it to Astro Cloud and then trigger the master DAG run. However, we do not check if the RC causes any static check failures like `mypy` or if the tests run fine as we do not run the checks which are only triggered once we create a PR. We come to know of such failures only upon new subsequent PRs. So to detect such failures early, change the `test-rc-deps `make target to create a PR by pushing the setup.cfg to a new branch.

Also, we observed in the past that it takes sometimes ~20 mins for the new image changes to be applied on Astro Cloud and hence we are increasing the wait time to 30 mins before triggering the master DAG run to test the RCs against our DAGs.

closes: #677 