### PR TITLE
Set auto commit to true by default in SnowflakeOperatorAsync

### DIFF
--- a/astronomer/providers/snowflake/operators/snowflake.py
+++ b/astronomer/providers/snowflake/operators/snowflake.py
@@ -83,6 +83,7 @@ class SnowflakeOperatorAsync(SnowflakeOperator):
     def __init__(
         self,
         *,
+        autocommit: bool = True,
         snowflake_conn_id: str = "snowflake_default",
         warehouse: Optional[str] = None,
         database: Optional[str] = None,
@@ -93,6 +94,7 @@ class SnowflakeOperatorAsync(SnowflakeOperator):
         poll_interval: int = 5,
         **kwargs: Any,
     ) -> None:
+        self.autocommit = autocommit
         self.poll_interval = poll_interval
         self.warehouse = warehouse
         self.database = database


### PR DESCRIPTION
There was an issue `SnowflakeOperatorAsync` with the auto-commit option which was set to false by default in `SQLExecuteQueryOperator` the latest `apache-airflow-providers-snowflake==4.0.0rc1` was inherited from the `SQLExecuteQueryOperator` so now it is set to True by default in `SnowflakeOperatorAsync` 