### PR TITLE
Fix `redshift_data` hook to consider access and secret key from the connections object not from extra

### DIFF
--- a/astronomer/providers/amazon/aws/hooks/redshift_data.py
+++ b/astronomer/providers/amazon/aws/hooks/redshift_data.py
@@ -77,6 +77,9 @@ class RedshiftDataHook(AwsBaseHook):
                 if "secret_access_key" in extra_config
                 else extra_config["aws_secret_access_key"]
             )
+        elif connection_object.login:
+            conn_params["aws_access_key_id"] = connection_object.login
+            conn_params["aws_secret_access_key"] = connection_object.password
         else:
             raise AirflowException("Required access_key_id, aws_secret_access_key")
 

--- a/astronomer/providers/amazon/aws/hooks/redshift_data.py
+++ b/astronomer/providers/amazon/aws/hooks/redshift_data.py
@@ -95,7 +95,7 @@ class RedshiftDataHook(AwsBaseHook):
             self.log.info(
                 "session token retrieved from extra, please note you are responsible for renewing these.",
             )
-            conn_params["aws_session_token"] = extra_config.get("aws_session_token")
+            conn_params["aws_session_token"] = extra_config["aws_session_token"]
 
         if "cluster_identifier" in extra_config:
             self.log.info("Retrieving cluster_identifier from Connection.extra_config['cluster_identifier']")

--- a/astronomer/providers/amazon/aws/hooks/redshift_data.py
+++ b/astronomer/providers/amazon/aws/hooks/redshift_data.py
@@ -91,6 +91,12 @@ class RedshiftDataHook(AwsBaseHook):
         else:
             raise AirflowException("Required Region name is missing !")
 
+        if "aws_session_token" in extra_config:
+            self.log.info(
+                "session token retrieved from extra, please note you are responsible for renewing these.",
+            )
+            conn_params["aws_session_token"] = extra_config.get("aws_session_token")
+
         if "cluster_identifier" in extra_config:
             self.log.info("Retrieving cluster_identifier from Connection.extra_config['cluster_identifier']")
             conn_params["cluster_identifier"] = extra_config["cluster_identifier"]

--- a/tests/amazon/aws/hooks/test_redshift_data.py
+++ b/tests/amazon/aws/hooks/test_redshift_data.py
@@ -248,9 +248,11 @@ def test_execute_query_exception(mock_conn, mock_params):
 
 
 @pytest.mark.parametrize(
-    "connection_details, expected_output",
+    "mock_login, mock_pwd, connection_details, expected_output",
     [
         (
+            "",
+            "",
             {
                 "aws_access_key_id": "",
                 "aws_secret_access_key": "",
@@ -269,6 +271,8 @@ def test_execute_query_exception(mock_conn, mock_params):
             },
         ),
         (
+            "",
+            "",
             {
                 "access_key_id": "",
                 "secret_access_key": "",
@@ -286,11 +290,29 @@ def test_execute_query_exception(mock_conn, mock_params):
                 "database": "",
             },
         ),
+        (
+            "test",
+            "test",
+            {
+                "db_user": "test_user",
+                "cluster_identifier": "",
+                "region": "",
+                "database": "",
+            },
+            {
+                "aws_access_key_id": "test",
+                "aws_secret_access_key": "test",
+                "db_user": "test_user",
+                "cluster_identifier": "",
+                "region_name": "",
+                "database": "",
+            },
+        ),
     ],
 )
 @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.get_connection")
-def test_get_conn_params(mock_get_connection, connection_details, expected_output):
-    mock_conn = Connection(extra=json.dumps(connection_details))
+def test_get_conn_params(mock_get_connection, mock_login, mock_pwd, connection_details, expected_output):
+    mock_conn = Connection(login=mock_login, password=mock_pwd, extra=json.dumps(connection_details))
     mock_get_connection.return_value = mock_conn
 
     hook = RedshiftDataHook(client_type="redshift-data")

--- a/tests/amazon/aws/hooks/test_redshift_data.py
+++ b/tests/amazon/aws/hooks/test_redshift_data.py
@@ -248,11 +248,9 @@ def test_execute_query_exception(mock_conn, mock_params):
 
 
 @pytest.mark.parametrize(
-    "mock_login, mock_pwd, connection_details, expected_output",
+    "connection_details, expected_output",
     [
         (
-            "",
-            "",
             {
                 "aws_access_key_id": "",
                 "aws_secret_access_key": "",
@@ -271,8 +269,6 @@ def test_execute_query_exception(mock_conn, mock_params):
             },
         ),
         (
-            "",
-            "",
             {
                 "access_key_id": "",
                 "secret_access_key": "",
@@ -290,14 +286,29 @@ def test_execute_query_exception(mock_conn, mock_params):
                 "database": "",
             },
         ),
+    ],
+)
+@mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.get_connection")
+def test_get_conn_params(mock_get_connection, connection_details, expected_output):
+    mock_conn = Connection(extra=json.dumps(connection_details))
+    mock_get_connection.return_value = mock_conn
+
+    hook = RedshiftDataHook(client_type="redshift-data")
+    response = hook.get_conn_params()
+    assert response == expected_output
+
+
+@pytest.mark.parametrize(
+    "mock_login, mock_pwd, connection_details, expected_output",
+    [
         (
             "test",
             "test",
             {
                 "db_user": "test_user",
-                "cluster_identifier": "",
-                "region": "",
-                "database": "",
+                "cluster_identifier": "test_cluster",
+                "region": "us-east-2",
+                "database": "test-redshift_database",
                 "aws_session_token": "test",
             },
             {
@@ -305,15 +316,21 @@ def test_execute_query_exception(mock_conn, mock_params):
                 "aws_secret_access_key": "test",
                 "aws_session_token": "test",
                 "db_user": "test_user",
-                "cluster_identifier": "",
-                "region_name": "",
-                "database": "",
+                "cluster_identifier": "test_cluster",
+                "region_name": "us-east-2",
+                "database": "test-redshift_database",
             },
         ),
     ],
 )
 @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.get_connection")
-def test_get_conn_params(mock_get_connection, mock_login, mock_pwd, connection_details, expected_output):
+def test_get_conn_params_with_login_pwd(
+    mock_get_connection, mock_login, mock_pwd, connection_details, expected_output
+):
+    """
+    Test get_conn_params by mocking the AWS secret and access key and session token,
+    passing access and secret key in connection login and password instead passing in extra
+    """
     mock_conn = Connection(login=mock_login, password=mock_pwd, extra=json.dumps(connection_details))
     mock_get_connection.return_value = mock_conn
 

--- a/tests/amazon/aws/hooks/test_redshift_data.py
+++ b/tests/amazon/aws/hooks/test_redshift_data.py
@@ -298,10 +298,12 @@ def test_execute_query_exception(mock_conn, mock_params):
                 "cluster_identifier": "",
                 "region": "",
                 "database": "",
+                "aws_session_token": "test",
             },
             {
                 "aws_access_key_id": "test",
                 "aws_secret_access_key": "test",
+                "aws_session_token": "test",
                 "db_user": "test_user",
                 "cluster_identifier": "",
                 "region_name": "",


### PR DESCRIPTION
- Consider access and secret key if it is passed in connection login and password field
- Consider AWS session token if it is passed in `extra_config`

closes: #741 