### PR TITLE
Fix ``KubernetesPodOperatorAsync`` to consider kubernetes connection id and details in trigger

### DIFF
--- a/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -59,7 +59,7 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
             )
         super().defer(
             trigger=WaitContainerTrigger(
-                kubernetes_conn_id=None,
+                kubernetes_conn_id=self.kubernetes_conn_id,
                 hook_params={
                     "cluster_context": self.cluster_context,
                     "config_file": self.config_file,


### PR DESCRIPTION
`kube_config_path` or `kube_config` (JSON) from Kubernetes connection was not consider in `KubernetesPodOperatorAsync`. Because the connection id is set to None in the trigger, So now it is fixed to consider the Kubernetes connection id and details in trigger.

closes: #745 