### PR TITLE
Add `DataprocLink` to see Dataproc jobs  in `DataprocSubmitJobOperatorAsync`

### DIFF
--- a/astronomer/providers/google/cloud/operators/dataproc.py
+++ b/astronomer/providers/google/cloud/operators/dataproc.py
@@ -6,6 +6,7 @@ from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.dataproc import DataprocHook
 from airflow.providers.google.cloud.links.dataproc import (
     DATAPROC_CLUSTER_LINK,
+    DATAPROC_JOB_LOG_LINK,
     DataprocLink,
 )
 from airflow.providers.google.cloud.operators.dataproc import (
@@ -261,6 +262,8 @@ class DataprocSubmitJobOperatorAsync(DataprocSubmitJobOperator):
         job_id = job_object.reference.job_id
         self.log.info("Job %s submitted successfully.", job_id)
         self.job_id = job_id
+        # Save data required for extra links no matter what the job status will be
+        DataprocLink.persist(context=context, task_instance=self, url=DATAPROC_JOB_LOG_LINK, resource=job_id)
         self.defer(
             timeout=self.execution_timeout,
             trigger=DataProcSubmitTrigger(

--- a/tests/google/cloud/operators/test_dataproc.py
+++ b/tests/google/cloud/operators/test_dataproc.py
@@ -195,11 +195,12 @@ def test_dataproc_delete_operator_execute_complete_exception(event):
 
 @mock.patch("airflow.providers.google.cloud.links.dataproc.DataprocLink.persist")
 @mock.patch("airflow.providers.google.cloud.operators.dataproc.DataprocHook.submit_job")
-def test_dataproc_operator_execute_async(mock_submit_job):
+def test_dataproc_operator_execute_async(mock_submit_job, mock_persist):
     """
     Asserts that a task is deferred and a DataProcSubmitTrigger will be fired
     when the DataprocSubmitJobOperatorAsync is executed.
     """
+    mock_persist.return_value = {}
     mock_submit_job.return_value.reference.job_id = TEST_JOB_ID
     task = DataprocSubmitJobOperatorAsync(
         task_id="task-id", job=SPARK_JOB, region=TEST_REGION, project_id=TEST_PROJECT_ID

--- a/tests/google/cloud/operators/test_dataproc.py
+++ b/tests/google/cloud/operators/test_dataproc.py
@@ -193,7 +193,7 @@ def test_dataproc_delete_operator_execute_complete_exception(event):
     with pytest.raises(AirflowException):
         task.execute_complete(context=context, event=event)
 
-
+@mock.patch("airflow.providers.google.cloud.links.dataproc.DataprocLink.persist")
 @mock.patch("airflow.providers.google.cloud.operators.dataproc.DataprocHook.submit_job")
 def test_dataproc_operator_execute_async(mock_submit_job):
     """


### PR DESCRIPTION
This PR enables the user to see Dataproc resource button when we run a job using ``DataprocSubmitJobOperatorAsync``.
<img width="842" alt="Screenshot 2023-01-10 at 4 30 04 PM" src="https://user-images.githubusercontent.com/92459020/211538191-82b82567-0b87-49f5-a9e3-3970353a4554.png">


closes #825 