### PR TITLE
Allow Async Google Operators to accept `impersonation_chain` and `delegate_to` parameters for authentication

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -134,6 +134,7 @@ with DAG(
         {"dataproc_dag": "example_gcp_dataproc"},
         {"kubernetes_engine_dag": "example_google_kubernetes_engine"},
         {"bigquery_impersonation_dag": "example_bigquery_impersonation"},
+        {"dataproc_impersonation_dag": "example_gcp_dataproc_impersonation"},
     ]
     google_trigger_tasks, ids = prepare_dag_dependency(google_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)

--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -133,7 +133,7 @@ with DAG(
         {"big_query_sensor_dag": "example_bigquery_sensors"},
         {"dataproc_dag": "example_gcp_dataproc"},
         {"kubernetes_engine_dag": "example_google_kubernetes_engine"},
-        {"bigquery_dag_impersonation": "example_async_bigquery_impersonation"},
+        {"bigquery_impersonation_dag": "example_bigquery_impersonation"},
     ]
     google_trigger_tasks, ids = prepare_dag_dependency(google_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)

--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -133,6 +133,7 @@ with DAG(
         {"big_query_sensor_dag": "example_bigquery_sensors"},
         {"dataproc_dag": "example_gcp_dataproc"},
         {"kubernetes_engine_dag": "example_google_kubernetes_engine"},
+        {"bigquery_dag_impersonation": "example_async_bigquery_impersonation"},
     ]
     google_trigger_tasks, ids = prepare_dag_dependency(google_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)

--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_impersonation_chain.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_impersonation_chain.py
@@ -1,6 +1,6 @@
 """
-Example Airflow DAG for Google BigQuery service.
-Uses Async version of BigQueryInsertJobOperator and BigQueryCheckOperator.
+Example Airflow DAG which uses impersonation and delegate_to
+parameters for authenticating with Google BigQuery service
 """
 import os
 from datetime import datetime, timedelta
@@ -23,7 +23,7 @@ DATASET_NAME = os.getenv("GCP_BIGQUERY_DATASET_NAME", "astro_dataset")
 GCP_CONN_ID = os.getenv("GCP_CONN_ID", "google_impersonation")
 LOCATION = os.getenv("GCP_LOCATION", "us")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
-IMPERSONATION_KEY = os.getenv("IMPERSONATION_KEY", "")
+IMPERSONATION_CHAIN = os.getenv("IMPERSONATION_CHAIN", "")
 DELEGATE_TO = os.getenv("DELEGATE_TO", "")
 
 
@@ -51,7 +51,7 @@ default_args = {
 }
 
 with DAG(
-    dag_id="example_async_bigquery_impersonation",
+    dag_id="example_bigquery_impersonation",
     schedule_interval=None,
     start_date=datetime(2022, 1, 1),
     catchup=False,
@@ -64,7 +64,7 @@ with DAG(
         dataset_id=DATASET,
         location=LOCATION,
         gcp_conn_id=GCP_CONN_ID,
-        impersonation_chain=IMPERSONATION_KEY,
+        impersonation_chain=IMPERSONATION_CHAIN,
     )
 
     create_table_1 = BigQueryCreateEmptyTableOperator(
@@ -74,7 +74,7 @@ with DAG(
         schema_fields=SCHEMA,
         location=LOCATION,
         bigquery_conn_id=GCP_CONN_ID,
-        impersonation_chain=IMPERSONATION_KEY,
+        impersonation_chain=IMPERSONATION_CHAIN,
     )
 
     create_dataset >> create_table_1
@@ -85,7 +85,7 @@ with DAG(
         delete_contents=True,
         gcp_conn_id=GCP_CONN_ID,
         trigger_rule="all_done",
-        impersonation_chain=IMPERSONATION_KEY,
+        impersonation_chain=IMPERSONATION_CHAIN,
     )
 
     # [START howto_operator_bigquery_insert_job_async]
@@ -99,7 +99,7 @@ with DAG(
         },
         location=LOCATION,
         gcp_conn_id=GCP_CONN_ID,
-        impersonation_chain=IMPERSONATION_KEY,
+        impersonation_chain=IMPERSONATION_CHAIN,
     )
     # [END howto_operator_bigquery_insert_job_async]
 
@@ -114,7 +114,7 @@ with DAG(
         },
         location=LOCATION,
         gcp_conn_id=GCP_CONN_ID,
-        impersonation_chain=IMPERSONATION_KEY,
+        impersonation_chain=IMPERSONATION_CHAIN,
         delegate_to=DELEGATE_TO,
     )
     # [END howto_operator_bigquery_select_job_async]
@@ -126,7 +126,7 @@ with DAG(
         use_legacy_sql=False,
         location=LOCATION,
         gcp_conn_id=GCP_CONN_ID,
-        impersonation_chain=IMPERSONATION_KEY,
+        impersonation_chain=IMPERSONATION_CHAIN,
     )
     # [END howto_operator_bigquery_check_async]
 

--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_impersonation_chain.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_impersonation_chain.py
@@ -20,7 +20,7 @@ from astronomer.providers.google.cloud.operators.bigquery import (
 
 PROJECT_ID = os.getenv("GCP_PROJECT_ID", "astronomer-airflow-providers")
 DATASET_NAME = os.getenv("GCP_BIGQUERY_DATASET_NAME", "astro_dataset")
-GCP_CONN_ID = os.getenv("GCP_CONN_ID", "google_impersonation")
+GCP_IMPERSONATION_CONN_ID = os.getenv("GCP_IMPERSONATION_CONN_ID", "google_impersonation")
 LOCATION = os.getenv("GCP_LOCATION", "us")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 IMPERSONATION_CHAIN = os.getenv("IMPERSONATION_CHAIN", "")
@@ -63,7 +63,7 @@ with DAG(
         task_id="create_dataset",
         dataset_id=DATASET,
         location=LOCATION,
-        gcp_conn_id=GCP_CONN_ID,
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
         impersonation_chain=IMPERSONATION_CHAIN,
     )
 
@@ -73,7 +73,7 @@ with DAG(
         table_id=TABLE_1,
         schema_fields=SCHEMA,
         location=LOCATION,
-        bigquery_conn_id=GCP_CONN_ID,
+        bigquery_conn_id=GCP_IMPERSONATION_CONN_ID,
         impersonation_chain=IMPERSONATION_CHAIN,
     )
 
@@ -83,7 +83,7 @@ with DAG(
         task_id="delete_dataset",
         dataset_id=DATASET,
         delete_contents=True,
-        gcp_conn_id=GCP_CONN_ID,
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
         trigger_rule="all_done",
         impersonation_chain=IMPERSONATION_CHAIN,
     )
@@ -98,7 +98,7 @@ with DAG(
             }
         },
         location=LOCATION,
-        gcp_conn_id=GCP_CONN_ID,
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
         impersonation_chain=IMPERSONATION_CHAIN,
     )
     # [END howto_operator_bigquery_insert_job_async]
@@ -113,7 +113,7 @@ with DAG(
             }
         },
         location=LOCATION,
-        gcp_conn_id=GCP_CONN_ID,
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
         impersonation_chain=IMPERSONATION_CHAIN,
         delegate_to=DELEGATE_TO,
     )
@@ -125,7 +125,7 @@ with DAG(
         sql=f"SELECT COUNT(*) FROM {DATASET}.{TABLE_1}",
         use_legacy_sql=False,
         location=LOCATION,
-        gcp_conn_id=GCP_CONN_ID,
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
         impersonation_chain=IMPERSONATION_CHAIN,
     )
     # [END howto_operator_bigquery_check_async]

--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_impersonation_key.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_impersonation_key.py
@@ -1,0 +1,134 @@
+"""
+Example Airflow DAG for Google BigQuery service.
+Uses Async version of BigQueryInsertJobOperator and BigQueryCheckOperator.
+"""
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.providers.google.cloud.operators.bigquery import (
+    BigQueryCreateEmptyDatasetOperator,
+    BigQueryCreateEmptyTableOperator,
+    BigQueryDeleteDatasetOperator,
+    BigQueryInsertJobOperator,
+)
+
+from astronomer.providers.google.cloud.operators.bigquery import (
+    BigQueryCheckOperatorAsync,
+    BigQueryInsertJobOperatorAsync,
+)
+
+PROJECT_ID = os.getenv("GCP_PROJECT_ID", "astronomer-airflow-providers")
+DATASET_NAME = os.getenv("GCP_BIGQUERY_DATASET_NAME", "astro_dataset")
+GCP_CONN_ID = os.getenv("GCP_CONN_ID", "google_cloud_default")
+LOCATION = os.getenv("GCP_LOCATION", "us")
+EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
+IMPERSONATION_KEY = os.getenv("IMPERSONATION_KEY", "")
+
+
+TABLE_1 = "table1"
+TABLE_2 = "table2"
+
+SCHEMA = [
+    {"name": "value", "type": "INTEGER", "mode": "REQUIRED"},
+    {"name": "name", "type": "STRING", "mode": "NULLABLE"},
+    {"name": "ds", "type": "STRING", "mode": "NULLABLE"},
+]
+
+DATASET = DATASET_NAME
+INSERT_DATE = datetime.now().strftime("%Y-%m-%d")
+INSERT_ROWS_QUERY = (
+    f"INSERT {DATASET}.{TABLE_1} VALUES "
+    f"(42, 'monthy python', '{INSERT_DATE}'), "
+    f"(42, 'fishy fish', '{INSERT_DATE}');"
+)
+
+default_args = {
+    "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
+}
+
+with DAG(
+    dag_id="example_async_bigquery_impersonation",
+    schedule_interval=None,
+    start_date=datetime(2022, 1, 1),
+    catchup=False,
+    default_args=default_args,
+    tags=["example", "async", "bigquery"],
+    user_defined_macros={"DATASET": DATASET, "TABLE": TABLE_1},
+) as dag:
+    create_dataset = BigQueryCreateEmptyDatasetOperator(
+        task_id="create_dataset",
+        dataset_id=DATASET,
+        location=LOCATION,
+        gcp_conn_id=GCP_CONN_ID,
+        impersonation_chain=IMPERSONATION_KEY,
+    )
+
+    create_table_1 = BigQueryCreateEmptyTableOperator(
+        task_id="create_table_1",
+        dataset_id=DATASET,
+        table_id=TABLE_1,
+        schema_fields=SCHEMA,
+        location=LOCATION,
+        bigquery_conn_id=GCP_CONN_ID,
+        impersonation_chain=IMPERSONATION_KEY,
+    )
+
+    create_dataset >> create_table_1
+
+    delete_dataset = BigQueryDeleteDatasetOperator(
+        task_id="delete_dataset",
+        dataset_id=DATASET,
+        delete_contents=True,
+        gcp_conn_id=GCP_CONN_ID,
+        trigger_rule="all_done",
+        impersonation_chain=IMPERSONATION_KEY,
+    )
+
+    # [START howto_operator_bigquery_insert_job_async]
+    insert_query_job = BigQueryInsertJobOperator(
+        task_id="insert_query_job",
+        configuration={
+            "query": {
+                "query": INSERT_ROWS_QUERY,
+                "useLegacySql": False,
+            }
+        },
+        location=LOCATION,
+        gcp_conn_id=GCP_CONN_ID,
+        impersonation_chain=IMPERSONATION_KEY,
+    )
+    # [END howto_operator_bigquery_insert_job_async]
+
+    # [START howto_operator_bigquery_select_job_async]
+    select_query_job = BigQueryInsertJobOperatorAsync(
+        task_id="select_query_job",
+        configuration={
+            "query": {
+                "query": "{% include 'example_bigquery_query.sql' %}",
+                "useLegacySql": False,
+            }
+        },
+        location=LOCATION,
+        gcp_conn_id=GCP_CONN_ID,
+        impersonation_chain=IMPERSONATION_KEY,
+    )
+    # [END howto_operator_bigquery_select_job_async]
+
+    # [START howto_operator_bigquery_check_async]
+    check_count = BigQueryCheckOperatorAsync(
+        task_id="check_count",
+        sql=f"SELECT COUNT(*) FROM {DATASET}.{TABLE_1}",
+        use_legacy_sql=False,
+        location=LOCATION,
+        gcp_conn_id=GCP_CONN_ID,
+        impersonation_chain=IMPERSONATION_KEY,
+    )
+    # [END howto_operator_bigquery_check_async]
+
+    end = EmptyOperator(task_id="end")
+
+    create_table_1 >> insert_query_job >> select_query_job >> check_count >> delete_dataset >> end

--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_impersonation_key.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_impersonation_key.py
@@ -25,6 +25,7 @@ GCP_CONN_ID = os.getenv("GCP_CONN_ID", "google_cloud_default")
 LOCATION = os.getenv("GCP_LOCATION", "us")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 IMPERSONATION_KEY = os.getenv("IMPERSONATION_KEY", "")
+DELEGATE_TO = os.getenv("DELEGATE_TO", "")
 
 
 TABLE_1 = "table1"
@@ -115,6 +116,7 @@ with DAG(
         location=LOCATION,
         gcp_conn_id=GCP_CONN_ID,
         impersonation_chain=IMPERSONATION_KEY,
+        delegate_to=DELEGATE_TO,
     )
     # [END howto_operator_bigquery_select_job_async]
 

--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_impersonation_key.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_impersonation_key.py
@@ -11,7 +11,6 @@ from airflow.providers.google.cloud.operators.bigquery import (
     BigQueryCreateEmptyDatasetOperator,
     BigQueryCreateEmptyTableOperator,
     BigQueryDeleteDatasetOperator,
-    BigQueryInsertJobOperator,
 )
 
 from astronomer.providers.google.cloud.operators.bigquery import (
@@ -90,7 +89,7 @@ with DAG(
     )
 
     # [START howto_operator_bigquery_insert_job_async]
-    insert_query_job = BigQueryInsertJobOperator(
+    insert_query_job = BigQueryInsertJobOperatorAsync(
         task_id="insert_query_job",
         configuration={
             "query": {

--- a/astronomer/providers/google/cloud/example_dags/example_bigquery_impersonation_key.py
+++ b/astronomer/providers/google/cloud/example_dags/example_bigquery_impersonation_key.py
@@ -21,7 +21,7 @@ from astronomer.providers.google.cloud.operators.bigquery import (
 
 PROJECT_ID = os.getenv("GCP_PROJECT_ID", "astronomer-airflow-providers")
 DATASET_NAME = os.getenv("GCP_BIGQUERY_DATASET_NAME", "astro_dataset")
-GCP_CONN_ID = os.getenv("GCP_CONN_ID", "google_cloud_default")
+GCP_CONN_ID = os.getenv("GCP_CONN_ID", "google_impersonation")
 LOCATION = os.getenv("GCP_LOCATION", "us")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 IMPERSONATION_KEY = os.getenv("IMPERSONATION_KEY", "")

--- a/astronomer/providers/google/cloud/example_dags/example_dataproc_impersonation.py
+++ b/astronomer/providers/google/cloud/example_dags/example_dataproc_impersonation.py
@@ -136,6 +136,7 @@ with models.DAG(
 
     # [START howto_operator_dataproc_update_cluster_async]
     update_cluster = DataprocUpdateClusterOperatorAsync(
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
         task_id="update_cluster",
         cluster_name=CLUSTER_NAME,
         cluster=CLUSTER_UPDATE,

--- a/astronomer/providers/google/cloud/example_dags/example_dataproc_impersonation.py
+++ b/astronomer/providers/google/cloud/example_dags/example_dataproc_impersonation.py
@@ -20,7 +20,7 @@ from astronomer.providers.google.cloud.operators.dataproc import (
 PROJECT_ID = os.getenv("GCP_PROJECT_ID", "astronomer-airflow-providers")
 CLUSTER_NAME = os.getenv("GCP_DATAPROC_CLUSTER_NAME", "example-cluster-astronomer-providers")
 REGION = os.getenv("GCP_LOCATION", "us-central1")
-GCP_CONN_ID = os.getenv("GCP_CONN_ID", "google_impersonation")
+GCP_IMPERSONATION_CONN_ID = os.getenv("GCP_IMPERSONATION_CONN_ID", "google_impersonation")
 ZONE = os.getenv("GCP_REGION", "us-central1-a")
 BUCKET = os.getenv("GCP_DATAPROC_BUCKET", "dataproc-system-tests-astronomer-providers")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
@@ -124,6 +124,7 @@ with models.DAG(
 ) as dag:
     # [START howto_operator_dataproc_create_cluster_async]
     create_cluster = DataprocCreateClusterOperatorAsync(
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
         task_id="create_cluster",
         project_id=PROJECT_ID,
         cluster_config=CLUSTER_CONFIG,
@@ -148,6 +149,7 @@ with models.DAG(
 
     # [START howto_create_bucket_task]
     create_bucket = GCSCreateBucketOperator(
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
         task_id="create_bucket",
         bucket_name=BUCKET,
         project_id=PROJECT_ID,
@@ -163,12 +165,17 @@ with models.DAG(
 
     # [START howto_operator_dataproc_submit_pig_job_async]
     pig_task = DataprocSubmitJobOperatorAsync(
-        task_id="pig_task", job=PIG_JOB, region=REGION, project_id=PROJECT_ID
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
+        task_id="pig_task",
+        job=PIG_JOB,
+        region=REGION,
+        project_id=PROJECT_ID,
     )
     # [END howto_operator_dataproc_submit_pig_job_async]
 
     # [START howto_DataprocSubmitJobOperatorAsync]
     spark_sql_task = DataprocSubmitJobOperatorAsync(
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
         task_id="spark_sql_task",
         job=SPARK_SQL_JOB,
         region=REGION,
@@ -178,6 +185,7 @@ with models.DAG(
     # [END howto_DataprocSubmitJobOperatorAsync]
     # [START howto_DataprocSubmitJobOperatorAsync]
     spark_task = DataprocSubmitJobOperatorAsync(
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
         task_id="spark_task",
         job=SPARK_JOB,
         region=REGION,
@@ -187,6 +195,7 @@ with models.DAG(
     # [END howto_DataprocSubmitJobOperatorAsync]
     # [START howto_DataprocSubmitJobOperatorAsync]
     hive_task = DataprocSubmitJobOperatorAsync(
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
         task_id="hive_task",
         job=HIVE_JOB,
         region=REGION,
@@ -196,6 +205,7 @@ with models.DAG(
     # [END howto_DataprocSubmitJobOperatorAsync]
     # [START howto_DataprocSubmitJobOperatorAsync]
     hadoop_task = DataprocSubmitJobOperatorAsync(
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
         task_id="hadoop_task",
         job=HADOOP_JOB,
         region=REGION,
@@ -206,6 +216,7 @@ with models.DAG(
 
     # [START howto_operator_dataproc_delete_cluster_async]
     delete_cluster = DataprocDeleteClusterOperatorAsync(
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
         task_id="delete_cluster",
         project_id=PROJECT_ID,
         cluster_name=CLUSTER_NAME,
@@ -217,6 +228,7 @@ with models.DAG(
 
     # [START howto_delete_buckettask]
     delete_bucket = GCSDeleteBucketOperator(
+        gcp_conn_id=GCP_IMPERSONATION_CONN_ID,
         task_id="delete_bucket",
         bucket_name=BUCKET,
         trigger_rule="all_done",

--- a/astronomer/providers/google/cloud/example_dags/example_dataproc_impersonation.py
+++ b/astronomer/providers/google/cloud/example_dags/example_dataproc_impersonation.py
@@ -1,0 +1,239 @@
+"""Example Airflow DAG which uses impersonation parameters for authenticating with Dataproc operators."""
+
+import os
+from datetime import datetime, timedelta
+
+from airflow import models
+from airflow.operators.empty import EmptyOperator
+from airflow.providers.google.cloud.operators.gcs import (
+    GCSCreateBucketOperator,
+    GCSDeleteBucketOperator,
+)
+
+from astronomer.providers.google.cloud.operators.dataproc import (
+    DataprocCreateClusterOperatorAsync,
+    DataprocDeleteClusterOperatorAsync,
+    DataprocSubmitJobOperatorAsync,
+    DataprocUpdateClusterOperatorAsync,
+)
+
+PROJECT_ID = os.getenv("GCP_PROJECT_ID", "astronomer-airflow-providers")
+CLUSTER_NAME = os.getenv("GCP_DATAPROC_CLUSTER_NAME", "example-cluster-astronomer-providers")
+REGION = os.getenv("GCP_LOCATION", "us-central1")
+GCP_CONN_ID = os.getenv("GCP_CONN_ID", "google_impersonation")
+ZONE = os.getenv("GCP_REGION", "us-central1-a")
+BUCKET = os.getenv("GCP_DATAPROC_BUCKET", "dataproc-system-tests-astronomer-providers")
+EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
+OUTPUT_FOLDER = "wordcount"
+OUTPUT_PATH = f"gs://{BUCKET}/{OUTPUT_FOLDER}/"
+IMPERSONATION_CHAIN = os.getenv("IMPERSONATION_CHAIN", "")
+
+# Cluster definition
+# [START how_to_cloud_dataproc_create_cluster]
+
+CLUSTER_CONFIG = {
+    "master_config": {
+        "num_instances": 1,
+        "machine_type_uri": "n1-standard-4",
+        "disk_config": {"boot_disk_type": "pd-standard", "boot_disk_size_gb": 1024},
+    },
+}
+
+# [END how_to_cloud_dataproc_create_cluster]
+
+
+CLUSTER_UPDATE = {"config": {"worker_config": {"num_instances": 2}}}
+UPDATE_MASK = {
+    "paths": ["config.worker_config.num_instances", "config.secondary_worker_config.num_instances"]
+}
+
+TIMEOUT = {"seconds": 1 * 24 * 60 * 60}
+
+# Jobs definitions
+# [START how_to_cloud_dataproc_pig_config]
+PIG_JOB = {
+    "reference": {"project_id": PROJECT_ID},
+    "placement": {"cluster_name": CLUSTER_NAME},
+    "pig_job": {"query_list": {"queries": ["define sin HiveUDF('sin');"]}},
+}
+# [END how_to_cloud_dataproc_pig_config]
+
+# [START how_to_cloud_dataproc_sparksql_config]
+SPARK_SQL_JOB = {
+    "reference": {"project_id": PROJECT_ID},
+    "placement": {"cluster_name": CLUSTER_NAME},
+    "spark_sql_job": {"query_list": {"queries": ["SHOW DATABASES;"]}},
+}
+# [END how_to_cloud_dataproc_sparksql_config]
+
+# [START how_to_cloud_dataproc_spark_config]
+SPARK_JOB = {
+    "reference": {"project_id": PROJECT_ID},
+    "placement": {"cluster_name": CLUSTER_NAME},
+    "spark_job": {
+        "jar_file_uris": ["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
+        "main_class": "org.apache.spark.examples.SparkPi",
+    },
+}
+# [END how_to_cloud_dataproc_spark_config]
+
+# [START how_to_cloud_dataproc_hive_config]
+HIVE_JOB = {
+    "reference": {"project_id": PROJECT_ID},
+    "placement": {"cluster_name": CLUSTER_NAME},
+    "hive_job": {"query_list": {"queries": ["SHOW DATABASES;"]}},
+}
+# [END how_to_cloud_dataproc_hive_config]
+
+# [START how_to_cloud_dataproc_hadoop_config]
+HADOOP_JOB = {
+    "reference": {"project_id": PROJECT_ID},
+    "placement": {"cluster_name": CLUSTER_NAME},
+    "hadoop_job": {
+        "main_jar_file_uri": "file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar",
+        "args": ["wordcount", "gs://pub/shakespeare/rose.txt", OUTPUT_PATH],
+    },
+}
+# [END how_to_cloud_dataproc_hadoop_config]
+WORKFLOW_NAME = "airflow-dataproc-test"
+WORKFLOW_TEMPLATE = {
+    "id": WORKFLOW_NAME,
+    "placement": {
+        "managed_cluster": {
+            "cluster_name": CLUSTER_NAME,
+            "config": CLUSTER_CONFIG,
+        }
+    },
+    "jobs": [{"step_id": "pig_job_1", "pig_job": PIG_JOB["pig_job"]}],
+}
+
+default_args = {
+    "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
+}
+
+
+with models.DAG(
+    dag_id="example_gcp_dataproc_impersonation",
+    schedule_interval=None,
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+    default_args=default_args,
+    tags=["example", "async", "dataproc"],
+) as dag:
+    # [START howto_operator_dataproc_create_cluster_async]
+    create_cluster = DataprocCreateClusterOperatorAsync(
+        task_id="create_cluster",
+        project_id=PROJECT_ID,
+        cluster_config=CLUSTER_CONFIG,
+        region=REGION,
+        cluster_name=CLUSTER_NAME,
+        impersonation_chain=IMPERSONATION_CHAIN,
+    )
+    # [END howto_operator_dataproc_create_cluster_async]
+
+    # [START howto_operator_dataproc_update_cluster_async]
+    update_cluster = DataprocUpdateClusterOperatorAsync(
+        task_id="update_cluster",
+        cluster_name=CLUSTER_NAME,
+        cluster=CLUSTER_UPDATE,
+        update_mask=UPDATE_MASK,
+        graceful_decommission_timeout=TIMEOUT,
+        project_id=PROJECT_ID,
+        region=REGION,
+        impersonation_chain=IMPERSONATION_CHAIN,
+    )
+    # [END howto_operator_dataproc_update_cluster_async]
+
+    # [START howto_create_bucket_task]
+    create_bucket = GCSCreateBucketOperator(
+        task_id="create_bucket",
+        bucket_name=BUCKET,
+        project_id=PROJECT_ID,
+        resource={
+            "iamConfiguration": {
+                "uniformBucketLevelAccess": {
+                    "enabled": False,
+                },
+            },
+        },
+    )
+    # [END howto_create_bucket_task]
+
+    # [START howto_operator_dataproc_submit_pig_job_async]
+    pig_task = DataprocSubmitJobOperatorAsync(
+        task_id="pig_task", job=PIG_JOB, region=REGION, project_id=PROJECT_ID
+    )
+    # [END howto_operator_dataproc_submit_pig_job_async]
+
+    # [START howto_DataprocSubmitJobOperatorAsync]
+    spark_sql_task = DataprocSubmitJobOperatorAsync(
+        task_id="spark_sql_task",
+        job=SPARK_SQL_JOB,
+        region=REGION,
+        project_id=PROJECT_ID,
+        impersonation_chain=IMPERSONATION_CHAIN,
+    )
+    # [END howto_DataprocSubmitJobOperatorAsync]
+    # [START howto_DataprocSubmitJobOperatorAsync]
+    spark_task = DataprocSubmitJobOperatorAsync(
+        task_id="spark_task",
+        job=SPARK_JOB,
+        region=REGION,
+        project_id=PROJECT_ID,
+        impersonation_chain=IMPERSONATION_CHAIN,
+    )
+    # [END howto_DataprocSubmitJobOperatorAsync]
+    # [START howto_DataprocSubmitJobOperatorAsync]
+    hive_task = DataprocSubmitJobOperatorAsync(
+        task_id="hive_task",
+        job=HIVE_JOB,
+        region=REGION,
+        project_id=PROJECT_ID,
+        impersonation_chain=IMPERSONATION_CHAIN,
+    )
+    # [END howto_DataprocSubmitJobOperatorAsync]
+    # [START howto_DataprocSubmitJobOperatorAsync]
+    hadoop_task = DataprocSubmitJobOperatorAsync(
+        task_id="hadoop_task",
+        job=HADOOP_JOB,
+        region=REGION,
+        project_id=PROJECT_ID,
+        impersonation_chain=IMPERSONATION_CHAIN,
+    )
+    # [END howto_DataprocSubmitJobOperatorAsync]
+
+    # [START howto_operator_dataproc_delete_cluster_async]
+    delete_cluster = DataprocDeleteClusterOperatorAsync(
+        task_id="delete_cluster",
+        project_id=PROJECT_ID,
+        cluster_name=CLUSTER_NAME,
+        region=REGION,
+        trigger_rule="all_done",
+        impersonation_chain=IMPERSONATION_CHAIN,
+    )
+    # [END howto_operator_dataproc_delete_cluster_async]
+
+    # [START howto_delete_buckettask]
+    delete_bucket = GCSDeleteBucketOperator(
+        task_id="delete_bucket",
+        bucket_name=BUCKET,
+        trigger_rule="all_done",
+    )
+    # [END howto_delete_buckettask]
+
+    end = EmptyOperator(task_id="end")
+
+    create_cluster >> update_cluster >> hive_task >> spark_task >> spark_sql_task >> delete_cluster
+    (
+        create_cluster
+        >> update_cluster
+        >> pig_task
+        >> create_bucket
+        >> hadoop_task
+        >> delete_bucket
+        >> delete_cluster
+    )
+
+    [spark_sql_task, hadoop_task, delete_cluster, delete_bucket] >> end

--- a/astronomer/providers/google/cloud/hooks/bigquery.py
+++ b/astronomer/providers/google/cloud/hooks/bigquery.py
@@ -25,7 +25,7 @@ class BigQueryHookAsync(GoogleBaseHookAsync):
 
     sync_hook_class = BigQueryHook
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
 
     async def get_job_instance(

--- a/astronomer/providers/google/cloud/hooks/bigquery.py
+++ b/astronomer/providers/google/cloud/hooks/bigquery.py
@@ -25,6 +25,9 @@ class BigQueryHookAsync(GoogleBaseHookAsync):
 
     sync_hook_class = BigQueryHook
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
     async def get_job_instance(
         self, project_id: Optional[str], job_id: Optional[str], session: ClientSession
     ) -> Job:

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -72,7 +72,11 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
     """
 
     def execute(self, context: Context) -> None:  # noqa: D102
-        hook = BigQueryHook(gcp_conn_id=self.gcp_conn_id)
+        hook = BigQueryHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
 
         self.hook = hook
         job_id = self.hook.generate_job_id(
@@ -114,6 +118,8 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
                 conn_id=self.gcp_conn_id,
                 job_id=self.job_id,
                 project_id=self.project_id,
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
             ),
             method_name="execute_complete",
         )
@@ -158,6 +164,8 @@ class BigQueryCheckOperatorAsync(BigQueryCheckOperator):
     def execute(self, context: Context) -> None:  # noqa: D102
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
         )
         job = self._submit_job(hook, job_id="")
         context["ti"].xcom_push(key="job_id", value=job.job_id)
@@ -167,6 +175,8 @@ class BigQueryCheckOperatorAsync(BigQueryCheckOperator):
                 conn_id=self.gcp_conn_id,
                 job_id=job.job_id,
                 project_id=hook.project_id,
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
             ),
             method_name="execute_complete",
         )
@@ -288,6 +298,8 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
                 dataset_id=self.dataset_id,
                 table_id=self.table_id,
                 project_id=hook.project_id,
+                delegate_to=self.delegate_to,
+                impersonation_chain=self.impersonation_chain,
             ),
             method_name="execute_complete",
         )
@@ -376,6 +388,7 @@ class BigQueryIntervalCheckOperatorAsync(BigQueryIntervalCheckOperator):
                 days_back=self.days_back,
                 ratio_formula=self.ratio_formula,
                 ignore_zero=self.ignore_zero,
+                impersonation_chain=self.impersonation_chain,
             ),
             method_name="execute_complete",
         )
@@ -434,6 +447,7 @@ class BigQueryValueCheckOperatorAsync(BigQueryValueCheckOperator):  # noqa: D101
                 sql=self.sql,
                 pass_value=self.pass_value,
                 tolerance=self.tol,
+                impersonation_chain=self.impersonation_chain,
             ),
             method_name="execute_complete",
         )

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -164,7 +164,6 @@ class BigQueryCheckOperatorAsync(BigQueryCheckOperator):
     def execute(self, context: Context) -> None:  # noqa: D102
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
         job = self._submit_job(hook, job_id="")
@@ -175,7 +174,6 @@ class BigQueryCheckOperatorAsync(BigQueryCheckOperator):
                 conn_id=self.gcp_conn_id,
                 job_id=job.job_id,
                 project_id=hook.project_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
             ),
             method_name="execute_complete",

--- a/astronomer/providers/google/cloud/operators/dataproc.py
+++ b/astronomer/providers/google/cloud/operators/dataproc.py
@@ -186,6 +186,7 @@ class DataprocDeleteClusterOperatorAsync(DataprocDeleteClusterOperator):
 
         self.defer(
             trigger=DataprocDeleteClusterTrigger(
+                gcp_conn_id=self.gcp_conn_id,
                 project_id=self.project_id,
                 region=self.region,
                 cluster_name=self.cluster_name,

--- a/astronomer/providers/google/cloud/operators/dataproc.py
+++ b/astronomer/providers/google/cloud/operators/dataproc.py
@@ -74,7 +74,7 @@ class DataprocCreateClusterOperatorAsync(DataprocCreateClusterOperator):
 
     def execute(self, context: Context) -> None:  # type: ignore[override]
         """Call create cluster API and defer to DataprocCreateClusterTrigger to check the status"""
-        hook = DataprocHook(gcp_conn_id=self.gcp_conn_id)
+        hook = DataprocHook(gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain)
         DataprocLink.persist(
             context=context, task_instance=self, url=DATAPROC_CLUSTER_LINK, resource=self.cluster_name
         )
@@ -108,6 +108,7 @@ class DataprocCreateClusterOperatorAsync(DataprocCreateClusterOperator):
                 cluster_config=self.cluster_config,
                 labels=self.labels,
                 gcp_conn_id=self.gcp_conn_id,
+                impersonation_chain=self.impersonation_chain,
                 polling_interval=self.polling_interval,
             ),
             method_name="execute_complete",
@@ -192,6 +193,7 @@ class DataprocDeleteClusterOperatorAsync(DataprocDeleteClusterOperator):
                 retry=self.retry,
                 end_time=end_time,
                 metadata=self.metadata,
+                impersonation_chain=self.impersonation_chain,
             ),
             method_name="execute_complete",
         )
@@ -265,6 +267,7 @@ class DataprocSubmitJobOperatorAsync(DataprocSubmitJobOperator):
                 dataproc_job_id=job_id,
                 project_id=self.project_id,
                 region=self.region,
+                impersonation_chain=self.impersonation_chain,
             ),
             method_name="execute_complete",
         )
@@ -366,6 +369,7 @@ class DataprocUpdateClusterOperatorAsync(DataprocUpdateClusterOperator):
                 end_time=end_time,
                 metadata=self.metadata,
                 gcp_conn_id=self.gcp_conn_id,
+                impersonation_chain=self.impersonation_chain,
                 polling_interval=self.polling_interval,
             ),
             method_name="execute_complete",

--- a/astronomer/providers/google/cloud/triggers/bigquery.py
+++ b/astronomer/providers/google/cloud/triggers/bigquery.py
@@ -123,7 +123,6 @@ class BigQueryCheckTrigger(BigQueryInsertJobTrigger):
                 "dataset_id": self.dataset_id,
                 "project_id": self.project_id,
                 "table_id": self.table_id,
-                "delegate_to": self.delegate_to,
                 "impersonation_chain": self.impersonation_chain,
                 "poll_interval": self.poll_interval,
             },

--- a/tests/google/cloud/triggers/test_bigquery.py
+++ b/tests/google/cloud/triggers/test_bigquery.py
@@ -191,13 +191,13 @@ def test_bigquery_check_op_trigger_serialization():
     and classpath.
     """
     trigger = BigQueryCheckTrigger(
-        TEST_CONN_ID,
-        TEST_JOB_ID,
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_IMPERSONATION_CHAIN,
-        POLLING_PERIOD_SECONDS,
+        conn_id=TEST_CONN_ID,
+        job_id=TEST_JOB_ID,
+        project_id=TEST_GCP_PROJECT_ID,
+        dataset_id=TEST_DATASET_ID,
+        table_id=TEST_TABLE_ID,
+        impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        poll_interval=POLLING_PERIOD_SECONDS,
     )
     classpath, kwargs = trigger.serialize()
     assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryCheckTrigger"
@@ -398,6 +398,7 @@ def test_bigquery_interval_check_trigger_serialization():
         TEST_IGNORE_ZERO,
         TEST_DATASET_ID,
         TEST_TABLE_ID,
+        TEST_IMPERSONATION_CHAIN,
         POLLING_PERIOD_SECONDS,
     )
     classpath, kwargs = trigger.serialize()

--- a/tests/google/cloud/triggers/test_bigquery.py
+++ b/tests/google/cloud/triggers/test_bigquery.py
@@ -40,6 +40,8 @@ TEST_RATIO_FORMULA = "max_over_min"
 TEST_IGNORE_ZERO = True
 TEST_GCP_CONN_ID = "TEST_GCP_CONN_ID"
 TEST_HOOK_PARAMS = {}
+TEST_DELEGATE_TO = None
+TEST_IMPERSONATION_CHAIN = None
 
 
 def test_bigquery_insert_job_op_trigger_serialization():
@@ -53,6 +55,8 @@ def test_bigquery_insert_job_op_trigger_serialization():
         TEST_GCP_PROJECT_ID,
         TEST_DATASET_ID,
         TEST_TABLE_ID,
+        TEST_DELEGATE_TO,
+        TEST_IMPERSONATION_CHAIN,
         POLLING_PERIOD_SECONDS,
     )
     classpath, kwargs = trigger.serialize()
@@ -63,6 +67,8 @@ def test_bigquery_insert_job_op_trigger_serialization():
         "project_id": TEST_GCP_PROJECT_ID,
         "dataset_id": TEST_DATASET_ID,
         "table_id": TEST_TABLE_ID,
+        "delegate_to": TEST_DELEGATE_TO,
+        "impersonation_chain": TEST_IMPERSONATION_CHAIN,
         "poll_interval": POLLING_PERIOD_SECONDS,
     }
 
@@ -190,6 +196,8 @@ def test_bigquery_check_op_trigger_serialization():
         TEST_GCP_PROJECT_ID,
         TEST_DATASET_ID,
         TEST_TABLE_ID,
+        TEST_DELEGATE_TO,
+        TEST_IMPERSONATION_CHAIN,
         POLLING_PERIOD_SECONDS,
     )
     classpath, kwargs = trigger.serialize()
@@ -200,6 +208,8 @@ def test_bigquery_check_op_trigger_serialization():
         "dataset_id": TEST_DATASET_ID,
         "project_id": TEST_GCP_PROJECT_ID,
         "table_id": TEST_TABLE_ID,
+        "delegate_to": TEST_DELEGATE_TO,
+        "impersonation_chain": TEST_IMPERSONATION_CHAIN,
         "poll_interval": POLLING_PERIOD_SECONDS,
     }
 
@@ -297,6 +307,8 @@ def test_bigquery_get_data_trigger_serialization():
         project_id=TEST_GCP_PROJECT_ID,
         dataset_id=TEST_DATASET_ID,
         table_id=TEST_TABLE_ID,
+        delegate_to=TEST_DELEGATE_TO,
+        impersonation_chain=TEST_IMPERSONATION_CHAIN,
         poll_interval=POLLING_PERIOD_SECONDS,
     )
     classpath, kwargs = trigger.serialize()
@@ -307,6 +319,8 @@ def test_bigquery_get_data_trigger_serialization():
         "dataset_id": TEST_DATASET_ID,
         "project_id": TEST_GCP_PROJECT_ID,
         "table_id": TEST_TABLE_ID,
+        "delegate_to": TEST_DELEGATE_TO,
+        "impersonation_chain": TEST_IMPERSONATION_CHAIN,
         "poll_interval": POLLING_PERIOD_SECONDS,
     }
 

--- a/tests/google/cloud/triggers/test_bigquery.py
+++ b/tests/google/cloud/triggers/test_bigquery.py
@@ -196,7 +196,6 @@ def test_bigquery_check_op_trigger_serialization():
         TEST_GCP_PROJECT_ID,
         TEST_DATASET_ID,
         TEST_TABLE_ID,
-        TEST_DELEGATE_TO,
         TEST_IMPERSONATION_CHAIN,
         POLLING_PERIOD_SECONDS,
     )
@@ -208,7 +207,6 @@ def test_bigquery_check_op_trigger_serialization():
         "dataset_id": TEST_DATASET_ID,
         "project_id": TEST_GCP_PROJECT_ID,
         "table_id": TEST_TABLE_ID,
-        "delegate_to": TEST_DELEGATE_TO,
         "impersonation_chain": TEST_IMPERSONATION_CHAIN,
         "poll_interval": POLLING_PERIOD_SECONDS,
     }

--- a/tests/google/cloud/triggers/test_dataproc.py
+++ b/tests/google/cloud/triggers/test_dataproc.py
@@ -24,6 +24,7 @@ TEST_REGION = "us-central1"
 TEST_ZONE = "us-central1-a"
 TEST_JOB_ID = "test-job"
 TEST_POLLING_INTERVAL = 3.0
+TEST_IMPERSONATION_CHAIN = None
 
 
 def test_dataproc_submit_trigger_serialization():
@@ -36,6 +37,7 @@ def test_dataproc_submit_trigger_serialization():
         dataproc_job_id=TEST_JOB_ID,
         project_id=TEST_PROJECT_ID,
         region=TEST_REGION,
+        impersonation_chain=TEST_IMPERSONATION_CHAIN,
         polling_interval=TEST_POLLING_INTERVAL,
     )
     classpath, kwargs = trigger.serialize()
@@ -46,6 +48,7 @@ def test_dataproc_submit_trigger_serialization():
         "region": TEST_REGION,
         "polling_interval": TEST_POLLING_INTERVAL,
         "gcp_conn_id": TEST_GCP_CONN_ID,
+        "impersonation_chain": TEST_IMPERSONATION_CHAIN,
     }
 
 
@@ -66,6 +69,7 @@ async def test_dataproc_submit_return_success_and_failure(mock_get_job_status, s
         dataproc_job_id=TEST_JOB_ID,
         project_id=TEST_PROJECT_ID,
         region=TEST_REGION,
+        impersonation_chain=TEST_IMPERSONATION_CHAIN,
         polling_interval=TEST_POLLING_INTERVAL,
     )
     generator = trigger.run()
@@ -162,6 +166,7 @@ def test_dataproc_create_cluster_trigger_serialization():
         polling_interval=TEST_POLLING_INTERVAL,
         end_time=100,
         metadata=(),
+        impersonation_chain=TEST_IMPERSONATION_CHAIN,
     )
     classpath, kwargs = trigger.serialize()
     assert classpath == "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger"
@@ -171,6 +176,7 @@ def test_dataproc_create_cluster_trigger_serialization():
         "cluster_name": "test_cluster",
         "gcp_conn_id": TEST_GCP_CONN_ID,
         "polling_interval": TEST_POLLING_INTERVAL,
+        "impersonation_chain": TEST_IMPERSONATION_CHAIN,
         "delete_on_error": True,
         "labels": None,
         "cluster_config": None,
@@ -460,6 +466,7 @@ def test_dataproc_delete_cluster_trigger_serialization():
         cluster_name="test_cluster",
         gcp_conn_id=TEST_GCP_CONN_ID,
         polling_interval=TEST_POLLING_INTERVAL,
+        impersonation_chain=TEST_IMPERSONATION_CHAIN,
         end_time=100,
         metadata=(),
     )
@@ -471,6 +478,7 @@ def test_dataproc_delete_cluster_trigger_serialization():
         "cluster_name": "test_cluster",
         "gcp_conn_id": TEST_GCP_CONN_ID,
         "polling_interval": TEST_POLLING_INTERVAL,
+        "impersonation_chain": TEST_IMPERSONATION_CHAIN,
         "end_time": 100,
         "metadata": (),
     }


### PR DESCRIPTION
Google operators ignore authentication parameters `impersonation_chain` which supports connecting with google cloud API without any authentication key by using impersonation chain authentication. These parameters are supported by their sync version operators, So now made a fix to the async Operators to support `impersonation_chain` and `delegate_to` other type authentication params.



Closes: #651 