### PR TITLE
Use bigquery hook bq_cast 

### DIFF
--- a/astronomer/providers/google/cloud/hooks/bigquery.py
+++ b/astronomer/providers/google/cloud/hooks/bigquery.py
@@ -13,7 +13,7 @@ try:
     from airflow.providers.google.cloud.utils.bigquery import bq_cast
 except ImportError:
     # For apache-airflow-providers-google < 8.5.0
-    from airflow.providers.google.cloud.utils.bigquery import _bq_cast as bq_cast
+    from airflow.providers.google.cloud.hooks.bigquery import _bq_cast as bq_cast
 
 BigQueryJob = Union[CopyJob, QueryJob, LoadJob, ExtractJob]
 

--- a/astronomer/providers/google/cloud/hooks/bigquery.py
+++ b/astronomer/providers/google/cloud/hooks/bigquery.py
@@ -2,7 +2,8 @@ from typing import Any, Dict, List, Optional, Union, cast
 
 from aiohttp import ClientSession as ClientSession
 from airflow.exceptions import AirflowException
-from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook, _bq_cast
+from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+from airflow.providers.google.cloud.utils.bigquery import bq_cast
 from gcloud.aio.bigquery import Job, Table
 from google.cloud.bigquery import CopyJob, ExtractJob, LoadJob, QueryJob
 from requests import Session
@@ -73,7 +74,7 @@ class BigQueryHookAsync(GoogleBaseHookAsync):
             fields = query_results["schema"]["fields"]
             col_types = [field["type"] for field in fields]
             for dict_row in rows:
-                typed_row = [_bq_cast(vs["v"], col_types[idx]) for idx, vs in enumerate(dict_row["f"])]
+                typed_row = [bq_cast(vs["v"], col_types[idx]) for idx, vs in enumerate(dict_row["f"])]
                 buffer.append(typed_row)
         return buffer
 

--- a/astronomer/providers/google/cloud/hooks/bigquery.py
+++ b/astronomer/providers/google/cloud/hooks/bigquery.py
@@ -3,12 +3,17 @@ from typing import Any, Dict, List, Optional, Union, cast
 from aiohttp import ClientSession as ClientSession
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
-from airflow.providers.google.cloud.utils.bigquery import bq_cast
 from gcloud.aio.bigquery import Job, Table
 from google.cloud.bigquery import CopyJob, ExtractJob, LoadJob, QueryJob
 from requests import Session
 
 from astronomer.providers.google.common.hooks.base_google import GoogleBaseHookAsync
+
+try:
+    from airflow.providers.google.cloud.utils.bigquery import bq_cast
+except ImportError:
+    # For apache-airflow-providers-google < 8.5.0
+    from airflow.providers.google.cloud.utils.bigquery import _bq_cast as bq_cast
 
 BigQueryJob = Union[CopyJob, QueryJob, LoadJob, ExtractJob]
 


### PR DESCRIPTION
Use bigquery hook bq_cast since _bq_cast was a private to the repo and would be removed in the upcoming google provider release i.e (apache-airflow-providers-google > 8.4.0) https://github.com/apache/airflow/pull/27543