### PR TITLE
[DO NOT MERGE]:Update RCs to test new deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,36 +44,36 @@ zip_safe = false
 
 [options.extras_require]
 amazon =
-    apache-airflow-providers-amazon>=3.0.0
+    apache-airflow-providers-amazon==6.1.0rc1
     aiobotocore>=2.1.1
 apache.hive =
-    apache-airflow-providers-apache-hive
+    apache-airflow-providers-apache-hive==4.1.0rc1
     impyla
 apache.livy =
-    apache-airflow-providers-apache-livy
+    apache-airflow-providers-apache-livy==3.2.0rc1
     paramiko
 cncf.kubernetes =
     apache-airflow-providers-cncf-kubernetes>=4
     kubernetes_asyncio
 databricks =
-    apache-airflow-providers-databricks>=2.2.0
+    apache-airflow-providers-databricks==3.4.0rc1
     databricks-sql-connector>=2.0.4;python_version>='3.10'
 dbt.cloud =
     apache-airflow-providers-dbt-cloud>=2.1.0
 google =
-    apache-airflow-providers-google>=8.1.0
+    apache-airflow-providers-google==8.5.0rc1
     gcloud-aio-storage
     gcloud-aio-bigquery
     protobuf<=3.20.0  # Bigquery provider isn't compatible with it. Details in https://github.com/apache/airflow/commit/25a9ae3b2eec85dfd500b0a921045fc95ab8ffd6
 http =
     apache-airflow-providers-http
 microsoft.azure =
-    apache-airflow-providers-microsoft-azure
+    apache-airflow-providers-microsoft-azure==5.0.0rc1
 sftp =
     apache-airflow-providers-sftp
     asyncssh>=2.12.0
 snowflake =
-    apache-airflow-providers-snowflake
+    apache-airflow-providers-snowflake==4.0.0rc1
 # If in future we move Openlineage extractors out of the repo, this dependency should be removed
 openlineage =
     openlineage-airflow>=0.12.0
@@ -117,16 +117,16 @@ mypy =
 # All extras from above except 'mypy', 'docs' and 'tests'
 all =
     aiobotocore>=2.1.1
-    apache-airflow-providers-amazon>=3.0.0
-    apache-airflow-providers-apache-hive
-    apache-airflow-providers-apache-livy
+    apache-airflow-providers-amazon==6.1.0rc1
+    apache-airflow-providers-apache-hive==4.1.0rc1
+    apache-airflow-providers-apache-livy==3.2.0rc1
     apache-airflow-providers-cncf-kubernetes>=4
-    apache-airflow-providers-databricks>=2.2.0
-    apache-airflow-providers-google>=8.1.0
+    apache-airflow-providers-databricks==3.4.0rc1
+    apache-airflow-providers-google==8.5.0rc1
     apache-airflow-providers-http
-    apache-airflow-providers-snowflake
+    apache-airflow-providers-snowflake==4.0.0rc1
     apache-airflow-providers-sftp
-    apache-airflow-providers-microsoft-azure
+    apache-airflow-providers-microsoft-azure==5.0.0rc1
     asyncssh>=2.12.0
     databricks-sql-connector>=2.0.4;python_version>='3.10'
     apache-airflow-providers-dbt-cloud>=2.1.0


### PR DESCRIPTION
Update RCs for new version of Providers created on November 15, 2022.
Not adding apache-airflow-providers-cncf-kubernetes==5.0.0rc3, due to the issue here: 
https://github.com/apache/airflow/issues/27674#issuecomment-1316417611