### PR TITLE
Bump version to 1.12.0.dev1

### DIFF
--- a/astronomer/providers/package.py
+++ b/astronomer/providers/package.py
@@ -8,7 +8,7 @@ def get_provider_info() -> Dict[str, Any]:
         "package-name": "astronomer-providers",
         "name": "Astronomer Providers",
         "description": "Apache Airflow Providers containing Deferrable Operators & Sensors from Astronomer",
-        "versions": "1.11.1",
+        "versions": "1.12.0.dev1",
         # Optional.
         "hook-class-names": [],
         "extra-links": [],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ project = "Astronomer Providers"
 author = "Astronomer Inc."
 
 # The full version, including alpha/beta/rc tags
-release = "1.11.1"
+release = "1.12.0.dev1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = astronomer-providers
-version = 1.11.1
+version = 1.12.0.dev1
 url = https://github.com/astronomer/astronomer-providers/
 author = Astronomer
 author_email = humans@astronomer.io


### PR DESCRIPTION
Since 1.11.1 is released with a bug fix, so bumped up this version to `1.12.0.dev1`