### PR TITLE
Add 'DO NOT MERGE' prefix for RC test PRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test-rc-deps: ## Test providers RC by building an image with given dependencies 
 	git add setup.cfg
 	git commit -m "Update setup.cfg to use RC provider packages"
 	git push origin $(branch_name)
-	gh pr create --base "main" --title "Test RC provider packages" --fill
+	gh pr create --base "main" --title "[DO NOT MERGE] Test RC provider packages" --fill
 
 shell:  ## Runs a shell within a container (Allows interactive session)
 	docker compose -f dev/docker-compose.yaml run --rm airflow-scheduler bash


### PR DESCRIPTION
Add `'DO NOT MERGE'` prefix to PRs created from RC test make target so that
we do not merge the PR mistakenly.