### PR TITLE
Enable `GKEStartPodOperatorAsync` in integration tests

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -132,9 +132,7 @@ with DAG(
         {"gcs_sensor_dag": "example_async_gcs_sensors"},
         {"big_query_sensor_dag": "example_bigquery_sensors"},
         {"dataproc_dag": "example_gcp_dataproc"},
-        # GkeStartPod operator do not work on astro-cloud
-        # https://github.com/astronomer/astronomer-providers/issues/443
-        # {"kubernetes_engine_dag": "example_google_kubernetes_engine"},
+        {"kubernetes_engine_dag": "example_google_kubernetes_engine"},
     ]
     google_trigger_tasks, ids = prepare_dag_dependency(google_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)


### PR DESCRIPTION
closes : #443 