### PR TITLE
Remove unused files from integration tests image

### DIFF
--- a/.circleci/integration-tests/script.sh
+++ b/.circleci/integration-tests/script.sh
@@ -71,8 +71,6 @@ mkdir "${SCRIPT_PATH}"/astronomer-providers
 cp -r "${PROJECT_PATH}"/astronomer "${SCRIPT_PATH}"/astronomer-providers
 cp -r  "${PROJECT_PATH}"/pyproject.toml "${SCRIPT_PATH}"/astronomer-providers
 cp -r  "${PROJECT_PATH}"/setup.cfg "${SCRIPT_PATH}"/astronomer-providers
-touch packages.txt
-touch requirements.txt
 
 # Copy examples
 for dag in $(find "${PROVIDER_PATH}" -type f -name 'example_*'); do cp "${dag}" "${SCRIPT_PATH}"; done;


### PR DESCRIPTION
since now we are building the integration test image  from `quay.io/astronomer/astro-runtime:6.0.2-base` instead of `quay.io/astronomer/astro-runtime:6.0.2` so  `packages.txt` and `requirements.txt` no longer require