### PR TITLE
Fix session token from extra config

### DIFF
--- a/astronomer/providers/amazon/aws/hooks/base_aws.py
+++ b/astronomer/providers/amazon/aws/hooks/base_aws.py
@@ -65,6 +65,12 @@ class AwsBaseHookAsync(AwsBaseHook):
             self.log.info("Retrieving region_name from Connection.extra_config['region_name']")
             region_name = extra_config["region_name"]  # pragma: no cover
 
+        if "aws_session_token" in extra_config:
+            self.log.info(
+                "session token retrieved from extra, please note you are responsible for renewing these.",
+            )  # pragma: no cover
+            aws_session_token = extra_config.get("aws_session_token")
+
         async_connection = get_session()
         return async_connection.create_client(
             service_name=self.client_type,

--- a/astronomer/providers/amazon/aws/hooks/base_aws.py
+++ b/astronomer/providers/amazon/aws/hooks/base_aws.py
@@ -68,7 +68,7 @@ class AwsBaseHookAsync(AwsBaseHook):
         if "aws_session_token" in extra_config:
             self.log.info(
                 "session token retrieved from extra, please note you are responsible for renewing these.",
-            )  # pragma: no cover
+            )
             aws_session_token = extra_config.get("aws_session_token")
 
         async_connection = get_session()

--- a/tests/amazon/aws/hooks/test_s3_hooks.py
+++ b/tests/amazon/aws/hooks/test_s3_hooks.py
@@ -32,9 +32,7 @@ async def test_aws_base_hook_async_get_client_async_with_get_connection(mock_con
 @mock.patch("astronomer.providers.amazon.aws.hooks.base_aws.AwsBaseHookAsync.get_connection")
 @pytest.mark.asyncio
 async def test_aws_base_hook_async_get_client_async_with_aws_secrets(mock_get_connection):
-    mock_conn = Connection(
-        extra=json.dumps({"aws_access_key_id": "", "aws_secret_access_key": "", "aws_session_token": ""})
-    )
+    mock_conn = Connection(extra=json.dumps({"aws_access_key_id": "", "aws_secret_access_key": ""}))
     mock_get_connection.return_value = mock_conn
 
     aws_base_hook_async_obj = AwsBaseHookAsync(client_type="S3", resource_type="S3")

--- a/tests/amazon/aws/hooks/test_s3_hooks.py
+++ b/tests/amazon/aws/hooks/test_s3_hooks.py
@@ -32,10 +32,26 @@ async def test_aws_base_hook_async_get_client_async_with_get_connection(mock_con
 @mock.patch("astronomer.providers.amazon.aws.hooks.base_aws.AwsBaseHookAsync.get_connection")
 @pytest.mark.asyncio
 async def test_aws_base_hook_async_get_client_async_with_aws_secrets(mock_get_connection):
-    mock_conn = Connection(extra=json.dumps({"aws_access_key_id": "", "aws_secret_access_key": ""}))
+    mock_conn = Connection(
+        extra=json.dumps({"aws_access_key_id": "", "aws_secret_access_key": "", "aws_session_token": ""})
+    )
     mock_get_connection.return_value = mock_conn
 
     aws_base_hook_async_obj = AwsBaseHookAsync(client_type="S3", resource_type="S3")
+    response = await aws_base_hook_async_obj.get_client_async()
+
+    assert isinstance(response, ClientCreatorContext)
+
+
+@mock.patch("astronomer.providers.amazon.aws.hooks.base_aws.AwsBaseHookAsync.get_connection")
+@pytest.mark.asyncio
+async def test_aws_base_hook_async_get_client_async_with_aws_session(mock_get_connection):
+    mock_conn = Connection(
+        login="test", password="", extra=json.dumps({"region_name": "", "aws_session_token": ""})
+    )
+    mock_get_connection.return_value = mock_conn
+
+    aws_base_hook_async_obj = AwsBaseHookAsync(client_type="S3", resource_type="S3", region_name=None)
     response = await aws_base_hook_async_obj.get_client_async()
 
     assert isinstance(response, ClientCreatorContext)


### PR DESCRIPTION
when AWS secrete and access key is passed via the connection UI field the session token is not considered, when it is passed via extra config it is considered

closes: #725 