### PR TITLE
Fix return value of snowflakeOperatorAsync

### DIFF
--- a/astronomer/providers/snowflake/example_dags/example_snowflake.py
+++ b/astronomer/providers/snowflake/example_dags/example_snowflake.py
@@ -62,7 +62,12 @@ with DAG(
         sql=SQL_MULTIPLE_STMTS,
     )
 
+    snowflake_op_sql_select_stmts = SnowflakeOperatorAsync(
+        task_id="snowflake_op_sql_select_stmts", sql=SNOWFLAKE_SLACK_SQL, return_last=False
+    )
+
     (
         snowflake_op_sql_str
         >> [snowflake_op_with_params, snowflake_op_sql_list, snowflake_op_sql_multiple_stmts]
+        >> snowflake_op_sql_select_stmts
     )

--- a/astronomer/providers/snowflake/operators/snowflake.py
+++ b/astronomer/providers/snowflake/operators/snowflake.py
@@ -194,7 +194,7 @@ class SnowflakeOperatorAsync(SnowflakeOperator):
             elif "status" in event and event["status"] == "success":
                 hook = self.get_db_hook()
                 qids = typing.cast(List[str], event["query_ids"])
-                results = hook.check_query_output(qids, self.handler)
+                results = hook.check_query_output(qids, self.handler, self.return_last)
                 self.log.info("%s completed successfully.", self.task_id)
                 if self.do_xcom_push:
                     return results


### PR DESCRIPTION
Passed the `return_last` parameter to hook `check_query_output` which is now the operator params, this param helps the user to return the result of only the last statement output or all statement output. By default, it is set to `True`, which will return the last value in case of multiple query execution.