### PR TITLE
Fix issue in SnowflakeOperatorAsync, SnowflakeSqlApiOperatorAsync  and RedshiftSQLOperatorAsync

### DIFF
--- a/astronomer/providers/amazon/aws/operators/redshift_sql.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_sql.py
@@ -24,9 +24,11 @@ class RedshiftSQLOperatorAsync(RedshiftSQLOperator):
     def __init__(
         self,
         *,
+        redshift_conn_id: str = "redshift_default",
         poll_interval: float = 5,
         **kwargs: Any,
     ) -> None:
+        self.redshift_conn_id = redshift_conn_id
         self.poll_interval = poll_interval
         super().__init__(**kwargs)
 

--- a/astronomer/providers/snowflake/operators/snowflake.py
+++ b/astronomer/providers/snowflake/operators/snowflake.py
@@ -73,8 +73,27 @@ class SnowflakeOperatorAsync(SnowflakeOperator):
     :param poll_interval: the interval in seconds to poll the query
     """  # noqa
 
-    def __init__(self, *, poll_interval: int = 5, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *,
+        snowflake_conn_id: str = "snowflake_default",
+        warehouse: Optional[str] = None,
+        database: Optional[str] = None,
+        role: Optional[str] = None,
+        schema: Optional[str] = None,
+        authenticator: Optional[str] = None,
+        session_parameters: Optional[Dict[str, Any]] = None,
+        poll_interval: int = 5,
+        **kwargs: Any,
+    ) -> None:
         self.poll_interval = poll_interval
+        self.snowflake_conn_id = snowflake_conn_id
+        self.warehouse = warehouse
+        self.database = database
+        self.role = role
+        self.schema = schema
+        self.authenticator = authenticator
+        self.session_parameters = session_parameters
         super().__init__(**kwargs)
 
     def get_db_hook(self) -> SnowflakeHookAsync:
@@ -215,6 +234,13 @@ class SnowflakeSqlApiOperatorAsync(SnowflakeOperator):
     def __init__(
         self,
         *,
+        snowflake_conn_id: str = "snowflake_default",
+        warehouse: Optional[str] = None,
+        database: Optional[str] = None,
+        role: Optional[str] = None,
+        schema: Optional[str] = None,
+        authenticator: Optional[str] = None,
+        session_parameters: Optional[Dict[str, Any]] = None,
         poll_interval: int = 5,
         statement_count: int = 0,
         token_life_time: timedelta = LIFETIME,
@@ -222,12 +248,20 @@ class SnowflakeSqlApiOperatorAsync(SnowflakeOperator):
         bindings: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
+
+        self.warehouse = warehouse
+        self.database = database
+        self.role = role
+        self.schema = schema
+        self.authenticator = authenticator
+        self.session_parameters = session_parameters
         self.poll_interval = poll_interval
         self.statement_count = statement_count
         self.token_life_time = token_life_time
         self.token_renewal_delta = token_renewal_delta
         self.bindings = bindings
         self.execute_async = False
+        self.snowflake_conn_id = snowflake_conn_id
         super().__init__(**kwargs)
 
     def execute(self, context: Context) -> None:


### PR DESCRIPTION
SnowflakeOperatorAsync, SnowflakeSqlApiOperatorAsync and RedshiftSQLOperatorAsync Operator failed due to new RC version changes apache-airflow-providers-amazon==6.1.0rc1 and apache-airflow-providers-snowflake==4.0.0rc1 the sync version of those operators started inherited from SQLExecuteQueryOperator which doesn't have snowflake_conn_id and redshift_conn_id. This issue is fixed by with backward compatibility