### PR TITLE
Support assume role for AWS base async hook

### DIFF
--- a/astronomer/providers/amazon/aws/hooks/base_aws.py
+++ b/astronomer/providers/amazon/aws/hooks/base_aws.py
@@ -13,9 +13,8 @@ class AwsBaseHookAsync(AwsBaseHook):
 
     .. note::
         AwsBaseHookAsync uses aiobotocore to create asynchronous S3 hooks. Hence, AwsBaseHookAsync
-        only supports the authentication mechanism that aiobotocore supports. The ability to assume
-        roles provided in the Airflow connection extra args via aiobotocore is not supported by the
-        library yet.
+        only supports the authentication mechanism that aiobotocore supports. Currently, AwsBaseHookAsync supports
+        only AWS STS client method ``assume_role`` provided in the Airflow connection extra args via aiobotocore.
 
     :param aws_conn_id: The Airflow connection used for AWS credentials.
         If this is None or empty then the default boto3 behaviour is used. If

--- a/astronomer/providers/amazon/aws/hooks/base_aws.py
+++ b/astronomer/providers/amazon/aws/hooks/base_aws.py
@@ -85,4 +85,4 @@ class AwsBaseHookAsync(AwsBaseHook):
                     **conn_config.assume_role_kwargs,
                 )
                 return response["Credentials"]
-            return None
+            return None  # pragma: no cover

--- a/astronomer/providers/amazon/aws/hooks/base_aws.py
+++ b/astronomer/providers/amazon/aws/hooks/base_aws.py
@@ -77,11 +77,12 @@ class AwsBaseHookAsync(AwsBaseHook):
             aws_access_key_id=conn_config.aws_access_key_id,
             aws_secret_access_key=conn_config.aws_secret_access_key,
         ) as client:
+            return_response = None
             if conn_config.assume_role_method == "assume_role" or conn_config.assume_role_method is None:
                 response: Dict[str, Dict[str, str]] = await client.assume_role(
                     RoleArn=conn_config.role_arn,
                     RoleSessionName="RoleSession",
                     **conn_config.assume_role_kwargs,
                 )
-                return response["Credentials"]
-            return None  # pragma: no cover
+                return_response = response["Credentials"]
+            return return_response

--- a/tests/amazon/aws/hooks/test_s3_hooks.py
+++ b/tests/amazon/aws/hooks/test_s3_hooks.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 from aiobotocore.session import ClientCreatorContext
 from airflow.models.connection import Connection
+from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper
 from botocore.exceptions import ClientError
 
 from astronomer.providers.amazon.aws.hooks.base_aws import AwsBaseHookAsync
@@ -53,6 +54,62 @@ async def test_aws_base_hook_async_get_client_async_with_aws_session(mock_get_co
     response = await aws_base_hook_async_obj.get_client_async()
 
     assert isinstance(response, ClientCreatorContext)
+
+
+@pytest.mark.asyncio
+@mock.patch("astronomer.providers.amazon.aws.hooks.base_aws.AwsBaseHookAsync.get_connection")
+@mock.patch("astronomer.providers.amazon.aws.hooks.base_aws.AwsBaseHookAsync.get_role_credentials")
+async def test_aws_base_hook_async_get_client_async_with_role_arn(mock_role_credentials, mock_get_connection):
+    mock_conn = Connection(
+        login="test",
+        password="",
+        extra=json.dumps({"region_name": "test", "role_arn": "arn:aws:iam::test:role/test"}),
+    )
+    mock_get_connection.return_value = mock_conn
+    mock_role_credentials.return_value = {
+        "AccessKeyId": "test",
+        "SecretAccessKey": "test",
+        "SessionToken": "test",
+    }
+    aws_base_hook_async_obj = AwsBaseHookAsync(client_type="S3", resource_type="S3", region_name=None)
+    response = await aws_base_hook_async_obj.get_client_async()
+
+    assert isinstance(response, ClientCreatorContext)
+
+
+@pytest.mark.asyncio
+@mock.patch("aiobotocore.session.get_session")
+@mock.patch("aiobotocore.session.ClientCreatorContext")
+@mock.patch("astronomer.providers.amazon.aws.hooks.base_aws.AwsBaseHookAsync.get_connection")
+async def test_get_role_credentials(mock_get_connection, mock_client_creator, mock_session):
+    mock_conn = Connection(
+        login="test",
+        password="",
+        extra=json.dumps(
+            {
+                "region_name": "test",
+                "role_arn": "arn:aws:iam::test:role/test",
+                "assume_role_method": "assume_role",
+            }
+        ),
+    )
+    mock_get_connection.return_value = mock_conn
+    aws_base_hook_async_obj = AwsBaseHookAsync(client_type="S3", resource_type="S3", region_name=None)
+    conn_config = AwsConnectionWrapper(
+        conn=mock_get_connection,
+        region_name=aws_base_hook_async_obj.region_name,
+        botocore_config=aws_base_hook_async_obj.config,
+        verify=aws_base_hook_async_obj.verify,
+    )
+
+    mock_session.create_client = mock_client_creator
+    mock_client_creator.return_value.__aenter__.return_value.assume_role.return_value = {
+        "Credentials": {"AccessKeyId": "test", "SecretAccessKey": "test", "SessionToken": "test"}
+    }
+    print("conn_config ", conn_config)
+    response = await aws_base_hook_async_obj.get_role_credentials(mock_session, conn_config)
+    print("response ", response)
+    assert response == {"AccessKeyId": "test", "SecretAccessKey": "test", "SessionToken": "test"}
 
 
 @mock.patch("astronomer.providers.amazon.aws.triggers.s3.S3HookAsync.get_client_async")

--- a/tests/amazon/aws/hooks/test_s3_hooks.py
+++ b/tests/amazon/aws/hooks/test_s3_hooks.py
@@ -101,14 +101,11 @@ async def test_get_role_credentials(mock_get_connection, mock_client_creator, mo
         botocore_config=aws_base_hook_async_obj.config,
         verify=aws_base_hook_async_obj.verify,
     )
-
     mock_session.create_client = mock_client_creator
     mock_client_creator.return_value.__aenter__.return_value.assume_role.return_value = {
         "Credentials": {"AccessKeyId": "test", "SecretAccessKey": "test", "SessionToken": "test"}
     }
-    print("conn_config ", conn_config)
     response = await aws_base_hook_async_obj.get_role_credentials(mock_session, conn_config)
-    print("response ", response)
     assert response == {"AccessKeyId": "test", "SecretAccessKey": "test", "SessionToken": "test"}
 
 


### PR DESCRIPTION
Previously `aiobotocore` doesn't support assume role with `role_arn`. Now added support for assuming role option in `AwsBaseHookAsync`

closes: #786 