### PR TITLE
Added poke interval for the S3KeyTrigger

### DIFF
--- a/astronomer/providers/amazon/aws/sensors/s3.py
+++ b/astronomer/providers/amazon/aws/sensors/s3.py
@@ -87,6 +87,7 @@ class S3KeySensorAsync(BaseSensorOperator):
                 check_fn=self.check_fn,
                 aws_conn_id=self.aws_conn_id,
                 verify=self.verify,
+                poke_interval=self.poke_interval,
             ),
             method_name="execute_complete",
         )

--- a/astronomer/providers/amazon/aws/triggers/s3.py
+++ b/astronomer/providers/amazon/aws/triggers/s3.py
@@ -31,6 +31,7 @@ class S3KeyTrigger(BaseTrigger):
         wildcard_match: bool = False,
         check_fn: Optional[Callable[..., bool]] = None,
         aws_conn_id: str = "aws_default",
+        poke_interval: float = 5.0,
         **hook_params: Any,
     ):
         super().__init__()
@@ -40,6 +41,7 @@ class S3KeyTrigger(BaseTrigger):
         self.check_fn = check_fn
         self.aws_conn_id = aws_conn_id
         self.hook_params = hook_params
+        self.poke_interval = poke_interval
 
     def serialize(self) -> Tuple[str, Dict[str, Any]]:
         """Serialize S3KeyTrigger arguments and classpath."""
@@ -52,6 +54,7 @@ class S3KeyTrigger(BaseTrigger):
                 "check_fn": self.check_fn,
                 "aws_conn_id": self.aws_conn_id,
                 "hook_params": self.hook_params,
+                "poke_interval": self.poke_interval,
             },
         )
 
@@ -68,6 +71,7 @@ class S3KeyTrigger(BaseTrigger):
                             client, self.bucket_name, self.bucket_key, self.wildcard_match
                         )
                         yield TriggerEvent({"status": "success", "s3_objects": s3_objects})
+                    await asyncio.sleep(self.poke_interval)
 
         except Exception as e:
             yield TriggerEvent({"status": "error", "message": str(e)})

--- a/tests/amazon/aws/triggers/test_s3_triggers.py
+++ b/tests/amazon/aws/triggers/test_s3_triggers.py
@@ -26,6 +26,7 @@ def test_s3_key_trigger_serialization():
         "aws_conn_id": "aws_default",
         "hook_params": {},
         "check_fn": None,
+        "poke_interval": 5.0,
     }
 
 

--- a/tests/amazon/aws/triggers/test_s3_triggers.py
+++ b/tests/amazon/aws/triggers/test_s3_triggers.py
@@ -47,6 +47,23 @@ async def test_s3_key_trigger_run(mock_client):
 
 
 @pytest.mark.asyncio
+@mock.patch("astronomer.providers.amazon.aws.triggers.s3.S3HookAsync.check_key")
+@mock.patch("astronomer.providers.amazon.aws.triggers.s3.S3HookAsync.get_client_async")
+async def test_s3_key_trigger_pending(mock_client, mock_check_key):
+    """
+    Test if the task is run is in trigger successfully and set check_key to return false.
+    """
+    mock_check_key.return_value = False
+    trigger = S3KeyTrigger(bucket_key="s3://test_bucket/file", bucket_name="test_bucket")
+    with mock_client:
+        task = asyncio.create_task(trigger.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
+
+
+@pytest.mark.asyncio
 @mock.patch("astronomer.providers.amazon.aws.triggers.s3.S3HookAsync.get_client_async")
 async def test_s3_key_trigger_run_exception(mock_client):
     """Test if the task is run is in case of exception."""


### PR DESCRIPTION
Added `poke_interval` for the S3KeyTrigger. Adding poke_interval makes the trigger sleep for seconds to avoid the trigger process becoming overwhelmed when sensing a large number of files in s3.



closes: #750 