### PR TITLE
Fix ADF broken docs

### DIFF
--- a/docs/providers/microsoft/index.rst
+++ b/docs/providers/microsoft/index.rst
@@ -12,4 +12,4 @@ Microsoft Example DAG
 
 * `WASB Blob Sensors <azure/sensors/wasb.html>`_
 * `ADF Operators <azure/operators/data_factory.html>`_
-* `ADF Sensors <azure/Sensors/data_factory.html>`_
+* `ADF Sensors <azure/sensors/data_factory.html>`_


### PR DESCRIPTION
Fix the broken readthedoc https://astronomer-providers.readthedocs.io/en/stable/providers/microsoft/azure/Sensors/data_factory.html

Before
<img width="1004" alt="Screenshot 2022-11-24 at 10 12 49 AM" src="https://user-images.githubusercontent.com/98807258/203711283-aa7b1db0-9855-4c81-8527-fbc8bc29be55.png">

After
<img width="1009" alt="Screenshot 2022-11-24 at 12 06 06 PM" src="https://user-images.githubusercontent.com/98807258/203711392-c9e8b23e-afbe-42bf-9924-300c529e1b86.png">


closes: https://github.com/astronomer/astronomer-providers/issues/778