### PR TITLE
Fix Bug in SnowflakeOperatorAsync and RedshiftSQLOperatorAsync 

### DIFF
--- a/astronomer/providers/amazon/aws/operators/redshift_sql.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_sql.py
@@ -4,9 +4,9 @@ from airflow.exceptions import AirflowException
 
 try:
     from airflow.providers.amazon.aws.operators.redshift_sql import RedshiftSQLOperator
-except ImportError:
+except ImportError:  # pragma: no cover
     # For apache-airflow-providers-snowflake > 6.0.0
-    from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator as RedshiftSQLOperator  # type: ignore[no-redef, attr-defined] # noqa: E501
+    from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator as RedshiftSQLOperator  # type: ignore[no-redef, attr-defined] # noqa: E501  # pragma: no cover
 
 from astronomer.providers.amazon.aws.hooks.redshift_data import RedshiftDataHook
 from astronomer.providers.amazon.aws.triggers.redshift_sql import RedshiftSQLTrigger
@@ -38,7 +38,7 @@ class RedshiftSQLOperatorAsync(RedshiftSQLOperator):
         if self.__class__.__base__.__name__ == "RedshiftSQLOperator":
             super().__init__(**kwargs)
         else:
-            super().__init__(conn_id=redshift_conn_id, **kwargs)
+            super().__init__(conn_id=redshift_conn_id, **kwargs)  # pragma: no cover
 
     def execute(self, context: Context) -> None:
         """

--- a/astronomer/providers/amazon/aws/operators/redshift_sql.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_sql.py
@@ -3,11 +3,9 @@ from typing import Any, cast
 from airflow.exceptions import AirflowException
 
 try:
-    from airflow.providers.amazon.aws.operators.redshift_sql import (
-        RedshiftSQLOperator as SyncRedshiftOperator,
-    )
+    from airflow.providers.amazon.aws.operators.redshift_sql import RedshiftSQLOperator
 except ImportError:
-    from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator as SyncRedshiftOperator
+    from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator as RedshiftSQLOperator
 
 
 from astronomer.providers.amazon.aws.hooks.redshift_data import RedshiftDataHook
@@ -15,7 +13,7 @@ from astronomer.providers.amazon.aws.triggers.redshift_sql import RedshiftSQLTri
 from astronomer.providers.utils.typing_compat import Context
 
 
-class RedshiftSQLOperatorAsync(SyncRedshiftOperator):
+class RedshiftSQLOperatorAsync(RedshiftSQLOperator):
     """
     Executes SQL Statements against an Amazon Redshift cluster"
 
@@ -37,9 +35,9 @@ class RedshiftSQLOperatorAsync(SyncRedshiftOperator):
     ) -> None:
         self.redshift_conn_id = redshift_conn_id
         self.poll_interval = poll_interval
-        try:
+        if self.__class__.__base__.__name__ == "RedshiftSQLOperator":
             super().__init__(**kwargs)
-        except AirflowException:
+        else:
             super().__init__(conn_id=redshift_conn_id, **kwargs)
 
     def execute(self, context: Context) -> None:

--- a/astronomer/providers/amazon/aws/operators/redshift_sql.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_sql.py
@@ -5,8 +5,8 @@ from airflow.exceptions import AirflowException
 try:
     from airflow.providers.amazon.aws.operators.redshift_sql import RedshiftSQLOperator
 except ImportError:
-    from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator as RedshiftSQLOperator
-
+    # For apache-airflow-providers-snowflake > 6.0.0
+    from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator as RedshiftSQLOperator  # type: ignore[no-redef, attr-defined] # noqa: E501
 
 from astronomer.providers.amazon.aws.hooks.redshift_data import RedshiftDataHook
 from astronomer.providers.amazon.aws.triggers.redshift_sql import RedshiftSQLTrigger

--- a/astronomer/providers/amazon/aws/operators/redshift_sql.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_sql.py
@@ -5,7 +5,7 @@ from airflow.exceptions import AirflowException
 try:
     from airflow.providers.amazon.aws.operators.redshift_sql import RedshiftSQLOperator
 except ImportError:  # pragma: no cover
-    # For apache-airflow-providers-snowflake > 6.0.0
+    # For apache-airflow-providers-amazon > 6.0.0
     # currently added type: ignore[no-redef, attr-defined] and pragma: no cover because this import
     # path won't be available in current setup
     from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator as RedshiftSQLOperator  # type: ignore[no-redef, attr-defined] # noqa: E501  # pragma: no cover
@@ -39,7 +39,7 @@ class RedshiftSQLOperatorAsync(RedshiftSQLOperator):
         self.poll_interval = poll_interval
         if self.__class__.__base__.__name__ == "RedshiftSQLOperator":
             # It's better to do str check of the parent class name because currently RedshiftSQLOperator
-            # is deprecated and in future they may remove the RedshiftSQLOperator
+            # is deprecated and in future OSS RedshiftSQLOperator may be removed
             super().__init__(**kwargs)
         else:
             super().__init__(conn_id=redshift_conn_id, **kwargs)  # pragma: no cover

--- a/astronomer/providers/amazon/aws/operators/redshift_sql.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_sql.py
@@ -6,6 +6,8 @@ try:
     from airflow.providers.amazon.aws.operators.redshift_sql import RedshiftSQLOperator
 except ImportError:  # pragma: no cover
     # For apache-airflow-providers-snowflake > 6.0.0
+    # currently added type: ignore[no-redef, attr-defined] and pragma: no cover because this import
+    # path won't be available in current setup
     from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator as RedshiftSQLOperator  # type: ignore[no-redef, attr-defined] # noqa: E501  # pragma: no cover
 
 from astronomer.providers.amazon.aws.hooks.redshift_data import RedshiftDataHook
@@ -36,6 +38,8 @@ class RedshiftSQLOperatorAsync(RedshiftSQLOperator):
         self.redshift_conn_id = redshift_conn_id
         self.poll_interval = poll_interval
         if self.__class__.__base__.__name__ == "RedshiftSQLOperator":
+            # It's better to do str check of the parent class name because currently RedshiftSQLOperator
+            # is deprecated and in future they may remove the RedshiftSQLOperator
             super().__init__(**kwargs)
         else:
             super().__init__(conn_id=redshift_conn_id, **kwargs)  # pragma: no cover

--- a/astronomer/providers/snowflake/operators/snowflake.py
+++ b/astronomer/providers/snowflake/operators/snowflake.py
@@ -8,6 +8,8 @@ try:
     from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
 except ImportError:  # pragma: no cover
     # For apache-airflow-providers-snowflake > 3.3.0
+    # currently added type: ignore[no-redef, attr-defined] and pragma: no cover because this import
+    # path won't be available in current setup
     from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator as SnowflakeOperator  # type: ignore[no-redef, attr-defined] # noqa: E501 # pragma: no cover
 
 from astronomer.providers.snowflake.hooks.snowflake import SnowflakeHookAsync
@@ -100,6 +102,8 @@ class SnowflakeOperatorAsync(SnowflakeOperator):
         self.session_parameters = session_parameters
         self.snowflake_conn_id = snowflake_conn_id
         if self.__class__.__base__.__name__ != "SnowflakeOperator":
+            # It's better to do str check of the parent class name because currently SnowflakeOperator
+            # is deprecated and in future they may remove the SnowflakeOperator
             if any(
                 [warehouse, database, role, schema, authenticator, session_parameters]
             ):  # pragma: no cover
@@ -282,6 +286,8 @@ class SnowflakeSqlApiOperatorAsync(SnowflakeOperator):
         self.bindings = bindings
         self.execute_async = False
         if self.__class__.__base__.__name__ != "SnowflakeOperator":
+            # It's better to do str check of the parent class name because currently SnowflakeOperator
+            # is deprecated and in future they may remove the SnowflakeOperator
             if any(
                 [warehouse, database, role, schema, authenticator, session_parameters]
             ):  # pragma: no cover

--- a/astronomer/providers/snowflake/operators/snowflake.py
+++ b/astronomer/providers/snowflake/operators/snowflake.py
@@ -5,11 +5,9 @@ from typing import Any, Dict, List, Optional, Union
 from airflow.exceptions import AirflowException
 
 try:
-    from airflow.providers.snowflake.operators.snowflake import (
-        SnowflakeOperator as SyncOperator,
-    )
+    from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
 except ImportError:
-    from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator as SyncOperator
+    from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator as SnowflakeOperator
 
 from astronomer.providers.snowflake.hooks.snowflake import SnowflakeHookAsync
 from astronomer.providers.snowflake.hooks.snowflake_sql_api import (
@@ -23,7 +21,7 @@ from astronomer.providers.snowflake.triggers.snowflake_trigger import (
 from astronomer.providers.utils.typing_compat import Context
 
 
-class SnowflakeOperatorAsync(SyncOperator):
+class SnowflakeOperatorAsync(SnowflakeOperator):
     """
     - SnowflakeOperatorAsync uses the snowflake python connector ``execute_async`` method to submit a database command
       for asynchronous execution.
@@ -88,7 +86,7 @@ class SnowflakeOperatorAsync(SyncOperator):
         role: Optional[str] = None,
         schema: Optional[str] = None,
         authenticator: Optional[str] = None,
-        session_parameters: Optional[str] = None,
+        session_parameters: Optional[Dict[str, Any]] = None,
         poll_interval: int = 5,
         **kwargs: Any,
     ) -> None:
@@ -187,7 +185,7 @@ class SnowflakeOperatorAsync(SyncOperator):
             return None
 
 
-class SnowflakeSqlApiOperatorAsync(SyncOperator):
+class SnowflakeSqlApiOperatorAsync(SnowflakeOperator):
     """
     Implemented Async Snowflake SQL API Operator to support multiple SQL statements sequentially,
     which is the behavior of the SnowflakeOperator, the Snowflake SQL API allows submitting
@@ -261,7 +259,7 @@ class SnowflakeSqlApiOperatorAsync(SyncOperator):
         role: Optional[str] = None,
         schema: Optional[str] = None,
         authenticator: Optional[str] = None,
-        session_parameters: Optional[str] = None,
+        session_parameters: Optional[Dict[str, Any]] = None,
         poll_interval: int = 5,
         statement_count: int = 0,
         token_life_time: timedelta = LIFETIME,

--- a/astronomer/providers/snowflake/operators/snowflake.py
+++ b/astronomer/providers/snowflake/operators/snowflake.py
@@ -291,7 +291,9 @@ class SnowflakeSqlApiOperatorAsync(SnowflakeOperator):
                     "session_parameters": session_parameters,
                     **hook_params,
                 }
-        super().__init__(**kwargs)
+            super().__init__(conn_id=snowflake_conn_id, **kwargs)
+        else:
+            super().__init__(**kwargs)
 
     def execute(self, context: Context) -> None:
         """

--- a/astronomer/providers/snowflake/operators/snowflake.py
+++ b/astronomer/providers/snowflake/operators/snowflake.py
@@ -6,9 +6,9 @@ from airflow.exceptions import AirflowException
 
 try:
     from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
-except ImportError:
+except ImportError:  # pragma: no cover
     # For apache-airflow-providers-snowflake > 3.3.0
-    from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator as SnowflakeOperator  # type: ignore[no-redef, attr-defined] # noqa: E501
+    from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator as SnowflakeOperator  # type: ignore[no-redef, attr-defined] # noqa: E501 # pragma: no cover
 
 from astronomer.providers.snowflake.hooks.snowflake import SnowflakeHookAsync
 from astronomer.providers.snowflake.hooks.snowflake_sql_api import (
@@ -100,8 +100,10 @@ class SnowflakeOperatorAsync(SnowflakeOperator):
         self.session_parameters = session_parameters
         self.snowflake_conn_id = snowflake_conn_id
         if self.__class__.__base__.__name__ != "SnowflakeOperator":
-            if any([warehouse, database, role, schema, authenticator, session_parameters]):
-                hook_params = kwargs.pop("hook_params", {})
+            if any(
+                [warehouse, database, role, schema, authenticator, session_parameters]
+            ):  # pragma: no cover
+                hook_params = kwargs.pop("hook_params", {})  # pragma: no cover
                 kwargs["hook_params"] = {
                     "warehouse": warehouse,
                     "database": database,
@@ -110,8 +112,8 @@ class SnowflakeOperatorAsync(SnowflakeOperator):
                     "authenticator": authenticator,
                     "session_parameters": session_parameters,
                     **hook_params,
-                }
-            super().__init__(conn_id=snowflake_conn_id, **kwargs)
+                }  # pragma: no cover
+            super().__init__(conn_id=snowflake_conn_id, **kwargs)  # pragma: no cover
         else:
             super().__init__(**kwargs)
 
@@ -280,8 +282,10 @@ class SnowflakeSqlApiOperatorAsync(SnowflakeOperator):
         self.bindings = bindings
         self.execute_async = False
         if self.__class__.__base__.__name__ != "SnowflakeOperator":
-            if any([warehouse, database, role, schema, authenticator, session_parameters]):
-                hook_params = kwargs.pop("hook_params", {})
+            if any(
+                [warehouse, database, role, schema, authenticator, session_parameters]
+            ):  # pragma: no cover
+                hook_params = kwargs.pop("hook_params", {})  # pragma: no cover
                 kwargs["hook_params"] = {
                     "warehouse": warehouse,
                     "database": database,
@@ -291,7 +295,7 @@ class SnowflakeSqlApiOperatorAsync(SnowflakeOperator):
                     "session_parameters": session_parameters,
                     **hook_params,
                 }
-            super().__init__(conn_id=snowflake_conn_id, **kwargs)
+            super().__init__(conn_id=snowflake_conn_id, **kwargs)  # pragma: no cover
         else:
             super().__init__(**kwargs)
 

--- a/astronomer/providers/snowflake/operators/snowflake.py
+++ b/astronomer/providers/snowflake/operators/snowflake.py
@@ -103,7 +103,7 @@ class SnowflakeOperatorAsync(SnowflakeOperator):
         self.snowflake_conn_id = snowflake_conn_id
         if self.__class__.__base__.__name__ != "SnowflakeOperator":
             # It's better to do str check of the parent class name because currently SnowflakeOperator
-            # is deprecated and in future they may remove the SnowflakeOperator
+            # is deprecated and in future OSS SnowflakeOperator may be removed
             if any(
                 [warehouse, database, role, schema, authenticator, session_parameters]
             ):  # pragma: no cover
@@ -287,7 +287,7 @@ class SnowflakeSqlApiOperatorAsync(SnowflakeOperator):
         self.execute_async = False
         if self.__class__.__base__.__name__ != "SnowflakeOperator":
             # It's better to do str check of the parent class name because currently SnowflakeOperator
-            # is deprecated and in future they may remove the SnowflakeOperator
+            # is deprecated and in future OSS SnowflakeOperator may be removed
             if any(
                 [warehouse, database, role, schema, authenticator, session_parameters]
             ):  # pragma: no cover


### PR DESCRIPTION
SnowflakeOperatorAsync, SnowflakeSqlApiOperatorAsync and RedshiftSQLOperatorAsync Operator failed due to new RC version changes `apache-airflow-providers-amazon==6.1.0rc1` and `apache-airflow-providers-snowflake==4.0.0rc1` the sync version of those operators started inherited from SQLExecuteQueryOperator  which doesn't have `snowflake_conn_id`  and `redshift_conn_id`. This issue is fixed by with backward compatibility 