### PR TITLE
Fix `get_logs`, `pod cleanup` and `XCom push` in ``GKEStartPodOperatorAsync``

### DIFF
--- a/astronomer/providers/google/cloud/operators/kubernetes_engine.py
+++ b/astronomer/providers/google/cloud/operators/kubernetes_engine.py
@@ -73,6 +73,7 @@ class GKEStartPodOperatorAsync(KubernetesPodOperator):
         regional: bool = False,
         poll_interval: float = 5,
         logging_interval: Optional[int] = None,
+        do_xcom_push: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -87,6 +88,7 @@ class GKEStartPodOperatorAsync(KubernetesPodOperator):
         self.pod_namespace: str = ""
         self.poll_interval = poll_interval
         self.logging_interval = logging_interval
+        self.do_xcom_push = do_xcom_push
 
     def _get_or_create_pod(self, context: Context) -> None:
         """A wrapper to fetch GKE config and get or create a pod"""
@@ -198,8 +200,8 @@ class GKEStartPodOperatorAsync(KubernetesPodOperator):
             pod=self.pod,
             remote_pod=remote_pod,
         )
-        ti = context["ti"]
-        ti.xcom_push(key="pod_name", value=self.pod.metadata.name)
-        ti.xcom_push(key="pod_namespace", value=self.pod.metadata.namespace)
         if self.do_xcom_push:
+            ti = context["ti"]
+            ti.xcom_push(key="pod_name", value=self.pod.metadata.name)
+            ti.xcom_push(key="pod_namespace", value=self.pod.metadata.namespace)
             return result

--- a/astronomer/providers/google/cloud/operators/kubernetes_engine.py
+++ b/astronomer/providers/google/cloud/operators/kubernetes_engine.py
@@ -154,7 +154,6 @@ class GKEStartPodOperatorAsync(KubernetesPodOperator):
         grab the latest logs and defer back to the trigger again.
         """
         remote_pod = None
-        print("evenet ", event)
         self.raise_for_trigger_status(event)
         try:
             with GKEStartPodOperator.get_gke_config_file(

--- a/astronomer/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/astronomer/providers/google/cloud/triggers/kubernetes_engine.py
@@ -118,8 +118,20 @@ class GKEStartPodTrigger(WaitContainerTrigger):
                 async with await hook.get_api_client_async() as api_client:
                     v1_api = CoreV1Api(api_client)
                     state = await self.wait_for_pod_start(v1_api)
-                    if state in PodPhase.terminal_states:
-                        event = TriggerEvent({"status": "done"})
+                    print("state ", state)
+                    if state == PodPhase.SUCCEEDED:
+                        event = TriggerEvent(
+                            {"status": "done", "namespace": self.namespace, "pod_name": self.name}
+                        )
+                    elif state == PodPhase.FAILED:
+                        event = TriggerEvent(
+                            {
+                                "status": "failed",
+                                "namespace": self.namespace,
+                                "pod_name": self.name,
+                                "description": "Failed to start pod operator",
+                            }
+                        )
                     else:
                         event = await self.wait_for_container_completion(v1_api)
                 yield event

--- a/astronomer/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/astronomer/providers/google/cloud/triggers/kubernetes_engine.py
@@ -118,7 +118,6 @@ class GKEStartPodTrigger(WaitContainerTrigger):
                 async with await hook.get_api_client_async() as api_client:
                     v1_api = CoreV1Api(api_client)
                     state = await self.wait_for_pod_start(v1_api)
-                    print("state ", state)
                     if state == PodPhase.SUCCEEDED:
                         event = TriggerEvent(
                             {"status": "done", "namespace": self.namespace, "pod_name": self.name}

--- a/tests/cncf/kubernetes/triggers/test_wait_container.py
+++ b/tests/cncf/kubernetes/triggers/test_wait_container.py
@@ -137,7 +137,9 @@ class TestWaitContainerTrigger:
             poll_interval=2,
         )
 
-        assert await trigger.run().__anext__() == TriggerEvent({"status": "done"})
+        assert await trigger.run().__anext__() == TriggerEvent(
+            {"status": "done", "namespace": mock.ANY, "pod_name": mock.ANY}
+        )
         wait_completion.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -181,7 +183,9 @@ class TestWaitContainerTrigger:
             poll_interval=2,
         )
 
-        assert await trigger.run().__anext__() == TriggerEvent({"status": "done"})
+        assert await trigger.run().__anext__() == TriggerEvent(
+            {"status": "done", "namespace": mock.ANY, "pod_name": mock.ANY}
+        )
         wait_completion.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -189,7 +193,7 @@ class TestWaitContainerTrigger:
         "logging_interval, exp_event",
         [
             param(0, {"status": "running", "last_log_time": DateTime(2022, 1, 1)}, id="short_interval"),
-            param(None, {"status": "done"}, id="no_interval"),
+            param(None, {"status": "done", "namespace": mock.ANY, "pod_name": mock.ANY}, id="no_interval"),
         ],
     )
     @mock.patch(READ_NAMESPACED_POD_PATH, new=get_read_pod_mock_containers([1, 1, None, None]))

--- a/tests/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/google/cloud/operators/test_kubernetes_engine.py
@@ -1,16 +1,25 @@
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodLoggingStatus
 from kubernetes.client import models as k8s
 from kubernetes.client.models.v1_object_meta import V1ObjectMeta
 
+from astronomer.providers.cncf.kubernetes.operators.kubernetes_pod import (
+    PodNotFoundException,
+)
+from astronomer.providers.cncf.kubernetes.triggers.wait_container import (
+    PodLaunchTimeoutException,
+)
 from astronomer.providers.google.cloud.operators.kubernetes_engine import (
     GKEStartPodOperatorAsync,
 )
 from astronomer.providers.google.cloud.triggers.kubernetes_engine import (
     GKEStartPodTrigger,
 )
+from tests.utils.airflow_util import create_context
 
 PROJECT_ID = "astronomer-***-providers"
 LOCATION = "us-west1"
@@ -82,8 +91,12 @@ def test_execute(mock__get_or_create_pod):
     assert isinstance(exc.value.trigger, GKEStartPodTrigger), "Trigger is not a GKEStartPodTrigger"
 
 
-def test_execute_complete_success():
+@mock.patch(
+    "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.trigger_reentry"
+)
+def test_execute_complete_success(mock_trigger_reentry):
     """assert that execute_complete_success log correct message when a task succeed"""
+    mock_trigger_reentry.return_value = {}
     operator = GKEStartPodOperatorAsync(
         task_id="start_pod",
         project_id=PROJECT_ID,
@@ -94,9 +107,7 @@ def test_execute_complete_success():
         image="ubuntu",
         gcp_conn_id=GCP_CONN_ID,
     )
-    with mock.patch.object(operator.log, "info") as mock_log_info:
-        operator.execute_complete(context=context, event={"status": "done"})
-    mock_log_info.assert_called_with("Job completed successfully")
+    assert operator.execute_complete(context=create_context(operator), event={}) is None
 
 
 def test_execute_complete_fail():
@@ -113,3 +124,139 @@ def test_execute_complete_fail():
     with pytest.raises(AirflowException):
         """assert that execute_complete_success raise exception when a task fail"""
         operator.execute_complete(context=context, event={"status": "error", "description": "Pod not found"})
+
+
+def test_raise_for_trigger_status_done():
+    """Assert trigger don't raise exception in case of status is done"""
+    assert (
+        GKEStartPodOperatorAsync(
+            task_id="start_pod",
+            project_id=PROJECT_ID,
+            location=LOCATION,
+            cluster_name=GKE_CLUSTER_NAME,
+            name="astro_k8s_gke_test_pod",
+            namespace=NAMESPACE,
+            image="ubuntu",
+            gcp_conn_id=GCP_CONN_ID,
+        ).raise_for_trigger_status({"status": "done"})
+        is None
+    )
+
+
+@mock.patch("airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.client")
+@mock.patch("astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.cleanup")
+@mock.patch("airflow.kubernetes.kube_client.get_kube_client")
+@mock.patch(
+    "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync"
+    ".raise_for_trigger_status"
+)
+@mock.patch("astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.find_pod")
+@mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
+@mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.fetch_container_logs")
+@mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
+@mock.patch(
+    "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file"
+)
+@mock.patch(
+    "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.extract_xcom"
+)
+def test_get_logs_not_running(
+    mock_extract_xcom,
+    mock_gke_config,
+    mock_get_default_client,
+    fetch_container_logs,
+    await_pod_completion,
+    find_pod,
+    raise_for_trigger_status,
+    get_kube_client,
+    cleanup,
+    mock_client,
+):
+    mock_extract_xcom.return_value = "{}"
+    pod = MagicMock()
+    find_pod.return_value = pod
+    mock_client.return_value = {}
+    op = GKEStartPodOperatorAsync(
+        task_id="start_pod",
+        project_id=PROJECT_ID,
+        location=LOCATION,
+        cluster_name=GKE_CLUSTER_NAME,
+        name="astro_k8s_gke_test_pod",
+        namespace=NAMESPACE,
+        image="ubuntu",
+        gcp_conn_id=GCP_CONN_ID,
+        get_logs=True,
+        do_xcom_push=True,
+    )
+    context = create_context(op)
+    await_pod_completion.return_value = None
+    fetch_container_logs.return_value = PodLoggingStatus(False, None)
+    op.trigger_reentry(context, {"namespace": NAMESPACE})
+    fetch_container_logs.is_called_with(pod, "base")
+
+
+@mock.patch("airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.client")
+@mock.patch("astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.cleanup")
+@mock.patch("airflow.kubernetes.kube_client.get_kube_client")
+@mock.patch(
+    "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync"
+    ".raise_for_trigger_status"
+)
+@mock.patch("astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.find_pod")
+@mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
+@mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.fetch_container_logs")
+@mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
+@mock.patch(
+    "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file"
+)
+def test_no_pod(
+    mock_gke_config,
+    mock_get_default_client,
+    fetch_container_logs,
+    await_pod_completion,
+    find_pod,
+    raise_for_trigger_status,
+    get_kube_client,
+    cleanup,
+    mock_client,
+):
+    """Assert if pod not found then raise exception"""
+    find_pod.return_value = None
+    op = GKEStartPodOperatorAsync(
+        task_id="start_pod",
+        project_id=PROJECT_ID,
+        location=LOCATION,
+        cluster_name=GKE_CLUSTER_NAME,
+        name="astro_k8s_gke_test_pod",
+        namespace=NAMESPACE,
+        image="ubuntu",
+        gcp_conn_id=GCP_CONN_ID,
+        get_logs=True,
+    )
+    context = create_context(op)
+    with pytest.raises(PodNotFoundException):
+        op.trigger_reentry(context, {"namespace": NAMESPACE})
+
+
+def test_trigger_error():
+    """Assert that trigger_reentry raise exception in case of error"""
+    op = GKEStartPodOperatorAsync(
+        task_id="start_pod",
+        project_id=PROJECT_ID,
+        location=LOCATION,
+        cluster_name=GKE_CLUSTER_NAME,
+        name="astro_k8s_gke_test_pod",
+        namespace=NAMESPACE,
+        image="ubuntu",
+        gcp_conn_id=GCP_CONN_ID,
+        get_logs=True,
+    )
+    with pytest.raises(PodLaunchTimeoutException):
+        op.execute_complete(
+            context,
+            {
+                "status": "error",
+                "error_type": "PodLaunchTimeoutException",
+                "description": "any message",
+            },
+        )


### PR DESCRIPTION
- Fix  Issue: #811 not showing pod's logs on completion if `get_logs` is True
  Currently in `GKEStartPodOperatorAsync`, even though the `get_logs` attribute is set to True it was not showing the pod's log as in sync operator as expected, now it is fixed extended support to conclude the `get_logs` attribute once the trigger callback function is executed fetching the container logs from the pod manager if `get_logs` attribute is set to True.
  
- Fix  Issue #451  pod cleanup and XCom push
   Once the trigger callback function is executed after the successful event. Pushed `pod name` and `namespace` and result in XCom when `do_xcom_push`  is set to True and cleaning of the pod was also handled.

- Handle the `GKEStartPodOperatorAsync` status based on the terminal status. #814
   Currently, GKEStartPodOperatorAsync (and GKEStartPodTrigger) succeeds whenever the pod's state is one of PodPhase.terminal_states, that is either Failed or Succeeded. So by adding condition in the trigger based on the terminal status and returning the failed even when the terminal status is in a failed state.

closes: #811 #451 #814 