### PR TITLE
Fix license broken link in readthedocs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,4 +189,4 @@ Limitations
 License
 -------
 
-`Apache License 2.0 <LICENSE>`_
+`Apache License 2.0 <https://github.com/astronomer/astronomer-providers/blob/main/LICENSE>`_


### PR DESCRIPTION
currently, the license docs link is broken in the readtheodcs https://astronomer-providers.readthedocs.io/en/stable/ https://astronomer-providers.readthedocs.io/en/stable/LICENSE . Here, I'm updating the relative path with the full GitHub path