### PR TITLE
Use platform flag when building docker image for astro cloud deployment

### DIFF
--- a/.circleci/integration-tests/script.sh
+++ b/.circleci/integration-tests/script.sh
@@ -79,7 +79,7 @@ for dag in $(find "${PROVIDER_PATH}" -type f -name 'example_*'); do cp "${dag}" 
 BUILD_NUMBER=$(awk 'BEGIN {srand(); print srand()}')
 if [[ ${DEPLOYMENT_INSTANCE} == "astro-cloud" ]]; then
   IMAGE_NAME=${DOCKER_REGISTRY}/${ORGANIZATION_ID}/${DEPLOYMENT_ID}:ci-${BUILD_NUMBER}
-  docker build -t "${IMAGE_NAME}" -f "${SCRIPT_PATH}"/Dockerfile.astro_cloud "${SCRIPT_PATH}"
+  docker build --platform=linux/amd64 -t "${IMAGE_NAME}" -f "${SCRIPT_PATH}"/Dockerfile.astro_cloud "${SCRIPT_PATH}"
   docker login "${DOCKER_REGISTRY}" -u "${ASTRONOMER_KEY_ID}" -p "${ASTRONOMER_KEY_SECRET}"
   docker push "${IMAGE_NAME}"
 


### PR DESCRIPTION
With runtime 6.0.4 we need to specify the platform flag while building the image, otherwise the deployment to astro cloud wont be successful. It is giving below error:

`standard_init_linux.go:228: exec user process caused: exec format error`

Refer to the discussion here: https://astronomer.slack.com/archives/C020PVBJPKK/p1668523795887349?thread_ts=1668449382.939969&cid=C020PVBJPKK