### PR TITLE
ExternalTaskSensorAsync to support poke_interval

### DIFF
--- a/astronomer/providers/core/sensors/external_task.py
+++ b/astronomer/providers/core/sensors/external_task.py
@@ -56,6 +56,7 @@ class ExternalTaskSensorAsync(ExternalTaskSensor):  # noqa: D101
                     task_id=self.external_task_id,
                     states=self.allowed_states + self.failed_states,
                     execution_dates=execution_dates,
+                    poll_interval=self.poke_interval,
                 ),
                 method_name="execute_complete",
             )

--- a/astronomer/providers/core/sensors/external_task.py
+++ b/astronomer/providers/core/sensors/external_task.py
@@ -18,6 +18,14 @@ if TYPE_CHECKING:
 
 
 class ExternalTaskSensorAsync(ExternalTaskSensor):  # noqa: D101
+    def __init__(
+        self,
+        poke_interval: float = 5.0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.poke_interval = poke_interval
+
     def execute(self, context: Context) -> None:
         """Correctly identify which trigger to execute, and defer execution as expected."""
         execution_dates = self.get_execution_dates(context)
@@ -36,6 +44,7 @@ class ExternalTaskSensorAsync(ExternalTaskSensor):  # noqa: D101
                     # then work out which result we have in execute_complete.
                     states=self.allowed_states + self.failed_states,
                     execution_dates=execution_dates,
+                    poll_interval=self.poke_interval,
                 ),
                 method_name="execute_complete",
             )


### PR DESCRIPTION
I've recently started onboarding as the astronomer provider async sensors, I'm really appreciative you've made these available publicly!

One thing I noticed is that the FileSensorAsync supports poke_interval but the ExternalTaskSensorAsync does not and runs as a fixed 5 seconds. While this isn't an issue at the moment as we only run a few external task sensors as we scale up I wouldn't want 100s running every 5 seconds.

I notice that both DagStateTrigger and TaskStateTrigger support poll_interval.

closes #817 