### PR TITLE
Run `SFTPSensorAsync` in integrations tests and add support for private key connection

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -197,6 +197,14 @@ with DAG(
     dag_run_ids.extend(ids)
     chain(*azure_trigger_tasks)
 
+    # SFTP
+    sftp_task_info = [
+        {"sftp_dag": "example_async_sftp_sensor"},
+    ]
+    sftp_trigger_tasks, ids = prepare_dag_dependency(sftp_task_info, "{{ ds }}")
+    dag_run_ids.extend(ids)
+    chain(*sftp_trigger_tasks)
+
     report = PythonOperator(
         task_id="get_report",
         python_callable=get_report,
@@ -224,6 +232,7 @@ with DAG(
         livy_trigger_tasks[0],
         hive_trigger_tasks[0],
         azure_trigger_tasks[0],
+        sftp_trigger_tasks[0],
     ]
 
     last_task = [
@@ -240,6 +249,7 @@ with DAG(
         livy_trigger_tasks[-1],
         hive_trigger_tasks[-1],
         azure_trigger_tasks[-1],
+        sftp_trigger_tasks[-1],
     ]
 
     last_task >> end

--- a/astronomer/providers/sftp/example_dags/example_sftp.py
+++ b/astronomer/providers/sftp/example_dags/example_sftp.py
@@ -1,9 +1,12 @@
+import json
 import logging
 import os
+import shutil
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, List
 
-from airflow import DAG
+from airflow import DAG, AirflowException, settings
+from airflow.models import Connection, Variable
 from airflow.operators.python import PythonOperator, get_current_context
 from airflow.utils.timezone import datetime
 from airflow.utils.trigger_rule import TriggerRule
@@ -21,9 +24,19 @@ AWS_S3_CREDS = {
     "aws_secret_access_key": os.getenv("AWS_SECRET_ACCESS_KEY", "aws_secret_key"),
     "region_name": os.getenv("AWS_DEFAULT_REGION", "us-east-2"),
 }
-AMI_ID = os.getenv("AMI_ID", "ami-097a2df4ac947655f")
+AMI_ID = os.getenv("AMI_ID", "test")
 PEM_FILENAME = os.getenv("PEM_FILENAME", "providers_team_keypair")
+PRIVATE_KEY = Variable.get("providers_team_keypair")
+INBOUND_SECURITY_GROUP = os.getenv("INBOUND_SECURITY_GROUP", "security-group")
+SFTP_SSH_PORT = int(os.getenv("SFTP_SSH_PORT", 22))
 BOTO_DUPLICATE_PERMISSION_ERROR = "InvalidPermission.Duplicate"
+
+COMMAND_TO_CREATE_TABLE_DATA_FILE: List[str] = [
+    "curl https://raw.githubusercontent.com/astronomer/astronomer-providers/\
+main/astronomer/providers/apache/hive/example_dags/zipcodes.csv \
+ >> zipcodes.csv",
+    "mv zipcodes.csv /home/ubuntu/",
+]
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
@@ -32,33 +45,76 @@ default_args = {
 }
 
 
+def create_sftp_airflow_connection(task_instance: Any) -> None:
+    """
+    Checks if airflow connection exists, if yes then deletes it.
+    Then, create a new sftp_default connection.
+    """
+    conn = Connection(
+        conn_id="sftp_default",
+        conn_type="sftp",
+        host=task_instance.xcom_pull(key="instance_public_dns_name", task_ids=["get_instance_details"])[0],
+        login="ubuntu",
+        port=SFTP_SSH_PORT,
+        extra=json.dumps(
+            {
+                "key_file": f"/usr/local/airflow/dags/{PEM_FILENAME}.pem",
+                "no_host_key_check": "true",
+                "known_hosts": "none",
+            }
+        ),
+    )  # create a connection object
+
+    session = settings.Session()
+    connection = session.query(Connection).filter_by(conn_id=conn.conn_id).one_or_none()
+    if connection is None:
+        logging.info("Connection %s doesn't exist.", str(conn.conn_id))
+    else:
+        session.delete(connection)
+        session.commit()
+        logging.info("Connection %s deleted.", str(conn.conn_id))
+
+    session.add(conn)
+    session.commit()  # it will insert the connection object programmatically.
+    logging.info("Connection metastore_default is created")
+
+
 def create_ec2_instance() -> None:
     """Create ec2 instance"""
     import boto3
 
     ec2 = boto3.resource("ec2", **AWS_S3_CREDS)
     instance = ec2.create_instances(
-        ImageId=AMI_ID, MinCount=1, MaxCount=1, InstanceType="t2.micro", KeyName=PEM_FILENAME
+        ImageId=AMI_ID,
+        MinCount=1,
+        MaxCount=1,
+        InstanceType="t2.micro",
+        KeyName=PEM_FILENAME,
+        SecurityGroups=[INBOUND_SECURITY_GROUP],
     )
     instance_id = instance[0].id
     ti = get_current_context()["ti"]
     ti.xcom_push(key="ec2_instance_id", value=instance_id)
 
 
-def terminate_instance(task_instance: "TaskInstance") -> None:
-    """Terminate ec2 instance by instance id"""
+def get_ec2_instance_details(task_instance: "TaskInstance") -> None:
+    """Bys using the instance id get the ec2 instance details"""
     import boto3
 
-    ec2 = boto3.client("ec2", **AWS_S3_CREDS)
+    client = boto3.client("ec2", **AWS_S3_CREDS)
     ec2_instance_id_xcom = task_instance.xcom_pull(key="ec2_instance_id", task_ids=["create_ec2_instance"])[0]
-    ec2.terminate_instances(
-        InstanceIds=[
-            ec2_instance_id_xcom,
-        ],
+    response = client.describe_instances(
+        InstanceIds=[ec2_instance_id_xcom],
     )
+    instance_details = response["Reservations"][0]["Instances"][0]
+    ti = get_current_context()["ti"]
+    ti.xcom_push(
+        key="instance_response_master_security_group", value=instance_details["SecurityGroups"][0]["GroupId"]
+    )
+    ti.xcom_push(key="instance_public_dns_name", value=instance_details["PublicDnsName"])
 
 
-def add_inbound_rule_for_security_group(task_instance: Any) -> None:
+def add_inbound_rule_for_security_group(task_instance: "TaskInstance") -> None:
     """
     Sets the inbound rule for the aws security group, based on
     current ip address of the system.
@@ -69,11 +125,11 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
     client = boto3.client("ec2", **AWS_S3_CREDS)
     current_docker_ip = get("https://api.ipify.org").text
 
-    # Allow SSH traffic on port 22 and copy file to HDFS.
+    # Allow SSH traffic on port 22 and copy file to ec2 instance.
     try:
         client.authorize_security_group_ingress(
             GroupId=task_instance.xcom_pull(
-                key="cluster_response_master_security_group", task_ids=["describe_created_cluster"]
+                key="instance_response_master_security_group", task_ids=["get_instance_details"]
             )[0],
             IpPermissions=[
                 {
@@ -94,6 +150,63 @@ def add_inbound_rule_for_security_group(task_instance: Any) -> None:
             raise error
 
 
+def ssh_and_run_command(task_instance: Any, **kwargs: Any) -> None:
+    """
+    Load the private_key from airflow variable and creates a pem_file
+    at /tmp/. SSH into the machine and execute the bash script from the list
+    of commands.
+    """
+    # remove the file if it exists
+    if os.path.exists(f"/tmp/{PEM_FILENAME}.pem"):
+        os.remove(f"/tmp/{PEM_FILENAME}.pem")
+
+    # read the content for pem file from Variable set on Airflow UI.
+    with open(f"/tmp/{PEM_FILENAME}.pem", "w+") as fh:
+        fh.write(PRIVATE_KEY)
+
+    shutil.copyfile(f"/tmp/{PEM_FILENAME}.pem", f"/usr/local/airflow/dags/{PEM_FILENAME}.pem")
+
+    # write private key to file with 400 permissions
+    os.chmod(f"/tmp/{PEM_FILENAME}.pem", 0o400)
+    os.chmod(f"/usr/local/airflow/dags/{PEM_FILENAME}.pem", 0o400)
+    # Check if the PEM file exists or not.
+    if not os.path.exists(f"/tmp/{PEM_FILENAME}.pem"):
+        # if it doesn't exists raise an error
+        raise AirflowException("PEM file wasn't copied properly.")
+
+    import paramiko
+
+    key = paramiko.RSAKey.from_private_key_file(kwargs["path_to_pem_file"])
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    # Connect/ssh to an instance
+    instance_public_dns_name = task_instance.xcom_pull(
+        key="instance_public_dns_name", task_ids=["get_instance_details"]
+    )[0]
+    client.connect(hostname=instance_public_dns_name, username=kwargs["username"], pkey=key)
+
+    # Execute a command(cmd) after connecting/ssh to an instance
+    for command in kwargs["command"]:
+        stdin, stdout, stderr = client.exec_command(command)
+        stdout.read()
+
+    # close the client connection once the job is done
+    client.close()
+
+
+def terminate_instance(task_instance: "TaskInstance") -> None:
+    """Terminate ec2 instance by instance id"""
+    import boto3
+
+    ec2 = boto3.client("ec2", **AWS_S3_CREDS)
+    ec2_instance_id_xcom = task_instance.xcom_pull(key="ec2_instance_id", task_ids=["create_ec2_instance"])[0]
+    ec2.terminate_instances(
+        InstanceIds=[
+            ec2_instance_id_xcom,
+        ],
+    )
+
+
 with DAG(
     dag_id="example_async_sftp_sensor",
     start_date=datetime(2022, 1, 1),
@@ -103,19 +216,48 @@ with DAG(
     tags=["example", "async", "sftp"],
 ) as dag:
 
-    cluster_creator = PythonOperator(task_id="create_ec2_instance", python_callable=create_ec2_instance)
+    create_ec2_instance = PythonOperator(task_id="create_ec2_instance", python_callable=create_ec2_instance)
+
+    get_instance_details = PythonOperator(
+        task_id="get_instance_details", python_callable=get_ec2_instance_details
+    )
 
     get_and_add_ip_address_for_inbound_rules = PythonOperator(
         task_id="get_and_add_ip_address_for_inbound_rules",
         python_callable=add_inbound_rule_for_security_group,
     )
 
+    ssh_and_copy_file = PythonOperator(
+        task_id="ssh_and_copy_file",
+        python_callable=ssh_and_run_command,
+        op_kwargs={
+            "path_to_pem_file": f"/tmp/{PEM_FILENAME}.pem",
+            "username": "ubuntu",
+            "command": COMMAND_TO_CREATE_TABLE_DATA_FILE,
+        },
+    )
+
+    create_sftp_default_airflow_connection = PythonOperator(
+        task_id="create_sftp_default_airflow_connection",
+        python_callable=create_sftp_airflow_connection,
+    )
+
     # [START howto_sensor_sftp_async]
     async_sftp_sensor = SFTPSensorAsync(
         task_id="async_sftp_sensor",
         sftp_conn_id=SFTP_CONN_ID,
-        path="path/on/sftp/server",
+        path="/home/ubuntu/",
         file_pattern="*.csv",
+        poke_interval=5,
+    )
+    # [END howto_sensor_sftp_async]
+
+    # [START howto_sensor_sftp_async]
+    # without file pattern
+    async_sftp_sensor_without_pattern = SFTPSensorAsync(
+        task_id="async_sftp_sensor_without_pattern",
+        sftp_conn_id=SFTP_CONN_ID,
+        path="/home/ubuntu/zipcodes.csv",
         poke_interval=5,
     )
     # [END howto_sensor_sftp_async]
@@ -124,4 +266,12 @@ with DAG(
         task_id="terminate_instance", trigger_rule=TriggerRule.ALL_DONE, python_callable=terminate_instance
     )
 
-    cluster_creator >> async_sftp_sensor >> get_and_add_ip_address_for_inbound_rules >> terminate_ec2_instance
+    (
+        create_ec2_instance
+        >> get_instance_details
+        >> get_and_add_ip_address_for_inbound_rules
+        >> ssh_and_copy_file
+        >> create_sftp_default_airflow_connection
+        >> [async_sftp_sensor, async_sftp_sensor_without_pattern]
+        >> terminate_ec2_instance
+    )

--- a/astronomer/providers/sftp/example_dags/example_sftp.py
+++ b/astronomer/providers/sftp/example_dags/example_sftp.py
@@ -1,19 +1,97 @@
+import logging
 import os
 from datetime import timedelta
+from typing import TYPE_CHECKING, Any
 
 from airflow import DAG
+from airflow.operators.python import PythonOperator, get_current_context
 from airflow.utils.timezone import datetime
+from airflow.utils.trigger_rule import TriggerRule
+from requests import get
 
 from astronomer.providers.sftp.sensors.sftp import SFTPSensorAsync
 
+if TYPE_CHECKING:
+    from airflow.models import TaskInstance
+
 SFTP_CONN_ID = os.getenv("ASTRO_SFTP_CONN_ID", "sftp_default")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
+AWS_S3_CREDS = {
+    "aws_access_key_id": os.getenv("AWS_ACCESS_KEY_ID", "aws_access_key"),
+    "aws_secret_access_key": os.getenv("AWS_SECRET_ACCESS_KEY", "aws_secret_key"),
+    "region_name": os.getenv("AWS_DEFAULT_REGION", "us-east-2"),
+}
+AMI_ID = os.getenv("AMI_ID", "ami-097a2df4ac947655f")
+PEM_FILENAME = os.getenv("PEM_FILENAME", "providers_team_keypair")
+BOTO_DUPLICATE_PERMISSION_ERROR = "InvalidPermission.Duplicate"
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
     "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
     "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
+
+
+def create_ec2_instance() -> None:
+    """Create ec2 instance"""
+    import boto3
+
+    ec2 = boto3.resource("ec2", **AWS_S3_CREDS)
+    instance = ec2.create_instances(
+        ImageId=AMI_ID, MinCount=1, MaxCount=1, InstanceType="t2.micro", KeyName=PEM_FILENAME
+    )
+    instance_id = instance[0].id
+    ti = get_current_context()["ti"]
+    ti.xcom_push(key="ec2_instance_id", value=instance_id)
+
+
+def terminate_instance(task_instance: "TaskInstance") -> None:
+    """Terminate ec2 instance by instance id"""
+    import boto3
+
+    ec2 = boto3.client("ec2", **AWS_S3_CREDS)
+    ec2_instance_id_xcom = task_instance.xcom_pull(key="ec2_instance_id", task_ids=["create_ec2_instance"])[0]
+    ec2.terminate_instances(
+        InstanceIds=[
+            ec2_instance_id_xcom,
+        ],
+    )
+
+
+def add_inbound_rule_for_security_group(task_instance: Any) -> None:
+    """
+    Sets the inbound rule for the aws security group, based on
+    current ip address of the system.
+    """
+    import boto3
+    from botocore.exceptions import ClientError
+
+    client = boto3.client("ec2", **AWS_S3_CREDS)
+    current_docker_ip = get("https://api.ipify.org").text
+
+    # Allow SSH traffic on port 22 and copy file to HDFS.
+    try:
+        client.authorize_security_group_ingress(
+            GroupId=task_instance.xcom_pull(
+                key="cluster_response_master_security_group", task_ids=["describe_created_cluster"]
+            )[0],
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "IpRanges": [{"CidrIp": str(current_docker_ip) + "/32"}],
+                }
+            ],
+        )
+    except ClientError as error:
+        if error.response.get("Error", {}).get("Code", "") == BOTO_DUPLICATE_PERMISSION_ERROR:
+            logging.error(
+                "Ingress for port 22 already authorized. Error message is: %s",
+                error.response["Error"]["Message"],
+            )
+        else:
+            raise error
 
 
 with DAG(
@@ -24,6 +102,14 @@ with DAG(
     default_args=default_args,
     tags=["example", "async", "sftp"],
 ) as dag:
+
+    cluster_creator = PythonOperator(task_id="create_ec2_instance", python_callable=create_ec2_instance)
+
+    get_and_add_ip_address_for_inbound_rules = PythonOperator(
+        task_id="get_and_add_ip_address_for_inbound_rules",
+        python_callable=add_inbound_rule_for_security_group,
+    )
+
     # [START howto_sensor_sftp_async]
     async_sftp_sensor = SFTPSensorAsync(
         task_id="async_sftp_sensor",
@@ -34,4 +120,8 @@ with DAG(
     )
     # [END howto_sensor_sftp_async]
 
-    async_sftp_sensor
+    terminate_ec2_instance = PythonOperator(
+        task_id="terminate_instance", trigger_rule=TriggerRule.ALL_DONE, python_callable=terminate_instance
+    )
+
+    cluster_creator >> async_sftp_sensor >> get_and_add_ip_address_for_inbound_rules >> terminate_ec2_instance

--- a/astronomer/providers/sftp/example_dags/example_sftp.py
+++ b/astronomer/providers/sftp/example_dags/example_sftp.py
@@ -115,7 +115,7 @@ def get_instances_status(instance_id: str) -> str:
         InstanceIds=[instance_id],
     )
     instance_details = response["Reservations"][0]["Instances"][0]
-    instance_state = instance_details["State"]["Name"]
+    instance_state: str = instance_details["State"]["Name"]
     if instance_state == "running":
         ti = get_current_context()["ti"]
         ti.xcom_push(key=INSTANCE_SECURITY_GROUP, value=instance_details["SecurityGroups"][0]["GroupId"])

--- a/astronomer/providers/sftp/example_dags/example_sftp.py
+++ b/astronomer/providers/sftp/example_dags/example_sftp.py
@@ -232,10 +232,6 @@ with DAG(
         task_id="create_ec2_instance", python_callable=create_instance_with_security_group
     )
 
-    # get_instance_details = PythonOperator(
-    #     task_id="get_instance_details", python_callable=get_ec2_instance_details
-    # )
-
     get_and_add_ip_address_for_inbound_rules = PythonOperator(
         task_id="get_and_add_ip_address_for_inbound_rules",
         python_callable=add_inbound_rule_for_security_group,

--- a/astronomer/providers/sftp/example_dags/example_sftp.py
+++ b/astronomer/providers/sftp/example_dags/example_sftp.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import shutil
 import time
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, List
@@ -64,7 +63,7 @@ def create_sftp_airflow_connection(task_instance: Any) -> None:
         port=SFTP_SSH_PORT,
         extra=json.dumps(
             {
-                "key_file": f"/usr/local/airflow/dags/{PEM_FILENAME}.pem",
+                "private_key": PRIVATE_KEY,
                 "no_host_key_check": "true",
                 "known_hosts": "none",
             }
@@ -171,14 +170,8 @@ def ssh_and_run_command(task_instance: Any, **kwargs: Any) -> None:
     with open(f"/tmp/{PEM_FILENAME}.pem", "w+") as fh:
         fh.write(PRIVATE_KEY)
 
-    if os.path.exists(f"/usr/local/airflow/dags/{PEM_FILENAME}.pem"):
-        os.remove(f"/usr/local/airflow/dags/{PEM_FILENAME}.pem")
-
-    shutil.copyfile(f"/tmp/{PEM_FILENAME}.pem", f"/usr/local/airflow/dags/{PEM_FILENAME}.pem")
-
     # write private key to file with 400 permissions
     os.chmod(f"/tmp/{PEM_FILENAME}.pem", 0o400)
-    os.chmod(f"/usr/local/airflow/dags/{PEM_FILENAME}.pem", 0o400)
     # Check if the PEM file exists or not.
     if not os.path.exists(f"/tmp/{PEM_FILENAME}.pem"):
         # if it doesn't exists raise an error

--- a/astronomer/providers/sftp/example_dags/example_sftp.py
+++ b/astronomer/providers/sftp/example_dags/example_sftp.py
@@ -79,7 +79,7 @@ def create_sftp_airflow_connection(task_instance: Any) -> None:
     logging.info("Connection metastore_default is created")
 
 
-def create_ec2_instance() -> None:
+def create_instance_with_security_group() -> None:
     """Create ec2 instance"""
     import boto3
 
@@ -216,7 +216,9 @@ with DAG(
     tags=["example", "async", "sftp"],
 ) as dag:
 
-    create_ec2_instance = PythonOperator(task_id="create_ec2_instance", python_callable=create_ec2_instance)
+    create_ec2_instance = PythonOperator(
+        task_id="create_ec2_instance", python_callable=create_instance_with_security_group
+    )
 
     get_instance_details = PythonOperator(
         task_id="get_instance_details", python_callable=get_ec2_instance_details

--- a/astronomer/providers/sftp/example_dags/example_sftp.py
+++ b/astronomer/providers/sftp/example_dags/example_sftp.py
@@ -29,6 +29,7 @@ PEM_FILENAME = os.getenv("PEM_FILENAME", "providers_team_keypair")
 PRIVATE_KEY = Variable.get("providers_team_keypair")
 INBOUND_SECURITY_GROUP = os.getenv("INBOUND_SECURITY_GROUP", "security-group")
 SFTP_SSH_PORT = int(os.getenv("SFTP_SSH_PORT", 22))
+SFTP_INSTANCE_TYPE = os.getenv("SFTP_INSTANCE_TYPE", "t2.micro")
 BOTO_DUPLICATE_PERMISSION_ERROR = "InvalidPermission.Duplicate"
 
 COMMAND_TO_CREATE_TABLE_DATA_FILE: List[str] = [
@@ -76,7 +77,7 @@ def create_sftp_airflow_connection(task_instance: Any) -> None:
 
     session.add(conn)
     session.commit()  # it will insert the connection object programmatically.
-    logging.info("Connection metastore_default is created")
+    logging.info("Connection sftp_default is created")
 
 
 def create_instance_with_security_group() -> None:
@@ -88,7 +89,7 @@ def create_instance_with_security_group() -> None:
         ImageId=AMI_ID,
         MinCount=1,
         MaxCount=1,
-        InstanceType="t2.micro",
+        InstanceType=SFTP_INSTANCE_TYPE,
         KeyName=PEM_FILENAME,
         SecurityGroups=[INBOUND_SECURITY_GROUP],
     )
@@ -98,7 +99,7 @@ def create_instance_with_security_group() -> None:
 
 
 def get_ec2_instance_details(task_instance: "TaskInstance") -> None:
-    """Bys using the instance id get the ec2 instance details"""
+    """Get the EC2 instance details by id retrieved from the Xcom"""
     import boto3
 
     client = boto3.client("ec2", **AWS_S3_CREDS)


### PR DESCRIPTION
Added the `SFTPSensorAsync`  example DAG into the master DAG, created the connection details via code and other details needed for the DAG to run as a self-sufficient

closes: #662  #760 