### PR TITLE
Typecast bigquery job response col value

### DIFF
--- a/astronomer/providers/google/cloud/hooks/bigquery.py
+++ b/astronomer/providers/google/cloud/hooks/bigquery.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional, Union, cast
 
 from aiohttp import ClientSession as ClientSession
 from airflow.exceptions import AirflowException
-from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook, _bq_cast
 from gcloud.aio.bigquery import Job, Table
 from google.cloud.bigquery import CopyJob, ExtractJob, LoadJob, QueryJob
 from requests import Session
@@ -70,8 +70,10 @@ class BigQueryHookAsync(GoogleBaseHookAsync):
         buffer = []
         if "rows" in query_results and query_results["rows"]:
             rows = query_results["rows"]
+            fields = query_results["schema"]["fields"]
+            col_types = [field["type"] for field in fields]
             for dict_row in rows:
-                typed_row = [vs["v"] for vs in dict_row["f"]]
+                typed_row = [_bq_cast(vs["v"], col_types[idx]) for idx, vs in enumerate(dict_row["f"])]
                 buffer.append(typed_row)
         return buffer
 

--- a/tests/google/cloud/hooks/test_bigquery.py
+++ b/tests/google/cloud/hooks/test_bigquery.py
@@ -227,3 +227,32 @@ async def test_get_table_client(mock_session):
         dataset=DATASET_ID, project_id=PROJECT_ID, table_id=TABLE_ID, session=mock_session
     )
     assert isinstance(result, Table)
+
+
+def test_get_records_return_type():
+    query_result = {
+        "kind": "bigquery#getQueryResultsResponse",
+        "etag": "test_etag",
+        "schema": {
+            "fields": [
+                {"name": "f0_", "type": "INTEGER", "mode": "NULLABLE"},
+                {"name": "f1_", "type": "FLOAT", "mode": "NULLABLE"},
+                {"name": "f2_", "type": "STRING", "mode": "NULLABLE"},
+            ]
+        },
+        "jobReference": {
+            "projectId": "test_airflow-providers",
+            "jobId": "test_jobid",
+            "location": "US",
+        },
+        "totalRows": "1",
+        "rows": [{"f": [{"v": "22"}, {"v": "3.14"}, {"v": "PI"}]}],
+        "totalBytesProcessed": "0",
+        "jobComplete": True,
+        "cacheHit": False,
+    }
+    hook = BigQueryHookAsync()
+    result = hook.get_records(query_result)
+    assert isinstance(result[0][0], int)
+    assert isinstance(result[0][1], float)
+    assert isinstance(result[0][2], str)

--- a/tests/google/cloud/triggers/test_bigquery.py
+++ b/tests/google/cloud/triggers/test_bigquery.py
@@ -240,7 +240,7 @@ async def test_bigquery_check_op_trigger_success_with_data(mock_job_output, mock
     generator = trigger.run()
     actual = await generator.asend(None)
 
-    assert TriggerEvent({"status": "success", "records": ["22"]}) == actual
+    assert TriggerEvent({"status": "success", "records": [22]}) == actual
 
 
 @pytest.mark.asyncio
@@ -322,9 +322,14 @@ async def test_bigquery_get_data_trigger_success_with_data(mock_job_output, mock
     mock_job_output.return_value = {
         "kind": "bigquery#tableDataList",
         "etag": "test_etag",
-        "schema": {"fields": [{"name": "f0_", "type": "INTEGER", "mode": "NULLABLE"}]},
+        "schema": {
+            "fields": [
+                {"name": "f0_", "type": "INTEGER", "mode": "NULLABLE"},
+                {"name": "f1_", "type": "STRING", "mode": "NULLABLE"},
+            ]
+        },
         "jobReference": {
-            "projectId": "test_astronomer-airflow-providers",
+            "projectId": "test-airflow-providers",
             "jobId": "test_jobid",
             "location": "US",
         },
@@ -354,7 +359,7 @@ async def test_bigquery_get_data_trigger_success_with_data(mock_job_output, mock
             {
                 "status": "success",
                 "message": "success",
-                "records": [["42", "monthy python"], ["42", "fishy fish"]],
+                "records": [[42, "monthy python"], [42, "fishy fish"]],
             }
         )
         == actual


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-providers/issues/743
The Bigquery hook get_records always return a list of string irrespective of the Bigquery table column type. So if even my table column has value 0 the task succeeds since bool("0") returns True.

This PR fixes it by typecasting the column value using `_bq_cast`

