### PR TITLE
Handle `SFTPSensorAsync` when file pattern is not passed

### DIFF
--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -131,7 +131,7 @@ class SFTPHookAsync(BaseHook):
         """
         Makes SFTP async connection and looks for last modified time in the specific file
         path and returns last modification time for the file path.
-        
+
         :param path: full path to the remote file
         """
         ssh_conn = await self._get_conn()

--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -6,7 +6,6 @@ import asyncssh
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from asgiref.sync import sync_to_async
-from paramiko.sftp import SFTP_NO_SUCH_FILE
 
 
 class SFTPHookAsync(BaseHook):

--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 from fnmatch import fnmatch
 from typing import List, Optional
 
@@ -131,6 +131,7 @@ class SFTPHookAsync(BaseHook):
         """
         Makes SFTP async connection and looks for last modified time in the specific file
         path and returns last modification time for the file path.
+        
         :param path: full path to the remote file
         """
         ssh_conn = await self._get_conn()

--- a/astronomer/providers/sftp/sensors/sftp.py
+++ b/astronomer/providers/sftp/sensors/sftp.py
@@ -19,6 +19,7 @@ class SFTPSensorAsync(SFTPSensor):
     :param file_pattern: Pattern to be used for matching against the list of files at the path above.
                  Uses the fnmatch module from std library to perform the matching.
     :param timeout: How long, in seconds, the sensor waits for successful before timing out
+    :param newer_than: DateTime for which the file or file path should be newer than, comparison is inclusive
     """
 
     def __init__(
@@ -50,6 +51,7 @@ class SFTPSensorAsync(SFTPSensor):
                 file_pattern=self.file_pattern,
                 sftp_conn_id=self.sftp_conn_id,
                 poke_interval=self.poke_interval,
+                newer_than=self.newer_than,
             ),
             method_name="execute_complete",
         )

--- a/astronomer/providers/sftp/triggers/sftp.py
+++ b/astronomer/providers/sftp/triggers/sftp.py
@@ -70,8 +70,6 @@ class SFTPTrigger(BaseTrigger):
                 mod_time = await hook.get_mod_time(actual_file_to_check)
                 if _newer_than:
                     _mod_time = convert_to_utc(datetime.strptime(mod_time, "%Y%m%d%H%M%S"))
-                    print("_mod_time ", _mod_time)
-                    print("_newer_than ", _newer_than)
                     if _newer_than > _mod_time:
                         await asyncio.sleep(self.poke_interval)
                 yield TriggerEvent({"status": "success", "message": f"Sensed file: {actual_file_to_check}"})

--- a/tests/sftp/hooks/test_sftp.py
+++ b/tests/sftp/hooks/test_sftp.py
@@ -152,8 +152,8 @@ class TestSFTPHookAsync:
 
         assert file == "file"
 
-    @patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")
     @pytest.mark.asyncio
+    @patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")
     async def test_get_file_by_pattern_with_no_match(self, mock_hook_get_conn):
         """
         Assert that AirflowException is raised when no files match file pattern on SFTP server
@@ -178,11 +178,11 @@ class TestSFTPHookAsync:
         expected_value = datetime.datetime.fromtimestamp(1667302566).strftime("%Y%m%d%H%M%S")
         assert mod_time == expected_value
 
-    @patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")
     @pytest.mark.asyncio
+    @patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")
     async def test_get_mod_time_exception(self, mock_hook_get_conn):
         """
-        Assert that get_mod_time with mocking the value and exception
+        Assert that get_mod_time raise exception when file does not exist
         """
         mock_hook_get_conn.return_value.start_sftp_client.return_value = MockSFTPClient()
         hook = SFTPHookAsync()

--- a/tests/sftp/hooks/test_sftp.py
+++ b/tests/sftp/hooks/test_sftp.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -174,7 +175,8 @@ class TestSFTPHookAsync:
         mock_hook_get_conn.return_value.start_sftp_client.return_value = MockSFTPClient()
         hook = SFTPHookAsync()
         mod_time = await hook.get_mod_time("/path/exists/file")
-        assert mod_time == "20221101170606"
+        expected_value = datetime.datetime.fromtimestamp(1667302566).strftime("%Y%m%d%H%M%S")
+        assert mod_time == expected_value
 
     @patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")
     @pytest.mark.asyncio

--- a/tests/sftp/hooks/test_sftp.py
+++ b/tests/sftp/hooks/test_sftp.py
@@ -166,8 +166,8 @@ class TestSFTPHookAsync:
 
         assert str(exc.value) == "No files matching file pattern were found at /path/exists/ — Deferring"
 
-    @patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")
     @pytest.mark.asyncio
+    @patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")
     async def test_get_mod_time(self, mock_hook_get_conn):
         """
         Assert that file attribute and return the modified time of the file

--- a/tests/sftp/triggers/test_sftp.py
+++ b/tests/sftp/triggers/test_sftp.py
@@ -1,4 +1,6 @@
 import asyncio
+import datetime
+import time
 from unittest import mock
 
 import pytest
@@ -20,21 +22,62 @@ class TestSFTPTrigger:
             "path": "test/path/",
             "file_pattern": "my_test_file",
             "sftp_conn_id": "sftp_default",
+            "newer_than": None,
             "poke_interval": 5.0,
         }
 
     @pytest.mark.asyncio
     @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_file_by_pattern")
-    async def test_sftp_trigger_run_trigger_success_state(self, mock_get_file_by_pattern):
+    @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_mod_time")
+    async def test_sftp_trigger_run_trigger_success_state(self, mock_mod_time, mock_get_file_by_pattern):
         """
         Assert that a TriggerEvent with a success status is yielded if a file
         matching the pattern is returned by the hook
         """
         mock_get_file_by_pattern.return_value = "some_file"
+        mock_mod_time.return_value = "19700101053001"
 
         trigger = SFTPTrigger(path="test/path/", sftp_conn_id="sftp_default", file_pattern="my_test_file")
 
         expected_event = {"status": "success", "message": "Sensed file: some_file"}
+
+        generator = trigger.run()
+        actual_event = await generator.asend(None)
+
+        assert TriggerEvent(expected_event) == actual_event
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_mod_time")
+    async def test_sftp_success_without_file_pattern(self, mock_mod_time):
+        """
+        Assert that a TriggerEvent with a success status is yielded if a file
+        matching without the pattern
+        """
+        mock_mod_time.return_value = "19700101053001"
+
+        trigger = SFTPTrigger(path="test/path/test.txt", sftp_conn_id="sftp_default", file_pattern="")
+
+        expected_event = {"status": "success", "message": "Sensed file: test/path/test.txt"}
+
+        generator = trigger.run()
+        actual_event = await generator.asend(None)
+
+        assert TriggerEvent(expected_event) == actual_event
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_mod_time")
+    async def test_sftp_success_with_newer_then(self, mock_mod_time):
+        """
+        Assert that a TriggerEvent with a success status is yielded if a file
+        matching without the pattern
+        """
+        mock_mod_time.return_value = "19700101053001"
+        yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
+        trigger = SFTPTrigger(
+            path="test/path/test.txt", sftp_conn_id="sftp_default", file_pattern="", newer_than=yesterday
+        )
+
+        expected_event = {"status": "success", "message": "Sensed file: test/path/test.txt"}
 
         generator = trigger.run()
         actual_event = await generator.asend(None)
@@ -51,6 +94,30 @@ class TestSFTPTrigger:
         mock_get_file_by_pattern.side_effect = AirflowException("No files at path found...")
 
         trigger = SFTPTrigger(path="test/path/", sftp_conn_id="sftp_default", file_pattern="my_test_file")
+
+        task = asyncio.create_task(trigger.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_mod_time")
+    async def test_sftp_success_with_newer_then_false(self, mock_mod_time):
+        """
+        Assert that a TriggerEvent with a success status is yielded if a file
+        matching without the pattern
+        """
+        today_time = time.time()
+        mock_mod_time.return_value = datetime.date.fromtimestamp(today_time).strftime("%Y%m%d%H%M%S")
+        newer_then_time = datetime.datetime.now() + datetime.timedelta(hours=1)
+        trigger = SFTPTrigger(
+            path="test/path/test.txt",
+            sftp_conn_id="sftp_default",
+            file_pattern="",
+            newer_than=newer_then_time,
+        )
 
         task = asyncio.create_task(trigger.run().__anext__())
         await asyncio.sleep(0.5)

--- a/tests/sftp/triggers/test_sftp.py
+++ b/tests/sftp/triggers/test_sftp.py
@@ -50,8 +50,8 @@ class TestSFTPTrigger:
     @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_mod_time")
     async def test_sftp_success_without_file_pattern(self, mock_mod_time):
         """
-        Assert that a TriggerEvent with a success status is yielded if a file
-        matching without the pattern
+        Test SFTPTrigger run method by mocking the file path and without file pattern,
+        assert that a TriggerEvent with a success status is yielded.
         """
         mock_mod_time.return_value = "19700101053001"
 
@@ -68,8 +68,8 @@ class TestSFTPTrigger:
     @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_mod_time")
     async def test_sftp_success_with_newer_then(self, mock_mod_time):
         """
-        Assert that a TriggerEvent with a success status is yielded if a file
-        matching without the pattern
+        Test SFTPTrigger run method by mocking the file path, without file pattern, and with newer then datetime
+        assert that a TriggerEvent with a success status is yielded.
         """
         mock_mod_time.return_value = "19700101053001"
         yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
@@ -104,10 +104,11 @@ class TestSFTPTrigger:
 
     @pytest.mark.asyncio
     @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_mod_time")
-    async def test_sftp_success_with_newer_then_false(self, mock_mod_time):
+    async def test_sftp_with_newer_then_date_greater(self, mock_mod_time):
         """
-        Assert that a TriggerEvent with a success status is yielded if a file
-        matching without the pattern
+        Test the Trigger run method by passing full file path, without file pattern and along with newer then datetime.
+        mock the datetime as greater then the last modified date and make the trigger task in running
+        state and assert to success
         """
         today_time = time.time()
         mock_mod_time.return_value = datetime.date.fromtimestamp(today_time).strftime("%Y%m%d%H%M%S")
@@ -130,8 +131,7 @@ class TestSFTPTrigger:
     @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_file_by_pattern")
     async def test_sftp_trigger_run_trigger_failure_state(self, mock_get_file_by_pattern):
         """
-        Assert that a TriggerEvent with a failure status is yielded if an exception
-        other than an AirflowException is raised by the hook
+        Mock the hook to raise other than an AirflowException and assert that a TriggerEvent with a failure status
         """
         mock_get_file_by_pattern.side_effect = Exception("An unexpected exception")
 


### PR DESCRIPTION
- Handled SFTP async operator when file pattern is not passed
- Added `newer_than` attribute corresponding to Sync operators and code changes for the same.
- Added test case for the code changes
closes: #707 