### PR TITLE
Fix mypy issue

### DIFF
--- a/astronomer/providers/amazon/aws/operators/emr.py
+++ b/astronomer/providers/amazon/aws/operators/emr.py
@@ -43,11 +43,11 @@ class EmrContainerOperatorAsync(EmrContainerOperator):
         )
         try:
             # for apache-airflow-providers-amazon<6.0.0
-            polling_attempts = self.max_tries
+            polling_attempts = self.max_tries  # type: ignore[attr-defined]
         except AttributeError:  # pragma: no cover
             # for apache-airflow-providers-amazon>=6.0.0
             # max_tries is deprecated so instead of max_tries using self.max_polling_attempts
-            polling_attempts = self.max_polling_attempts  # type: ignore[attr-defined]
+            polling_attempts = self.max_polling_attempts
 
         self.defer(
             timeout=self.execution_timeout,


### PR DESCRIPTION
In the latest  `apache-airflow-providers-amazon-6.0.0`  the `max_tries` attribute is deprecated and that got fixed in the RC image test PR #682, as we discussed fixing mypy issue after the release.
<img width="1048" alt="Screenshot 2022-10-03 at 1 13 00 PM" src="https://user-images.githubusercontent.com/94612827/193525296-35913368-7791-4cda-90d3-66fefdb242cb.png">
