### PR TITLE
POC Big Query polling ping-pong

### DIFF
--- a/astronomer/providers/google/cloud/triggers/bigquery.py
+++ b/astronomer/providers/google/cloud/triggers/bigquery.py
@@ -137,63 +137,21 @@ class BigQueryLegacyTrigger(BaseTrigger):
         return BigQueryHookAsync(gcp_conn_id=self.conn_id)
 
 
-class BigQueryCheckTrigger(BigQueryLegacyTrigger):
+class BigQueryCheckTrigger(BigQueryTrigger):
     """BigQueryCheckTrigger run on the trigger worker"""
 
-    def serialize(self) -> Tuple[str, Dict[str, Any]]:
-        """Serializes BigQueryCheckTrigger arguments and classpath."""
-        return (
-            "astronomer.providers.google.cloud.triggers.bigquery.BigQueryCheckTrigger",
-            {
-                "conn_id": self.conn_id,
-                "job_id": self.job_id,
-                "dataset_id": self.dataset_id,
-                "project_id": self.project_id,
-                "table_id": self.table_id,
-                "poll_interval": self.poll_interval,
-            },
-        )
-
-    async def run(self) -> AsyncIterator["TriggerEvent"]:  # type: ignore[override]
-        """Gets current job execution status and yields a TriggerEvent"""
-        hook = self._get_async_hook()
-        while True:
-            try:
-                # Poll for job execution status
-                response_from_hook = await hook.get_job_status(job_id=self.job_id, project_id=self.project_id)
-                if response_from_hook == "success":
-                    query_results = await hook.get_job_output(job_id=self.job_id, project_id=self.project_id)
-
-                    records = hook.get_records(query_results)
-
-                    # If empty list, then no records are available
-                    if not records:
-                        yield TriggerEvent(
-                            {
-                                "status": "success",
-                                "records": None,
-                            }
-                        )
-                    else:
-                        # Extract only first record from the query results
-                        first_record = records.pop(0)
-                        yield TriggerEvent(
-                            {
-                                "status": "success",
-                                "records": first_record,
-                            }
-                        )
-                    return
-
-                elif response_from_hook == "pending":
-                    self.log.info("Query is still running...")
-                    self.log.info("Sleeping for %s seconds.", self.poll_interval)
-                    await asyncio.sleep(self.poll_interval)
-                else:
-                    yield TriggerEvent({"status": "error", "message": response_from_hook})
-            except Exception as e:
-                self.log.exception("Exception occurred while checking for query completion")
-                yield TriggerEvent({"status": "error", "message": str(e)})
+    async def poll_process(self) -> Tuple[Optional[str], Dict[str, Any]]:
+        """Poll the Big Query job."""
+        response, payload = await super().poll_process()
+        if response == "success":
+            hook = self._get_async_hook()
+            query_results = await hook.get_job_output(job_id=self.job_id, project_id=self.project_id)
+            records = hook.get_records(query_results)
+            if records:  # Extract only first record from the query results
+                payload["records"] = records[0]
+            else:  # If empty list, then no records are available
+                payload["records"] = None
+        return response, payload
 
 
 class BigQueryGetDataTrigger(BigQueryLegacyTrigger):

--- a/tests/google/cloud/operators/test_bigquery.py
+++ b/tests/google/cloud/operators/test_bigquery.py
@@ -20,8 +20,8 @@ from astronomer.providers.google.cloud.operators.bigquery import (
 from astronomer.providers.google.cloud.triggers.bigquery import (
     BigQueryCheckTrigger,
     BigQueryGetDataTrigger,
-    BigQueryInsertJobTrigger,
     BigQueryIntervalCheckTrigger,
+    BigQueryTrigger,
     BigQueryValueCheckTrigger,
 )
 
@@ -69,9 +69,7 @@ def test_bigquery_insert_job_operator_async(mock_hook):
     with pytest.raises(TaskDeferred) as exc:
         op.execute(create_context(op))
 
-    assert isinstance(
-        exc.value.trigger, BigQueryInsertJobTrigger
-    ), "Trigger is not a BigQueryInsertJobTrigger"
+    assert isinstance(exc.value.trigger, BigQueryTrigger), "Trigger is not a BigQueryTrigger"
 
 
 def test_bigquery_insert_job_operator_execute_failure(context):

--- a/tests/google/cloud/operators/test_bigquery.py
+++ b/tests/google/cloud/operators/test_bigquery.py
@@ -18,7 +18,6 @@ from astronomer.providers.google.cloud.operators.bigquery import (
     BigQueryValueCheckOperatorAsync,
 )
 from astronomer.providers.google.cloud.triggers.bigquery import (
-    BigQueryCheckTrigger,
     BigQueryGetDataTrigger,
     BigQueryIntervalCheckTrigger,
     BigQueryTrigger,
@@ -282,7 +281,7 @@ def test_execute_force_rerun(mock_hook):
 @mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
 def test_bigquery_check_operator_async(mock_hook):
     """
-    Asserts that a task is deferred and a BigQueryCheckTrigger will be fired
+    Asserts that a task is deferred and a BigQueryGetDataTrigger will be fired
     when the BigQueryCheckOperatorAsync is executed.
     """
     job_id = "123456"
@@ -300,7 +299,7 @@ def test_bigquery_check_operator_async(mock_hook):
     with pytest.raises(TaskDeferred) as exc:
         op.execute(create_context(op))
 
-    assert isinstance(exc.value.trigger, BigQueryCheckTrigger), "Trigger is not a BigQueryCheckTrigger"
+    assert isinstance(exc.value.trigger, BigQueryGetDataTrigger), "Trigger is not a BigQueryGetDataTrigger"
 
 
 def test_bigquery_check_operator_execute_failure(context):
@@ -345,7 +344,7 @@ def test_bigquery_check_op_end_ping_pong_with_non_boolean_records():
     expected_exception_msg = f"Test failed.\nQuery:\n{test_sql}\nResults:\n{[20, False]!s}"
 
     with pytest.raises(AirflowException) as exc:
-        operator.end_ping_pong({"status": "success", "records": [20, False]})
+        operator.end_ping_pong({"status": "success", "records": [[20, False]]})
 
     assert str(exc.value) == expected_exception_msg
 
@@ -360,7 +359,7 @@ def test_bigquery_check_operator_end_ping_pong():
     )
 
     with mock.patch.object(operator.log, "info") as mock_log_info:
-        operator.end_ping_pong({"status": "success", "records": [20]})
+        operator.end_ping_pong({"status": "success", "records": [[20]]})
     mock_log_info.assert_called_with("Success.")
 
 

--- a/tests/google/cloud/operators/test_bigquery.py
+++ b/tests/google/cloud/operators/test_bigquery.py
@@ -311,50 +311,56 @@ def test_bigquery_check_operator_execute_failure(context):
     )
 
     with pytest.raises(AirflowException):
-        operator.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
+        operator.execution_progress(
+            context=None, event={"status": "error", "message": "test failure message"}
+        )
 
 
-def test_bigquery_check_op_execute_complete_with_no_records():
+def test_bigquery_check_op_end_ping_pong_with_no_records():
     """Asserts that exception is raised with correct expected exception message"""
 
     operator = BigQueryCheckOperatorAsync(
-        task_id="bq_check_operator_execute_complete", sql="SELECT * FROM any", location=TEST_DATASET_LOCATION
+        task_id="bq_check_operator_end_ping_pong",
+        sql="SELECT * FROM any",
+        location=TEST_DATASET_LOCATION,
     )
 
     with pytest.raises(AirflowException) as exc:
-        operator.execute_complete(context=None, event={"status": "success", "records": None})
+        operator.end_ping_pong({"status": "success", "records": None})
 
     expected_exception_msg = "The query returned None"
 
     assert str(exc.value) == expected_exception_msg
 
 
-def test_bigquery_check_op_execute_complete_with_non_boolean_records():
+def test_bigquery_check_op_end_ping_pong_with_non_boolean_records():
     """Executing a sql which returns a non-boolean value should raise exception"""
 
     test_sql = "SELECT * FROM any"
 
     operator = BigQueryCheckOperatorAsync(
-        task_id="bq_check_operator_execute_complete", sql=test_sql, location=TEST_DATASET_LOCATION
+        task_id="bq_check_operator_end_ping_pong", sql=test_sql, location=TEST_DATASET_LOCATION
     )
 
     expected_exception_msg = f"Test failed.\nQuery:\n{test_sql}\nResults:\n{[20, False]!s}"
 
     with pytest.raises(AirflowException) as exc:
-        operator.execute_complete(context=None, event={"status": "success", "records": [20, False]})
+        operator.end_ping_pong({"status": "success", "records": [20, False]})
 
     assert str(exc.value) == expected_exception_msg
 
 
-def test_bigquery_check_operator_execute_complete():
+def test_bigquery_check_operator_end_ping_pong():
     """Asserts that logging occurs as expected"""
 
     operator = BigQueryCheckOperatorAsync(
-        task_id="bq_check_operator_execute_complete", sql="SELECT * FROM any", location=TEST_DATASET_LOCATION
+        task_id="bq_check_operator_end_ping_pong",
+        sql="SELECT * FROM any",
+        location=TEST_DATASET_LOCATION,
     )
 
     with mock.patch.object(operator.log, "info") as mock_log_info:
-        operator.execute_complete(context=None, event={"status": "success", "records": [20]})
+        operator.end_ping_pong({"status": "success", "records": [20]})
     mock_log_info.assert_called_with("Success.")
 
 

--- a/tests/google/cloud/triggers/test_bigquery.py
+++ b/tests/google/cloud/triggers/test_bigquery.py
@@ -12,9 +12,9 @@ from yarl import URL
 from astronomer.providers.google.cloud.hooks.bigquery import BigQueryTableHookAsync
 from astronomer.providers.google.cloud.triggers.bigquery import (
     BigQueryGetDataTrigger,
+    BigQueryInsertJobTrigger,
     BigQueryIntervalCheckTrigger,
     BigQueryTableExistenceTrigger,
-    BigQueryTrigger,
     BigQueryValueCheckTrigger,
 )
 
@@ -40,14 +40,83 @@ TEST_IGNORE_ZERO = True
 TEST_GCP_CONN_ID = "TEST_GCP_CONN_ID"
 TEST_HOOK_PARAMS = {}
 
-BIG_QUERY_TRIGGER_LOGGER = "astronomer.providers.google.cloud.triggers.bigquery.BigQueryTrigger"
+INSERT_JOB_PARAM = pytest.param(
+    BigQueryInsertJobTrigger(
+        conn_id=TEST_CONN_ID,
+        job_id=TEST_JOB_ID,
+        project_id=TEST_GCP_PROJECT_ID,
+        dataset_id=TEST_DATASET_ID,
+        table_id=TEST_TABLE_ID,
+        poll_interval=0.0,
+    ),
+    "astronomer.providers.google.cloud.triggers.bigquery.BigQueryInsertJobTrigger",
+    id="BigQueryInsertJobTrigger",
+)
+GET_DATA_PARAM = pytest.param(
+    BigQueryGetDataTrigger(
+        conn_id=TEST_CONN_ID,
+        job_id=TEST_JOB_ID,
+        project_id=TEST_GCP_PROJECT_ID,
+        dataset_id=TEST_DATASET_ID,
+        table_id=TEST_TABLE_ID,
+        poll_interval=0.0,
+    ),
+    "astronomer.providers.google.cloud.triggers.bigquery.BigQueryGetDataTrigger",
+    id="BigQueryGetDataTrigger",
+)
+INTERVAL_CHECK_PARAM = pytest.param(
+    BigQueryIntervalCheckTrigger(
+        conn_id=TEST_CONN_ID,
+        first_job_id=TEST_FIRST_JOB_ID,
+        second_job_id=TEST_SECOND_JOB_ID,
+        project_id=TEST_GCP_PROJECT_ID,
+        table=TEST_TABLE_ID,
+        metrics_thresholds=TEST_METRIC_THRESHOLDS,
+        date_filter_column=TEST_DATE_FILTER_COLUMN,
+        days_back=TEST_DAYS_BACK,
+        ratio_formula=TEST_RATIO_FORMULA,
+        ignore_zero=TEST_IGNORE_ZERO,
+        dataset_id=TEST_DATASET_ID,
+        table_id=TEST_TABLE_ID,
+        poll_interval=0.0,
+    ),
+    "astronomer.providers.google.cloud.triggers.bigquery.BigQueryIntervalCheckTrigger",
+    id="BigQueryIntervalCheckTrigger",
+)
+VALUE_CHECK_PARAM = pytest.param(
+    BigQueryValueCheckTrigger(
+        conn_id=TEST_CONN_ID,
+        job_id=TEST_JOB_ID,
+        project_id=TEST_GCP_PROJECT_ID,
+        dataset_id=TEST_DATASET_ID,
+        table_id=TEST_TABLE_ID,
+        sql=TEST_SQL_QUERY,
+        pass_value=TEST_PASS_VALUE,
+        tolerance=TEST_TOLERANCE,
+        poll_interval=0.0,
+    ),
+    "astronomer.providers.google.cloud.triggers.bigquery.BigQueryValueCheckTrigger",
+    id="BigQueryValueCheckTrigger",
+)
+TABLE_EXISTENCE_PARAM = pytest.param(
+    BigQueryTableExistenceTrigger(
+        conn_id=TEST_GCP_CONN_ID,
+        project_id=TEST_DATASET_ID,
+        dataset_id=TEST_GCP_PROJECT_ID,
+        table_id=TEST_TABLE_ID,
+        hook_params=TEST_HOOK_PARAMS,
+        poll_interval=0.0,
+    ),
+    "astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger",
+    id="BigQueryTableExistenceTrigger",
+)
 
 
 @pytest.mark.parametrize(
     "trigger, classpath, kwargs",
     [
         pytest.param(
-            BigQueryTrigger(
+            BigQueryInsertJobTrigger(
                 conn_id=TEST_CONN_ID,
                 job_id=TEST_JOB_ID,
                 project_id=TEST_GCP_PROJECT_ID,
@@ -55,7 +124,7 @@ BIG_QUERY_TRIGGER_LOGGER = "astronomer.providers.google.cloud.triggers.bigquery.
                 table_id=TEST_TABLE_ID,
                 poll_interval=POLLING_PERIOD_SECONDS,
             ),
-            "astronomer.providers.google.cloud.triggers.bigquery.BigQueryTrigger",
+            "astronomer.providers.google.cloud.triggers.bigquery.BigQueryInsertJobTrigger",
             {
                 "conn_id": TEST_CONN_ID,
                 "job_id": TEST_JOB_ID,
@@ -64,7 +133,7 @@ BIG_QUERY_TRIGGER_LOGGER = "astronomer.providers.google.cloud.triggers.bigquery.
                 "table_id": TEST_TABLE_ID,
                 "poll_interval": POLLING_PERIOD_SECONDS,
             },
-            id="BigQueryTrigger",
+            id="BigQueryInsertJobTrigger",
         ),
         pytest.param(
             BigQueryGetDataTrigger(
@@ -86,6 +155,84 @@ BIG_QUERY_TRIGGER_LOGGER = "astronomer.providers.google.cloud.triggers.bigquery.
             },
             id="BigQueryGetDataTrigger",
         ),
+        pytest.param(
+            BigQueryIntervalCheckTrigger(
+                conn_id=TEST_CONN_ID,
+                first_job_id=TEST_FIRST_JOB_ID,
+                second_job_id=TEST_SECOND_JOB_ID,
+                project_id=TEST_GCP_PROJECT_ID,
+                table=TEST_TABLE_ID,
+                metrics_thresholds=TEST_METRIC_THRESHOLDS,
+                date_filter_column=TEST_DATE_FILTER_COLUMN,
+                days_back=TEST_DAYS_BACK,
+                ratio_formula=TEST_RATIO_FORMULA,
+                ignore_zero=TEST_IGNORE_ZERO,
+                dataset_id=TEST_DATASET_ID,
+                table_id=TEST_TABLE_ID,
+                poll_interval=POLLING_PERIOD_SECONDS,
+            ),
+            "astronomer.providers.google.cloud.triggers.bigquery.BigQueryIntervalCheckTrigger",
+            {
+                "conn_id": TEST_CONN_ID,
+                "first_job_id": TEST_FIRST_JOB_ID,
+                "second_job_id": TEST_SECOND_JOB_ID,
+                "project_id": TEST_GCP_PROJECT_ID,
+                "table": TEST_TABLE_ID,
+                "metrics_thresholds": TEST_METRIC_THRESHOLDS,
+                "date_filter_column": TEST_DATE_FILTER_COLUMN,
+                "days_back": TEST_DAYS_BACK,
+                "ratio_formula": TEST_RATIO_FORMULA,
+                "ignore_zero": TEST_IGNORE_ZERO,
+                "poll_interval": POLLING_PERIOD_SECONDS,
+            },
+            id="BigQueryIntervalCheckTrigger",
+        ),
+        pytest.param(
+            BigQueryValueCheckTrigger(
+                conn_id=TEST_CONN_ID,
+                pass_value=TEST_PASS_VALUE,
+                job_id=TEST_JOB_ID,
+                dataset_id=TEST_DATASET_ID,
+                project_id=TEST_GCP_PROJECT_ID,
+                sql=TEST_SQL_QUERY,
+                table_id=TEST_TABLE_ID,
+                tolerance=TEST_TOLERANCE,
+                poll_interval=POLLING_PERIOD_SECONDS,
+            ),
+            "astronomer.providers.google.cloud.triggers.bigquery.BigQueryValueCheckTrigger",
+            {
+                "conn_id": TEST_CONN_ID,
+                "pass_value": TEST_PASS_VALUE,
+                "job_id": TEST_JOB_ID,
+                "dataset_id": TEST_DATASET_ID,
+                "project_id": TEST_GCP_PROJECT_ID,
+                "sql": TEST_SQL_QUERY,
+                "table_id": TEST_TABLE_ID,
+                "tolerance": TEST_TOLERANCE,
+                "poll_interval": POLLING_PERIOD_SECONDS,
+            },
+            id="BigQueryValueCheckTrigger",
+        ),
+        pytest.param(
+            BigQueryTableExistenceTrigger(
+                conn_id=TEST_GCP_CONN_ID,
+                project_id=TEST_GCP_PROJECT_ID,
+                dataset_id=TEST_DATASET_ID,
+                table_id=TEST_TABLE_ID,
+                hook_params=TEST_HOOK_PARAMS,
+                poll_interval=POLLING_PERIOD_SECONDS,
+            ),
+            "astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger",
+            {
+                "conn_id": TEST_GCP_CONN_ID,
+                "project_id": TEST_GCP_PROJECT_ID,
+                "dataset_id": TEST_DATASET_ID,
+                "table_id": TEST_TABLE_ID,
+                "hook_params": TEST_HOOK_PARAMS,
+                "poll_interval": POLLING_PERIOD_SECONDS,
+            },
+            id="BigQueryTableExistenceTrigger",
+        ),
     ],
 )
 def test_serialization(trigger, classpath, kwargs):
@@ -98,95 +245,118 @@ def test_serialization(trigger, classpath, kwargs):
 
 
 @pytest.mark.parametrize(
-    "status, event_data, log_record",
-    [
-        pytest.param(
-            "pending",
-            {
-                "status": "pending",
-                "job_id": TEST_JOB_ID,
-                "project_id": TEST_GCP_PROJECT_ID,
-                "poll_interval": 0.0,
-            },
-            (BIG_QUERY_TRIGGER_LOGGER, logging.DEBUG, "Query is still running... sleeping for 0.0 seconds."),
-            id="pending",
-        ),
-        pytest.param(
-            "success",
-            {
-                "status": "success",
-                "job_id": TEST_JOB_ID,
-                "project_id": TEST_GCP_PROJECT_ID,
-                "poll_interval": 0.0,
-            },
-            (BIG_QUERY_TRIGGER_LOGGER, logging.DEBUG, "Response from hook: success"),
-            id="success",
-        ),
-        pytest.param(
-            "???",
-            {
-                "status": "error",
-                "message": "Unknown response: '???'",
-                "job_id": TEST_JOB_ID,
-                "project_id": TEST_GCP_PROJECT_ID,
-                "poll_interval": 0.0,
-            },
-            (BIG_QUERY_TRIGGER_LOGGER, logging.ERROR, "Unknown response from hook: ???"),
-            id="error-unknown",
-        ),
-    ],
-    ids=["pending", "success", "error"],
+    "trigger, logger",
+    [INSERT_JOB_PARAM, GET_DATA_PARAM, INTERVAL_CHECK_PARAM, VALUE_CHECK_PARAM],
 )
 @pytest.mark.asyncio
 @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_trigger_lifetime(mock_job_status, caplog, status, event_data, log_record):
+async def test_trigger_exception(mock_job_status, caplog, trigger, logger):
     """
-    Tests BigQueryTrigger fires during a BigQuery process's lifetime.
+    Tests BigQueryTrigger fires if the hook raises an exception.
     """
-    caplog.set_level(logging.DEBUG, logger=BIG_QUERY_TRIGGER_LOGGER)
-    mock_job_status.return_value = status
-
-    trigger = BigQueryTrigger(
-        conn_id=TEST_CONN_ID,
-        job_id=TEST_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-        dataset_id=TEST_DATASET_ID,
-        table_id=TEST_TABLE_ID,
-        poll_interval=0.0,
-    )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent(event_data) == actual
-    assert log_record in caplog.record_tuples
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_op_trigger_error(mock_job_status, caplog):
-    """
-    Tests BigQueryTrigger fires if the BigQuery process errors.
-    """
-    caplog.set_level(logging.DEBUG, logger=BIG_QUERY_TRIGGER_LOGGER)
+    caplog.set_level(logging.DEBUG, logger=logger)
     mock_job_status.side_effect = Exception("I failed!")
 
-    trigger = BigQueryTrigger(
-        conn_id=TEST_CONN_ID,
-        job_id=TEST_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-        dataset_id=TEST_DATASET_ID,
-        table_id=TEST_TABLE_ID,
-        poll_interval=0.0,
-    )
-
     generator = trigger.run()
     actual = await generator.asend(None)
-    assert TriggerEvent({"status": "error", "message": "I failed!"}) == actual
+    expected = {
+        "status": "error",
+        "trigger": trigger.serialize()[1],
+        "message": "I failed!",
+    }
+    assert TriggerEvent(expected) == actual
     assert (
-        BIG_QUERY_TRIGGER_LOGGER,
+        logger,
         logging.ERROR,
         "Exception occurred while checking for query completion",
     ) in caplog.record_tuples
+
+
+@pytest.mark.parametrize(
+    "trigger, logger",
+    [INSERT_JOB_PARAM, GET_DATA_PARAM, INTERVAL_CHECK_PARAM, VALUE_CHECK_PARAM],
+)
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+async def test_trigger_pending(mock_job_status, caplog, trigger, logger):
+    """
+    Tests BigQueryTrigger fires when the hook result is still pending.
+    """
+    caplog.set_level(logging.DEBUG, logger=logger)
+    mock_job_status.return_value = "pending"
+
+    generator = trigger.run()
+    actual = await generator.asend(None)
+    expected = {"status": "pending", "trigger": trigger.serialize()[1], "result": None}
+    assert TriggerEvent(expected) == actual
+    log_message = "Still pending... sleeping for 0.0 seconds."
+    assert (logger, logging.DEBUG, log_message) in caplog.record_tuples
+
+
+@pytest.mark.parametrize("trigger, logger", [INSERT_JOB_PARAM, GET_DATA_PARAM, VALUE_CHECK_PARAM])
+@pytest.mark.parametrize(
+    "job_status, log_message, message",
+    [
+        ("error", "Poll response: error", "Error response from hook"),
+        ("???", "Unknown poll response: ???", "Unknown response from hook: ???"),
+    ],
+    ids=["error", "???"],
+)
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+async def test_job_trigger_error(
+    mock_job_status,
+    caplog,
+    trigger,
+    logger,
+    job_status,
+    log_message,
+    message,
+):
+    """
+    Tests BigQueryTrigger fires if the hook returns an error or unknown status.
+    """
+    caplog.set_level(logging.ERROR, logger=logger)
+    mock_job_status.return_value = job_status
+
+    generator = trigger.run()
+    actual = await generator.asend(None)
+    expected = {"status": "error", "trigger": trigger.serialize()[1], "result": None, "message": message}
+    assert TriggerEvent(expected) == actual
+    assert (logger, logging.ERROR, log_message) in caplog.record_tuples
+
+
+@pytest.mark.parametrize("trigger, logger", [INTERVAL_CHECK_PARAM])
+@pytest.mark.parametrize(
+    "first_job_status, second_job_status",
+    [("error", "???"), ("???", "error"), ("???", "???")],
+)
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+async def test_interval_check_trigger_error(
+    mock_job_status,
+    caplog,
+    trigger,
+    logger,
+    first_job_status,
+    second_job_status,
+):
+    """
+    Tests BigQueryIntervalCheckTrigger fires if the hook returns an error or unknown status.
+    """
+    caplog.set_level(logging.ERROR, logger=logger)
+    mock_job_status.side_effect = [first_job_status, second_job_status]
+
+    generator = trigger.run()
+    actual = await generator.asend(None)
+    expected = {
+        "status": "error",
+        "message": "Error response from hook",
+        "trigger": trigger.serialize()[1],
+        "result": [first_job_status, second_job_status],
+    }
+    assert TriggerEvent(expected) == actual
+    assert (logger, logging.ERROR, "Poll response: error") in caplog.record_tuples
 
 
 @pytest.mark.parametrize(
@@ -247,50 +417,8 @@ async def test_bigquery_get_data_trigger_success(mock_job_output, mock_job_statu
     generator = trigger.run()
     actual = await generator.asend(None)
 
-    expected = {
-        "status": "success",
-        "records": records,
-        "job_id": TEST_JOB_ID,
-        "project_id": TEST_GCP_PROJECT_ID,
-        "poll_interval": 0.0,
-    }
+    expected = {"status": "success", "trigger": trigger.serialize()[1], "result": records}
     assert TriggerEvent(expected) == actual
-
-
-def test_bigquery_interval_check_trigger_serialization():
-    """
-    Asserts that the BigQueryIntervalCheckTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = BigQueryIntervalCheckTrigger(
-        TEST_CONN_ID,
-        TEST_FIRST_JOB_ID,
-        TEST_SECOND_JOB_ID,
-        TEST_GCP_PROJECT_ID,
-        TEST_TABLE_ID,
-        TEST_METRIC_THRESHOLDS,
-        TEST_DATE_FILTER_COLUMN,
-        TEST_DAYS_BACK,
-        TEST_RATIO_FORMULA,
-        TEST_IGNORE_ZERO,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        POLLING_PERIOD_SECONDS,
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryIntervalCheckTrigger"
-    assert kwargs == {
-        "conn_id": TEST_CONN_ID,
-        "first_job_id": TEST_FIRST_JOB_ID,
-        "second_job_id": TEST_SECOND_JOB_ID,
-        "project_id": TEST_GCP_PROJECT_ID,
-        "table": TEST_TABLE_ID,
-        "metrics_thresholds": TEST_METRIC_THRESHOLDS,
-        "date_filter_column": TEST_DATE_FILTER_COLUMN,
-        "days_back": TEST_DAYS_BACK,
-        "ratio_formula": TEST_RATIO_FORMULA,
-        "ignore_zero": TEST_IGNORE_ZERO,
-    }
 
 
 @pytest.mark.parametrize(
@@ -327,157 +455,12 @@ async def test_bigquery_interval_check_trigger_success(
 
     generator = trigger.run()
     actual = await generator.asend(None)
-    assert actual == TriggerEvent({"status": "error", "message": "The second SQL query returned None"})
-
-
-@pytest.mark.parametrize(
-    "trigger_class",
-    [BigQueryIntervalCheckTrigger],
-)
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_interval_check_trigger_pending(mock_job_status, caplog, trigger_class):
-    """
-    Tests that the BigQueryIntervalCheckTrigger do not fire while a query is still running.
-    """
-    mock_job_status.return_value = "pending"
-    caplog.set_level(logging.INFO)
-
-    trigger = trigger_class(
-        conn_id=TEST_CONN_ID,
-        first_job_id=TEST_FIRST_JOB_ID,
-        second_job_id=TEST_SECOND_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-        table=TEST_TABLE_ID,
-        metrics_thresholds=TEST_METRIC_THRESHOLDS,
-        date_filter_column=TEST_DATE_FILTER_COLUMN,
-        days_back=TEST_DAYS_BACK,
-        ratio_formula=TEST_RATIO_FORMULA,
-        ignore_zero=TEST_IGNORE_ZERO,
-        dataset_id=TEST_DATASET_ID,
-        table_id=TEST_TABLE_ID,
-        poll_interval=POLLING_PERIOD_SECONDS,
-    )
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-
-    assert f"Using the connection  {TEST_CONN_ID} ." in caplog.text
-
-    assert "Query is still running..." in caplog.text
-    assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
-
-    # Prevents error when task is destroyed while in "pending" state
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.parametrize(
-    "trigger_class",
-    [BigQueryIntervalCheckTrigger],
-)
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_interval_check_trigger_terminated(mock_job_status, trigger_class):
-    """
-    Tests the BigQueryIntervalCheckTrigger fires the correct event in case of an error.
-    """
-    # Set the status to a value other than success or pending
-    mock_job_status.return_value = "error"
-    trigger = trigger_class(
-        conn_id=TEST_CONN_ID,
-        first_job_id=TEST_FIRST_JOB_ID,
-        second_job_id=TEST_SECOND_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-        table=TEST_TABLE_ID,
-        metrics_thresholds=TEST_METRIC_THRESHOLDS,
-        date_filter_column=TEST_DATE_FILTER_COLUMN,
-        days_back=TEST_DAYS_BACK,
-        ratio_formula=TEST_RATIO_FORMULA,
-        ignore_zero=TEST_IGNORE_ZERO,
-        dataset_id=TEST_DATASET_ID,
-        table_id=TEST_TABLE_ID,
-        poll_interval=POLLING_PERIOD_SECONDS,
-    )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-
-    assert TriggerEvent({"status": "error", "message": "error", "data": None}) == actual
-
-
-@pytest.mark.parametrize(
-    "trigger_class",
-    [BigQueryIntervalCheckTrigger],
-)
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_interval_check_trigger_exception(mock_job_status, caplog, trigger_class):
-    """
-    Tests that the BigQueryIntervalCheckTrigger fires the correct event in case of an error.
-    """
-    mock_job_status.side_effect = Exception("Test exception")
-    caplog.set_level(logging.DEBUG)
-
-    trigger = trigger_class(
-        conn_id=TEST_CONN_ID,
-        first_job_id=TEST_FIRST_JOB_ID,
-        second_job_id=TEST_SECOND_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-        table=TEST_TABLE_ID,
-        metrics_thresholds=TEST_METRIC_THRESHOLDS,
-        date_filter_column=TEST_DATE_FILTER_COLUMN,
-        days_back=TEST_DAYS_BACK,
-        ratio_formula=TEST_RATIO_FORMULA,
-        ignore_zero=TEST_IGNORE_ZERO,
-        dataset_id=TEST_DATASET_ID,
-        table_id=TEST_TABLE_ID,
-        poll_interval=POLLING_PERIOD_SECONDS,
-    )
-
-    # trigger event is yielded so it creates a generator object
-    # so i have used async for to get all the values and added it to task
-    task = [i async for i in trigger.run()]
-    # since we use return as soon as we yield the trigger event
-    # at any given point there should be one trigger event returned to the task
-    # so we validate for length of task to be 1
-
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
-
-
-def test_bigquery_value_check_op_trigger_serialization():
-    """
-    Asserts that the BigQueryValueCheckTrigger correctly serializes its arguments
-    and classpath.
-    """
-
-    trigger = BigQueryValueCheckTrigger(
-        conn_id=TEST_CONN_ID,
-        pass_value=TEST_PASS_VALUE,
-        job_id=TEST_JOB_ID,
-        dataset_id=TEST_DATASET_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-        sql=TEST_SQL_QUERY,
-        table_id=TEST_TABLE_ID,
-        tolerance=TEST_TOLERANCE,
-        poll_interval=POLLING_PERIOD_SECONDS,
-    )
-    classpath, kwargs = trigger.serialize()
-
-    assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryValueCheckTrigger"
-    assert kwargs == {
-        "conn_id": TEST_CONN_ID,
-        "pass_value": TEST_PASS_VALUE,
-        "job_id": TEST_JOB_ID,
-        "dataset_id": TEST_DATASET_ID,
-        "project_id": TEST_GCP_PROJECT_ID,
-        "sql": TEST_SQL_QUERY,
-        "table_id": TEST_TABLE_ID,
-        "tolerance": TEST_TOLERANCE,
-        "poll_interval": POLLING_PERIOD_SECONDS,
+    expected = {
+        "status": "error",
+        "message": "The second SQL query returned None",
+        "trigger": trigger.serialize()[1],
     }
+    assert actual == TriggerEvent(expected)
 
 
 @pytest.mark.asyncio
@@ -509,42 +492,7 @@ async def test_bigquery_value_check_op_trigger_success(mock_job_status, get_job_
 
     generator = trigger.run()
     actual = await generator.asend(None)
-    assert actual == TriggerEvent({"status": "success", "message": "Job completed", "records": [4]})
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_value_check_op_trigger_pending(mock_job_status, caplog):
-    """
-    Tests that the BigQueryValueCheckTrigger only fires once the query execution reaches a successful state.
-    """
-    mock_job_status.return_value = "pending"
-    caplog.set_level(logging.INFO)
-
-    trigger = BigQueryValueCheckTrigger(
-        TEST_CONN_ID,
-        TEST_PASS_VALUE,
-        TEST_JOB_ID,
-        TEST_DATASET_ID,
-        TEST_GCP_PROJECT_ID,
-        TEST_SQL_QUERY,
-        TEST_TABLE_ID,
-        TEST_TOLERANCE,
-        POLLING_PERIOD_SECONDS,
-    )
-
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was returned
-    assert task.done() is False
-
-    assert "Query is still running..." in caplog.text
-
-    assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
-
-    # Prevents error when task is destroyed while in "pending" state
-    asyncio.get_event_loop().stop()
+    assert actual == TriggerEvent({"status": "success", "trigger": trigger.serialize()[1], "result": [2]})
 
 
 @pytest.mark.asyncio
@@ -556,143 +504,87 @@ async def test_bigquery_value_check_op_trigger_fail(mock_job_status):
     mock_job_status.return_value = "dummy"
 
     trigger = BigQueryValueCheckTrigger(
-        TEST_CONN_ID,
-        TEST_PASS_VALUE,
-        TEST_JOB_ID,
-        TEST_DATASET_ID,
-        TEST_GCP_PROJECT_ID,
-        TEST_SQL_QUERY,
-        TEST_TABLE_ID,
-        TEST_TOLERANCE,
-        POLLING_PERIOD_SECONDS,
+        conn_id=TEST_CONN_ID,
+        pass_value=TEST_PASS_VALUE,
+        job_id=TEST_JOB_ID,
+        dataset_id=TEST_DATASET_ID,
+        project_id=TEST_GCP_PROJECT_ID,
+        sql=TEST_SQL_QUERY,
+        table_id=TEST_TABLE_ID,
+        tolerance=TEST_TOLERANCE,
+        poll_interval=POLLING_PERIOD_SECONDS,
     )
 
     generator = trigger.run()
     actual = await generator.asend(None)
-    assert TriggerEvent({"status": "error", "message": "dummy", "records": None}) == actual
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_value_check_trigger_exception(mock_job_status):
-    """
-    Tests the BigQueryValueCheckTrigger does not fire if there is an exception.
-    """
-    mock_job_status.side_effect = Exception("Test exception")
-
-    trigger = BigQueryValueCheckTrigger(
-        conn_id=TEST_CONN_ID,
-        sql=TEST_SQL_QUERY,
-        pass_value=TEST_PASS_VALUE,
-        tolerance=1,
-        job_id=TEST_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-    )
-
-    # trigger event is yielded so it creates a generator object
-    # so i have used async for to get all the values and added it to task
-    task = [i async for i in trigger.run()]
-    # since we use return as soon as we yield the trigger event
-    # at any given point there should be one trigger event returned to the task
-    # so we validate for length of task to be 1
-
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
-
-
-def test_big_query_table_existence_trigger_serialization():
-    """
-    Asserts that the BigQueryTableExistenceTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = BigQueryTableExistenceTrigger(
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        POLLING_PERIOD_SECONDS,
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger"
-    assert kwargs == {
-        "dataset_id": TEST_DATASET_ID,
-        "project_id": TEST_GCP_PROJECT_ID,
-        "table_id": TEST_TABLE_ID,
-        "gcp_conn_id": TEST_GCP_CONN_ID,
-        "poke_interval": POLLING_PERIOD_SECONDS,
-        "hook_params": TEST_HOOK_PARAMS,
+    expected = {
+        "status": "error",
+        "message": "Unknown response from hook: dummy",
+        "trigger": trigger.serialize()[1],
+        "result": None,
     }
+    assert TriggerEvent(expected) == actual
 
 
+@pytest.mark.parametrize("trigger, logger", [TABLE_EXISTENCE_PARAM])
 @pytest.mark.asyncio
 @mock.patch("astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists")
-async def test_big_query_table_existence_trigger_success(mock_table_exists):
+async def test_table_existence_trigger_exception(mock_table_exists, caplog, trigger, logger):
+    """
+    Tests BigQueryTableExistenceTrigger fires if the hook raises an exception.
+    """
+    caplog.set_level(logging.DEBUG, logger=logger)
+    mock_table_exists.side_effect = mock.AsyncMock(side_effect=Exception("I failed!"))
+
+    generator = trigger.run()
+    actual = await generator.asend(None)
+    expected = {
+        "status": "error",
+        "trigger": trigger.serialize()[1],
+        "message": "I failed!",
+    }
+    assert TriggerEvent(expected) == actual
+    assert (
+        logger,
+        logging.ERROR,
+        "Exception occurred while checking for query completion",
+    ) in caplog.record_tuples
+
+
+@pytest.mark.parametrize("trigger, logger", [TABLE_EXISTENCE_PARAM])
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists")
+async def test_table_existence_trigger_pending(mock_table_exists, caplog, trigger, logger):
+    """
+    Tests BigQueryTableExistenceTrigger fires when the hook result is still pending.
+    """
+    caplog.set_level(logging.DEBUG, logger=logger)
+    mock_table_exists.side_effect = mock.AsyncMock(return_value=False)
+
+    generator = trigger.run()
+    actual = await generator.asend(None)
+    expected = {"status": "pending", "trigger": trigger.serialize()[1], "result": None}
+    assert TriggerEvent(expected) == actual
+    log_message = "Still pending... sleeping for 0.0 seconds."
+    assert (logger, logging.DEBUG, log_message) in caplog.record_tuples
+
+
+@pytest.mark.parametrize("trigger, logger", [TABLE_EXISTENCE_PARAM])
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists")
+async def test_big_query_table_existence_trigger_success(mock_table_exists, trigger, logger):
     """
     Tests success case BigQueryTableExistenceTrigger
     """
     mock_table_exists.return_value = True
 
-    trigger = BigQueryTableExistenceTrigger(
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        POLLING_PERIOD_SECONDS,
-    )
-
     generator = trigger.run()
     actual = await generator.asend(None)
-    assert TriggerEvent({"status": "success", "message": "success"}) == actual
+    assert TriggerEvent({"status": "success", "trigger": trigger.serialize()[1], "result": None}) == actual
 
 
 @pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists")
-async def test_big_query_table_existence_trigger_pending(mock_table_exists):
-    """
-    Test that BigQueryTableExistenceTrigger is in loop till the table exist.
-    """
-    mock_table_exists.return_value = False
-
-    trigger = BigQueryTableExistenceTrigger(
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        POLLING_PERIOD_SECONDS,
-    )
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists")
-async def test_big_query_table_existence_trigger_exception(mock_table_exists):
-    """
-    Test BigQueryTableExistenceTrigger throws exception if any error.
-    """
-    mock_table_exists.side_effect = mock.AsyncMock(side_effect=Exception("Test exception"))
-
-    trigger = BigQueryTableExistenceTrigger(
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        POLLING_PERIOD_SECONDS,
-    )
-    task = [i async for i in trigger.run()]
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
-
-
-@pytest.mark.asyncio
+@pytest.mark.parametrize("trigger, logger", [TABLE_EXISTENCE_PARAM])
 @pytest.mark.parametrize(
     "mock_get_table_client_value, expected_value",
     [
@@ -703,28 +595,25 @@ async def test_big_query_table_existence_trigger_exception(mock_table_exists):
     ],
 )
 @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryTableHookAsync.get_table_client")
-async def test_table_exists(mock_get_table_client, mock_get_table_client_value, expected_value):
+async def test_table_exists(
+    mock_get_table_client,
+    mock_get_table_client_value,
+    trigger,
+    logger,
+    expected_value,
+):
     """Test BigQueryTableExistenceTrigger._table_exists async function with mocked value and mocked return value"""
-    hook = mock.AsyncMock(BigQueryTableHookAsync)
+    trigger._get_async_hook = lambda: mock.AsyncMock(BigQueryTableHookAsync)
     mock_get_table_client.return_value = mock_get_table_client_value
-    trigger = BigQueryTableExistenceTrigger(
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        POLLING_PERIOD_SECONDS,
-    )
-    res = await trigger._table_exists(hook, TEST_DATASET_ID, TEST_TABLE_ID, TEST_GCP_PROJECT_ID)
+    res = await trigger._table_exists()
     assert res == expected_value
 
 
 @pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryTableHookAsync.get_table_client")
-async def test_table_exists_exception(mock_get_table_client):
+@pytest.mark.parametrize("trigger, logger", [TABLE_EXISTENCE_PARAM])
+async def test_table_exists_404(monkeypatch, trigger, logger):
     """Test BigQueryTableExistenceTrigger._table_exists async function with exception and return False"""
-    hook = BigQueryTableHookAsync()
-    mock_get_table_client.side_effect = ClientResponseError(
+    client_response = ClientResponseError(
         history=(),
         request_info=RequestInfo(
             headers=CIMultiDict(),
@@ -735,25 +624,21 @@ async def test_table_exists_exception(mock_get_table_client):
         status=404,
         message="Not Found",
     )
-    trigger = BigQueryTableExistenceTrigger(
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        POLLING_PERIOD_SECONDS,
+    monkeypatch.setattr(
+        trigger,
+        "_get_async_hook",
+        lambda: mock.Mock(get_table_client=mock.AsyncMock(side_effect=client_response)),
     )
-    res = await trigger._table_exists(hook, TEST_DATASET_ID, TEST_TABLE_ID, TEST_GCP_PROJECT_ID)
+    res = await trigger._table_exists()
     expected_response = False
     assert res == expected_response
 
 
 @pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryTableHookAsync.get_table_client")
-async def test_table_exists_raise_exception(mock_get_table_client):
+@pytest.mark.parametrize("trigger, logger", [TABLE_EXISTENCE_PARAM])
+async def test_table_exists_raise_exception(monkeypatch, trigger, logger):
     """Test BigQueryTableExistenceTrigger._table_exists async function with raise exception"""
-    hook = BigQueryTableHookAsync()
-    mock_get_table_client.side_effect = ClientResponseError(
+    client_response = ClientResponseError(
         history=(),
         request_info=RequestInfo(
             headers=CIMultiDict(),
@@ -762,15 +647,12 @@ async def test_table_exists_raise_exception(mock_get_table_client):
             url=URL("https://example.com"),
         ),
         status=400,
-        message="Not Found",
+        message="Bad Request",
     )
-    trigger = BigQueryTableExistenceTrigger(
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        POLLING_PERIOD_SECONDS,
+    monkeypatch.setattr(
+        trigger,
+        "_get_async_hook",
+        lambda: mock.Mock(get_table_client=mock.AsyncMock(side_effect=client_response)),
     )
     with pytest.raises(ClientResponseError):
-        await trigger._table_exists(hook, TEST_DATASET_ID, TEST_TABLE_ID, TEST_GCP_PROJECT_ID)
+        await trigger._table_exists()

--- a/tests/google/cloud/triggers/test_bigquery.py
+++ b/tests/google/cloud/triggers/test_bigquery.py
@@ -103,13 +103,23 @@ def test_serialization(trigger, classpath, kwargs):
     [
         pytest.param(
             "pending",
-            {"status": "pending", "job_id": TEST_JOB_ID, "poll_interval": 0.0},
+            {
+                "status": "pending",
+                "job_id": TEST_JOB_ID,
+                "project_id": TEST_GCP_PROJECT_ID,
+                "poll_interval": 0.0,
+            },
             (BIG_QUERY_TRIGGER_LOGGER, logging.DEBUG, "Query is still running... sleeping for 0.0 seconds."),
             id="pending",
         ),
         pytest.param(
             "success",
-            {"status": "success", "job_id": TEST_JOB_ID, "poll_interval": 0.0},
+            {
+                "status": "success",
+                "job_id": TEST_JOB_ID,
+                "project_id": TEST_GCP_PROJECT_ID,
+                "poll_interval": 0.0,
+            },
             (BIG_QUERY_TRIGGER_LOGGER, logging.DEBUG, "Response from hook: success"),
             id="success",
         ),
@@ -119,6 +129,7 @@ def test_serialization(trigger, classpath, kwargs):
                 "status": "error",
                 "message": "Unknown response: '???'",
                 "job_id": TEST_JOB_ID,
+                "project_id": TEST_GCP_PROJECT_ID,
                 "poll_interval": 0.0,
             },
             (BIG_QUERY_TRIGGER_LOGGER, logging.ERROR, "Unknown response from hook: ???"),
@@ -327,7 +338,13 @@ async def test_bigquery_check_op_trigger_success(mock_job_output, mock_job_statu
     generator = trigger.run()
     actual = await generator.asend(None)
 
-    expected = {"status": "success", "records": records, "job_id": TEST_JOB_ID, "poll_interval": 0.0}
+    expected = {
+        "status": "success",
+        "records": records,
+        "job_id": TEST_JOB_ID,
+        "project_id": TEST_GCP_PROJECT_ID,
+        "poll_interval": 0.0,
+    }
     assert TriggerEvent(expected) == actual
 
 


### PR DESCRIPTION
Instead of running a loop in the trigger, this essentially "uses" the triggerer process as the loop. The idea is:

1. The operator gets deferred after submitting the query.
2. The trigger waits and checks the result *once* and reports via an event
3. The operator is resumed by the event to check the status
    3a. If the job is reported as still running, defer to run the trigger *again*. Go back to 2.
    3b. If the job is done (success or error), return or raise.

This kind of achieves the ping-pong effect and emit the relevant logs in the operator's worker process, instead of in the triggerer process. The repeated triggering would probably have some overhead, but should be OK since everything is async.