### PR TITLE
Databricks class based tests

### DIFF
--- a/tests/databricks/hooks/test_databricks.py
+++ b/tests/databricks/hooks/test_databricks.py
@@ -64,240 +64,230 @@ if version.parse(provider_version) > version.parse("2.0.2"):
     api_version = "2.1"
 
 
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync._do_api_call_async")
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
-async def test_databricks_hook_get_run_state(mock_run_response, mocked_response):
-    """
-    Asserts that a run state is returned as expected while a Databricks run
-    is in a PENDING state (i.e. "RUNNING") and after it reaches a TERMINATED
-    state (i.e. "SUCCESS").
-    """
-    hook = DatabricksHookAsync()
-    # Mock response while job is running
-    mock_run_response.return_value = {
-        "state": {
-            "life_cycle_state": "RUNNING",
-            "result_state": "",
-            "state_message": "In run",
-            "user_cancelled_or_timedout": "False",
-        }
-    }
-    run_state_running = await hook.get_run_state_async(RUN_ID)
-
-    assert run_state_running.life_cycle_state == "RUNNING"
-    assert run_state_running.result_state == ""
-    assert run_state_running.state_message == "In run"
-
-    # Mock response after job is complete
-    mock_run_response.return_value = {
-        "state": {
-            "life_cycle_state": "TERMINATED",
-            "result_state": "SUCCESS",
-            "state_message": "",
-            "user_cancelled_or_timedout": "False",
-        }
-    }
-    run_state_complete = await hook.get_run_state_async(RUN_ID)
-
-    assert run_state_complete.life_cycle_state == "TERMINATED"
-    assert run_state_complete.result_state == "SUCCESS"
-    assert run_state_complete.state_message == ""
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "mock_response",
-    [
-        (
-            {
-                "state": {
-                    "life_cycle_state": "RUNNING",
-                    "result_state": "",
-                    "state_message": "In run",
-                    "user_cancelled_or_timedout": "False",
-                }
+class TestDatabricksHookAsync:
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync._do_api_call_async")
+    async def test_databricks_hook_get_run_state(self, mocked_response):
+        """
+        Asserts that a run state is returned as expected while a Databricks run
+        is in a PENDING state (i.e. "RUNNING") and after it reaches a TERMINATED
+        state (i.e. "SUCCESS").
+        """
+        hook = DatabricksHookAsync()
+        # Mock response while job is running
+        mocked_response.return_value = {
+            "state": {
+                "life_cycle_state": "RUNNING",
+                "result_state": "",
+                "state_message": "In run",
+                "user_cancelled_or_timedout": "False",
             }
-        ),
-        (
-            {
-                "state": {
-                    "life_cycle_state": "TERMINATED",
-                    "result_state": "SUCCESS",
-                    "state_message": "",
-                    "user_cancelled_or_timedout": "False",
-                }
+        }
+        run_state_running = await hook.get_run_state_async(RUN_ID)
+
+        assert run_state_running.life_cycle_state == "RUNNING"
+        assert run_state_running.result_state == ""
+        assert run_state_running.state_message == "In run"
+
+        # Mock response after job is complete
+        mocked_response.return_value = {
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "SUCCESS",
+                "state_message": "",
+                "user_cancelled_or_timedout": "False",
             }
-        ),
-    ],
-)
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync._do_api_call_async")
-async def test_get_run_response(mock_do_api_async, mock_response):
-    """
-    Test get_run_response function by mocking the _do_api_call_async response and the response date from the API.
-    """
-    hook = DatabricksHookAsync()
-    mock_do_api_async.return_value = mock_response
-    run_state_response = await hook.get_run_response(RUN_ID)
-    assert run_state_response == mock_response
+        }
+        run_state_complete = await hook.get_run_state_async(RUN_ID)
 
+        assert run_state_complete.life_cycle_state == "TERMINATED"
+        assert run_state_complete.result_state == "SUCCESS"
+        assert run_state_complete.state_message == ""
 
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync._do_api_call_async")
-async def test_get_run_output_response(mock_do_api_async):
-    """Test get_run_output_response method by mocking _do_api_call_async and the response of get-output API"""
-    hook = DatabricksHookAsync()
-    mock_do_api_async.return_value = MOCK_GET_OUTPUT_RESPONSE
-    run_output = await hook.get_run_output_response(RUN_ID)
-    assert run_output == MOCK_GET_OUTPUT_RESPONSE
+    @pytest.mark.asyncio
+    async def test_do_api_call_async_get_basic_auth(self, caplog, aioresponse):
+        """
+        Asserts that the Databricks hook makes a GET call as expected when
+        provided with basic auth credentials.
+        The aiohttp module assumes basic auth for its 'auth' parameter, so
+        we need to set this manually in the header for both bearer token
+        and basic auth.
+        """
+        caplog.set_level(logging.INFO)
+        hook = DatabricksHookAsync()
+        hook.databricks_conn = MagicMock()
+        hook.databricks_conn.host = "https://localhost"
+        hook.databricks_conn.login = LOGIN
+        hook.databricks_conn.password = PASSWORD
+        params = {"run_id": RUN_ID}
 
+        aioresponse.get(
+            f"https://localhost/api/{api_version}/jobs/runs/get?run_id=unit_test_run_id",
+            status=200,
+            body='{"result":"Yay!"}',
+        )
+        resp = await hook._do_api_call_async(GET_RUN_ENDPOINT, params)
+        assert resp == {"result": "Yay!"}
+        assert resp["result"] == "Yay!"
+        assert "Using basic auth. " in caplog.text
 
-@pytest.mark.asyncio
-async def test_do_api_call_async_get_basic_auth(caplog, aioresponse):
-    """
-    Asserts that the Databricks hook makes a GET call as expected when
-    provided with basic auth credentials.
-    The aiohttp module assumes basic auth for its 'auth' parameter, so
-    we need to set this manually in the header for both bearer token
-    and basic auth.
-    """
-    caplog.set_level(logging.INFO)
-    hook = DatabricksHookAsync()
-    hook.databricks_conn = MagicMock()
-    hook.databricks_conn.host = "https://localhost"
-    hook.databricks_conn.login = LOGIN
-    hook.databricks_conn.password = PASSWORD
-    params = {"run_id": RUN_ID}
+    @pytest.mark.asyncio
+    async def test_do_api_call_async_get_auth_token(self, caplog, aioresponse):
+        """
+        Asserts that the Databricks hook makes a GET call as expected when
+        provided with an auth token.
+        The aiohttp module assumes basic auth for its 'auth' parameter, so
+        we need to set this manually in the header for both bearer token
+        and basic auth.
+        """
+        caplog.set_level(logging.INFO)
+        hook = DatabricksHookAsync()
+        hook.databricks_conn = MagicMock()
+        hook.databricks_conn.host = "https://localhost"
+        hook.databricks_conn.extra_dejson = {"token": "test_token"}
+        params = {"run_id": RUN_ID}
 
-    aioresponse.get(
-        f"https://localhost/api/{api_version}/jobs/runs/get?run_id=unit_test_run_id",
-        status=200,
-        body='{"result":"Yay!"}',
+        aioresponse.get(
+            f"https://localhost/api/{api_version}/jobs/runs/get?run_id=unit_test_run_id",
+            status=200,
+            body='{"result":"Yay!"}',
+        )
+        resp = await hook._do_api_call_async(GET_RUN_ENDPOINT, params)
+        assert resp == {"result": "Yay!"}
+        assert resp["result"] == "Yay!"
+        assert "Using token auth. " in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_do_api_call_async_non_retryable_error(self, aioresponse):
+        """
+        Asserts that the Databricks hook will throw an exception
+        when a non-retryable error is returned by the API.
+        """
+        hook = DatabricksHookAsync()
+        hook.databricks_conn = MagicMock()
+        hook.databricks_conn.host = "https://localhost"
+        hook.databricks_conn.login = LOGIN
+        hook.databricks_conn.password = PASSWORD
+        params = {"run_id": RUN_ID}
+
+        aioresponse.get(
+            f"https://localhost/api/{api_version}/jobs/runs/get?run_id=unit_test_run_id",
+            status=400,
+        )
+
+        with pytest.raises(AirflowException):
+            await hook._do_api_call_async(GET_RUN_ENDPOINT, params)
+
+    @pytest.mark.asyncio
+    async def test_do_api_call_async_retryable_error(self, aioresponse):
+        """
+        Asserts that the Databricks hook will attempt another API call as many
+        times as the retry_limit when a retryable error is returned by the API.
+        """
+        hook = DatabricksHookAsync()
+        hook.databricks_conn = MagicMock()
+        hook.databricks_conn.host = "https://localhost"
+        hook.databricks_conn.login = LOGIN
+        hook.databricks_conn.password = PASSWORD
+        params = {"run_id": RUN_ID}
+
+        aioresponse.get(
+            f"https://localhost/api/{api_version}/jobs/runs/get?run_id=unit_test_run_id",
+            status=500,
+            repeat=True,
+        )
+
+        with pytest.raises(AirflowException) as exc:
+            await hook._do_api_call_async(GET_RUN_ENDPOINT, params)
+
+        assert str(exc.value) == f"API requests to Databricks failed {hook.retry_limit} times. Giving up."
+
+    @pytest.mark.asyncio
+    async def test_do_api_call_async_post(self, aioresponse):
+        """Asserts that the Databricks hook makes a POST call as expected."""
+        hook = DatabricksHookAsync()
+        hook.databricks_conn = MagicMock()
+        hook.databricks_conn.host = "https://localhost"
+        hook.databricks_conn.login = LOGIN
+        hook.databricks_conn.password = PASSWORD
+        json = {
+            "task_id": TASK_ID,
+            "existing_cluster_id": "xxxx-xxxxxx-xxxxxx",
+            "notebook_task": {"notebook_path": "/Users/test@astronomer.io/test_notebook"},
+        }
+
+        aioresponse.post(
+            f"https://localhost/api/{api_version}/jobs/runs/submit",
+            status=202,
+            body='{"result":"Yay!"}',
+        )
+        resp = await hook._do_api_call_async(SUBMIT_RUN_ENDPOINT, json)
+        assert resp == {"result": "Yay!"}
+        assert resp["result"] == "Yay!"
+
+    @pytest.mark.asyncio
+    async def test_do_api_call_async_unknown_method(self):
+        """
+        Asserts that the Databricks hook throws an exception when it attempts to
+        make an API call using a non-existent method.
+        """
+        hook = DatabricksHookAsync()
+        hook.databricks_conn = MagicMock()
+        hook.databricks_conn.host = "https://localhost"
+        hook.databricks_conn.login = LOGIN
+        hook.databricks_conn.password = PASSWORD
+        payload = {
+            "task_id": TASK_ID,
+            "existing_cluster_id": "xxxx-xxxxxx-xxxxxx",
+            "notebook_task": {"notebook_path": "/Users/test@astronomer.io/test_notebook"},
+        }
+
+        with pytest.raises(AirflowException) as exc:
+            await hook._do_api_call_async(("NOPE", "api/2.0/jobs/runs/submit"), payload)
+
+        assert str(exc.value) == "Unexpected HTTP Method: NOPE"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_response",
+        [
+            (
+                    {
+                        "state": {
+                            "life_cycle_state": "RUNNING",
+                            "result_state": "",
+                            "state_message": "In run",
+                            "user_cancelled_or_timedout": "False",
+                        }
+                    }
+            ),
+            (
+                    {
+                        "state": {
+                            "life_cycle_state": "TERMINATED",
+                            "result_state": "SUCCESS",
+                            "state_message": "",
+                            "user_cancelled_or_timedout": "False",
+                        }
+                    }
+            ),
+        ],
     )
-    resp = await hook._do_api_call_async(GET_RUN_ENDPOINT, params)
-    assert resp == {"result": "Yay!"}
-    assert resp["result"] == "Yay!"
-    assert "Using basic auth. " in caplog.text
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync._do_api_call_async")
+    async def test_get_run_response(self, mock_do_api_async, mock_response):
+        """
+        Test get_run_response function by mocking the _do_api_call_async response and the response date from the API.
+        """
+        hook = DatabricksHookAsync()
+        mock_do_api_async.return_value = mock_response
+        run_state_response = await hook.get_run_response(RUN_ID)
+        assert run_state_response == mock_response
 
-
-@pytest.mark.asyncio
-async def test_do_api_call_async_get_auth_token(caplog, aioresponse):
-    """
-    Asserts that the Databricks hook makes a GET call as expected when
-    provided with an auth token.
-    The aiohttp module assumes basic auth for its 'auth' parameter, so
-    we need to set this manually in the header for both bearer token
-    and basic auth.
-    """
-    caplog.set_level(logging.INFO)
-    hook = DatabricksHookAsync()
-    hook.databricks_conn = MagicMock()
-    hook.databricks_conn.host = "https://localhost"
-    hook.databricks_conn.extra_dejson = {"token": "test_token"}
-    params = {"run_id": RUN_ID}
-
-    aioresponse.get(
-        f"https://localhost/api/{api_version}/jobs/runs/get?run_id=unit_test_run_id",
-        status=200,
-        body='{"result":"Yay!"}',
-    )
-    resp = await hook._do_api_call_async(GET_RUN_ENDPOINT, params)
-    assert resp == {"result": "Yay!"}
-    assert resp["result"] == "Yay!"
-    assert "Using token auth. " in caplog.text
-
-
-@pytest.mark.asyncio
-async def test_do_api_call_async_non_retryable_error(aioresponse):
-    """
-    Asserts that the Databricks hook will throw an exception
-    when a non-retryable error is returned by the API.
-    """
-    hook = DatabricksHookAsync()
-    hook.databricks_conn = MagicMock()
-    hook.databricks_conn.host = "https://localhost"
-    hook.databricks_conn.login = LOGIN
-    hook.databricks_conn.password = PASSWORD
-    params = {"run_id": RUN_ID}
-
-    aioresponse.get(
-        f"https://localhost/api/{api_version}/jobs/runs/get?run_id=unit_test_run_id",
-        status=400,
-    )
-
-    with pytest.raises(AirflowException):
-        await hook._do_api_call_async(GET_RUN_ENDPOINT, params)
-
-
-@pytest.mark.asyncio
-async def test_do_api_call_async_retryable_error(aioresponse):
-    """
-    Asserts that the Databricks hook will attempt another API call as many
-    times as the retry_limit when a retryable error is returned by the API.
-    """
-    hook = DatabricksHookAsync()
-    hook.databricks_conn = MagicMock()
-    hook.databricks_conn.host = "https://localhost"
-    hook.databricks_conn.login = LOGIN
-    hook.databricks_conn.password = PASSWORD
-    params = {"run_id": RUN_ID}
-
-    aioresponse.get(
-        f"https://localhost/api/{api_version}/jobs/runs/get?run_id=unit_test_run_id",
-        status=500,
-        repeat=True,
-    )
-
-    with pytest.raises(AirflowException) as exc:
-        await hook._do_api_call_async(GET_RUN_ENDPOINT, params)
-
-    assert str(exc.value) == f"API requests to Databricks failed {hook.retry_limit} times. Giving up."
-
-
-@pytest.mark.asyncio
-async def test_do_api_call_async_post(aioresponse):
-    """
-    Asserts that the Databricks hook makes a POST call as expected.
-    """
-    hook = DatabricksHookAsync()
-    hook.databricks_conn = MagicMock()
-    hook.databricks_conn.host = "https://localhost"
-    hook.databricks_conn.login = LOGIN
-    hook.databricks_conn.password = PASSWORD
-    json = {
-        "task_id": TASK_ID,
-        "existing_cluster_id": "xxxx-xxxxxx-xxxxxx",
-        "notebook_task": {"notebook_path": "/Users/test@astronomer.io/test_notebook"},
-    }
-
-    aioresponse.post(
-        f"https://localhost/api/{api_version}/jobs/runs/submit",
-        status=202,
-        body='{"result":"Yay!"}',
-    )
-    resp = await hook._do_api_call_async(SUBMIT_RUN_ENDPOINT, json)
-    assert resp == {"result": "Yay!"}
-    assert resp["result"] == "Yay!"
-
-
-@pytest.mark.asyncio
-async def test_do_api_call_async_unknown_method():
-    """
-    Asserts that the Databricks hook throws an exception when it attempts to
-    make an API call using a non-existent method.
-    """
-    hook = DatabricksHookAsync()
-    hook.databricks_conn = MagicMock()
-    hook.databricks_conn.host = "https://localhost"
-    hook.databricks_conn.login = LOGIN
-    hook.databricks_conn.password = PASSWORD
-    payload = {
-        "task_id": TASK_ID,
-        "existing_cluster_id": "xxxx-xxxxxx-xxxxxx",
-        "notebook_task": {"notebook_path": "/Users/test@astronomer.io/test_notebook"},
-    }
-
-    with pytest.raises(AirflowException) as exc:
-        await hook._do_api_call_async(("NOPE", "api/2.0/jobs/runs/submit"), payload)
-
-    assert str(exc.value) == "Unexpected HTTP Method: NOPE"
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync._do_api_call_async")
+    async def test_get_run_output_response(self, mock_do_api_async):
+        """Test get_run_output_response method by mocking _do_api_call_async and the response of get-output API"""
+        hook = DatabricksHookAsync()
+        mock_do_api_async.return_value = MOCK_GET_OUTPUT_RESPONSE
+        run_output = await hook.get_run_output_response(RUN_ID)
+        assert run_output == MOCK_GET_OUTPUT_RESPONSE

--- a/tests/databricks/hooks/test_databricks.py
+++ b/tests/databricks/hooks/test_databricks.py
@@ -252,24 +252,24 @@ class TestDatabricksHookAsync:
         "mock_response",
         [
             (
-                    {
-                        "state": {
-                            "life_cycle_state": "RUNNING",
-                            "result_state": "",
-                            "state_message": "In run",
-                            "user_cancelled_or_timedout": "False",
-                        }
+                {
+                    "state": {
+                        "life_cycle_state": "RUNNING",
+                        "result_state": "",
+                        "state_message": "In run",
+                        "user_cancelled_or_timedout": "False",
                     }
+                }
             ),
             (
-                    {
-                        "state": {
-                            "life_cycle_state": "TERMINATED",
-                            "result_state": "SUCCESS",
-                            "state_message": "",
-                            "user_cancelled_or_timedout": "False",
-                        }
+                {
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "SUCCESS",
+                        "state_message": "",
+                        "user_cancelled_or_timedout": "False",
                     }
+                }
             ),
         ],
     )

--- a/tests/databricks/operators/test_databricks.py
+++ b/tests/databricks/operators/test_databricks.py
@@ -1,18 +1,14 @@
-from datetime import datetime
 from unittest import mock
 
 import pytest
-from airflow import DAG
 from airflow.exceptions import AirflowException, TaskDeferred
-from airflow.models.dagrun import DagRun
-from airflow.models.taskinstance import TaskInstance
-from airflow.utils.types import DagRunType
 
 from astronomer.providers.databricks.operators.databricks import (
     DatabricksRunNowOperatorAsync,
     DatabricksSubmitRunOperatorAsync,
 )
 from astronomer.providers.databricks.triggers.databricks import DatabricksTrigger
+from tests.utils.airflow_util import create_context
 
 TASK_ID = "databricks_check"
 CONN_ID = "databricks_default"
@@ -25,235 +21,193 @@ XCOM_RUN_ID_KEY = "run_id"
 XCOM_RUN_PAGE_URL_KEY = "run_page_url"
 
 
-@pytest.fixture
-def context():
-    """
-    Creates an empty context.
-    """
-    context = {}
-    yield context
+class TestDatabricksSubmitRunOperatorAsync:
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.submit_run")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_job_id")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
+    def test_databricks_submit_run_operator_async(
+        self, submit_run_response, get_job_id, get_run_page_url_response
+    ):
+        """
+        Asserts that a task is deferred and an DatabricksTrigger will be fired
+        when the DatabricksSubmitRunOperatorAsync is executed.
+        """
+        submit_run_response.return_value = {"run_id": RUN_ID}
+        get_run_page_url_response.return_value = RUN_PAGE_URL
+        get_job_id.return_value = None
 
-
-@mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.submit_run")
-@mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_job_id")
-@mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
-def test_databricks_submit_run_operator_async(
-    submit_run_response, get_job_id, get_run_page_url_response, context
-):
-    """
-    Asserts that a task is deferred and an DatabricksTrigger will be fired
-    when the DatabricksSubmitRunOperatorAsync is executed.
-    """
-    submit_run_response.return_value = {"run_id": RUN_ID}
-    get_run_page_url_response.return_value = RUN_PAGE_URL
-    get_job_id.return_value = None
-
-    operator = DatabricksSubmitRunOperatorAsync(
-        task_id="submit_run",
-        databricks_conn_id=CONN_ID,
-        existing_cluster_id="xxxx-xxxxxx-xxxxxx",
-        notebook_task={"notebook_path": "/Users/test@astronomer.io/Quickstart Notebook"},
-    )
-
-    with pytest.raises(TaskDeferred) as exc:
-        operator.execute(context=create_context(operator))
-
-    assert isinstance(exc.value.trigger, DatabricksTrigger), "Trigger is not a DatabricksTrigger"
-
-
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.run_now")
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
-def test_databricks_run_now_operator_async(
-    run_now_response,
-    get_run_page_url_response,
-):
-    """
-    Asserts that a task is deferred and an DatabricksTrigger will be fired
-    when the DatabricksRunNowOperatorAsync is executed.
-    """
-    run_now_response.return_value = {"run_id": RUN_ID}
-    get_run_page_url_response.return_value = RUN_PAGE_URL
-
-    operator = DatabricksRunNowOperatorAsync(
-        task_id="run_now",
-        databricks_conn_id=CONN_ID,
-    )
-
-    with pytest.raises(TaskDeferred) as exc:
-        operator.execute(context=create_context(operator))
-
-    assert isinstance(exc.value.trigger, DatabricksTrigger), "Trigger is not a DatabricksTrigger"
-
-
-def test_databricks_run_now_execute_complete():
-    """Asserts that logging occurs as expected"""
-    operator = DatabricksRunNowOperatorAsync(
-        task_id=TASK_ID,
-        databricks_conn_id=CONN_ID,
-        do_xcom_push=True,
-    )
-    operator.run_page_url = RUN_PAGE_URL
-    with mock.patch.object(operator.log, "info") as mock_log_info:
-        operator.execute_complete(create_context(operator), {"status": "success", "message": "success"})
-    mock_log_info.assert_called_with("%s completed successfully.", "databricks_check")
-
-
-@mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.submit_run")
-@mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
-def test_databricks_submit_run_execute_complete_error(
-    submit_run_response, get_run_page_url_response, context
-):
-    """
-    Asserts that a task is completed with success status.
-    """
-    submit_run_response.return_value = {"run_id": RUN_ID}
-    get_run_page_url_response.return_value = RUN_PAGE_URL
-
-    operator = DatabricksSubmitRunOperatorAsync(
-        task_id="submit_run",
-        databricks_conn_id=CONN_ID,
-        existing_cluster_id="xxxx-xxxxxx-xxxxxx",
-        notebook_task={"notebook_path": "/Users/test@astronomer.io/Quickstart Notebook"},
-    )
-
-    with pytest.raises(AirflowException):
-        operator.execute_complete(context={}, event={"status": "error", "message": "error"})
-
-
-@mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.submit_run")
-@mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
-def test_databricks_run_now_execute_complete_error(submit_run_response, get_run_page_url_response, context):
-    """
-    Asserts that a task is completed with success status.
-    """
-    submit_run_response.return_value = {"run_id": RUN_ID}
-    get_run_page_url_response.return_value = RUN_PAGE_URL
-
-    operator = DatabricksRunNowOperatorAsync(
-        task_id="submit_run",
-        databricks_conn_id=CONN_ID,
-        job_id="12345",
-    )
-
-    with pytest.raises(AirflowException):
-        operator.execute_complete(context={}, event={"status": "error", "message": "error"})
-
-
-def create_context(task):
-    dag = DAG(dag_id="dag")
-    execution_date = datetime(2022, 1, 1, 0, 0, 0)
-    dag_run = DagRun(
-        dag_id=dag.dag_id,
-        execution_date=execution_date,
-        run_id=DagRun.generate_run_id(DagRunType.MANUAL, execution_date),
-    )
-    task_instance = TaskInstance(task=task)
-    task_instance.dag_run = dag_run
-    task_instance.dag_id = dag.dag_id
-    task_instance.xcom_push = mock.Mock()
-    return {
-        "dag": dag,
-        "run_id": dag_run.run_id,
-        "task": task,
-        "ti": task_instance,
-        "task_instance": task_instance,
-    }
-
-
-@mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.submit_run")
-@mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
-def test_databricks_submit_run_execute_complete_success(
-    submit_run_response, get_run_page_url_response, context
-):
-    """
-    Asserts that a task is completed with success status.
-    """
-    submit_run_response.return_value = {"run_id": RUN_ID}
-    get_run_page_url_response.return_value = RUN_PAGE_URL
-
-    operator = DatabricksSubmitRunOperatorAsync(
-        task_id="submit_run",
-        databricks_conn_id=CONN_ID,
-        existing_cluster_id="xxxx-xxxxxx-xxxxxx",
-        notebook_task={"notebook_path": "/Users/test@astronomer.io/Quickstart Notebook"},
-        do_xcom_push=True,
-    )
-
-    assert (
-        operator.execute_complete(
-            context=create_context(operator),
-            event={
-                "status": "success",
-                "message": "success",
-                "job_id": "12345",
-                "run_id": RUN_ID,
-                "run_page_url": RUN_PAGE_URL,
-            },
+        operator = DatabricksSubmitRunOperatorAsync(
+            task_id="submit_run",
+            databricks_conn_id=CONN_ID,
+            existing_cluster_id="xxxx-xxxxxx-xxxxxx",
+            notebook_task={"notebook_path": "/Users/test@astronomer.io/Quickstart Notebook"},
         )
-        is None
-    )
 
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute(context=create_context(operator))
 
-@mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.submit_run")
-@mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
-def test_databricks_run_now_execute_complete_success(submit_run_response, get_run_page_url_response, context):
-    """
-    Asserts that a task is completed with success status.
-    """
-    submit_run_response.return_value = {"run_id": RUN_ID}
-    get_run_page_url_response.return_value = RUN_PAGE_URL
+        assert isinstance(exc.value.trigger, DatabricksTrigger), "Trigger is not a DatabricksTrigger"
 
-    operator = DatabricksRunNowOperatorAsync(
-        task_id="submit_run",
-        databricks_conn_id=CONN_ID,
-        job_id="12345",
-        do_xcom_push=True,
-    )
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.submit_run")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
+    def test_databricks_submit_run_execute_complete_error(
+        self, submit_run_response, get_run_page_url_response
+    ):
+        """
+        Asserts that a task is completed with success status.
+        """
+        submit_run_response.return_value = {"run_id": RUN_ID}
+        get_run_page_url_response.return_value = RUN_PAGE_URL
 
-    assert (
-        operator.execute_complete(
-            context=create_context(operator),
-            event={
-                "status": "success",
-                "message": "success",
-                "job_id": "12345",
-                "run_id": RUN_ID,
-                "run_page_url": RUN_PAGE_URL,
-            },
+        operator = DatabricksSubmitRunOperatorAsync(
+            task_id="submit_run",
+            databricks_conn_id=CONN_ID,
+            existing_cluster_id="xxxx-xxxxxx-xxxxxx",
+            notebook_task={"notebook_path": "/Users/test@astronomer.io/Quickstart Notebook"},
         )
-        is None
-    )
+
+        with pytest.raises(AirflowException):
+            operator.execute_complete(context={}, event={"status": "error", "message": "error"})
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.submit_run")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
+    def test_databricks_submit_run_execute_complete_success(
+        self, submit_run_response, get_run_page_url_response
+    ):
+        """Asserts that a task is completed with success status."""
+        submit_run_response.return_value = {"run_id": RUN_ID}
+        get_run_page_url_response.return_value = RUN_PAGE_URL
+
+        operator = DatabricksSubmitRunOperatorAsync(
+            task_id="submit_run",
+            databricks_conn_id=CONN_ID,
+            existing_cluster_id="xxxx-xxxxxx-xxxxxx",
+            notebook_task={"notebook_path": "/Users/test@astronomer.io/Quickstart Notebook"},
+            do_xcom_push=True,
+        )
+
+        assert (
+            operator.execute_complete(
+                context=create_context(operator),
+                event={
+                    "status": "success",
+                    "message": "success",
+                    "job_id": "12345",
+                    "run_id": RUN_ID,
+                    "run_page_url": RUN_PAGE_URL,
+                },
+            )
+            is None
+        )
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksSubmitRunOperator._get_hook")
+    def test_databricks_submit_run_operator_async_hook(self, mock_get_hook):
+        """
+        Asserts that the hook raises TypeError for apache-airflow-providers-databricks>=3.2.0
+        when the DatabricksSubmitRunOperatorAsync is executed.
+        """
+        mock_get_hook.side_effect = TypeError("test exception")
+        operator = DatabricksSubmitRunOperatorAsync(
+            task_id="submit_run",
+            databricks_conn_id=CONN_ID,
+            existing_cluster_id="xxxx-xxxxxx-xxxxxx",
+            notebook_task={"notebook_path": "/Users/test@astronomer.io/Quickstart Notebook"},
+        )
+
+        with pytest.raises(TypeError):
+            operator.execute(context=create_context(operator))
 
 
-@mock.patch("airflow.providers.databricks.operators.databricks.DatabricksRunNowOperator._get_hook")
-def test_databricks_run_now_operator_async_hook(mock_get_hook):
-    """
-    Asserts that the hook raises TypeError for apache-airflow-providers-databricks>=3.2.0
-    when the DatabricksRunNowOperatorAsync is executed.
-    """
-    mock_get_hook.side_effect = TypeError("test exception")
-    operator = DatabricksRunNowOperatorAsync(
-        task_id="run_now",
-        databricks_conn_id=CONN_ID,
-    )
+class TestDatabricksRunNowOperatorAsync:
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.run_now")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
+    def test_databricks_run_now_operator_async(self, run_now_response, get_run_page_url_response):
+        """
+        Asserts that a task is deferred and an DatabricksTrigger will be fired
+        when the DatabricksRunNowOperatorAsync is executed.
+        """
+        run_now_response.return_value = {"run_id": RUN_ID}
+        get_run_page_url_response.return_value = RUN_PAGE_URL
 
-    with pytest.raises(TypeError):
-        operator.execute(context=create_context(operator))
+        operator = DatabricksRunNowOperatorAsync(
+            task_id="run_now",
+            databricks_conn_id=CONN_ID,
+        )
 
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute(context=create_context(operator))
 
-@mock.patch("airflow.providers.databricks.operators.databricks.DatabricksSubmitRunOperator._get_hook")
-def test_databricks_submit_run_operator_async_hook(mock_get_hook):
-    """
-    Asserts that the hook raises TypeError for apache-airflow-providers-databricks>=3.2.0
-    when the DatabricksSubmitRunOperatorAsync is executed.
-    """
-    mock_get_hook.side_effect = TypeError("test exception")
-    operator = DatabricksSubmitRunOperatorAsync(
-        task_id="submit_run",
-        databricks_conn_id=CONN_ID,
-        existing_cluster_id="xxxx-xxxxxx-xxxxxx",
-        notebook_task={"notebook_path": "/Users/test@astronomer.io/Quickstart Notebook"},
-    )
+        assert isinstance(exc.value.trigger, DatabricksTrigger), "Trigger is not a DatabricksTrigger"
 
-    with pytest.raises(TypeError):
-        operator.execute(context=create_context(operator))
+    def test_databricks_run_now_execute_complete(self):
+        """Asserts that logging occurs as expected"""
+        operator = DatabricksRunNowOperatorAsync(
+            task_id=TASK_ID,
+            databricks_conn_id=CONN_ID,
+            do_xcom_push=True,
+        )
+        operator.run_page_url = RUN_PAGE_URL
+        with mock.patch.object(operator.log, "info") as mock_log_info:
+            operator.execute_complete(create_context(operator), {"status": "success", "message": "success"})
+        mock_log_info.assert_called_with("%s completed successfully.", "databricks_check")
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.submit_run")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
+    def test_databricks_run_now_execute_complete_error(self, submit_run_response, get_run_page_url_response):
+        """Asserts that a task is completed with success status."""
+        submit_run_response.return_value = {"run_id": RUN_ID}
+        get_run_page_url_response.return_value = RUN_PAGE_URL
+
+        operator = DatabricksRunNowOperatorAsync(
+            task_id="submit_run",
+            databricks_conn_id=CONN_ID,
+            job_id="12345",
+        )
+
+        with pytest.raises(AirflowException):
+            operator.execute_complete(context={}, event={"status": "error", "message": "error"})
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.submit_run")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
+    def test_databricks_run_now_execute_complete_success(
+        self, submit_run_response, get_run_page_url_response
+    ):
+        """Asserts that a task is completed with success status."""
+        submit_run_response.return_value = {"run_id": RUN_ID}
+        get_run_page_url_response.return_value = RUN_PAGE_URL
+
+        operator = DatabricksRunNowOperatorAsync(
+            task_id="submit_run",
+            databricks_conn_id=CONN_ID,
+            job_id="12345",
+            do_xcom_push=True,
+        )
+
+        assert (
+            operator.execute_complete(
+                context=create_context(operator),
+                event={
+                    "status": "success",
+                    "message": "success",
+                    "job_id": "12345",
+                    "run_id": RUN_ID,
+                    "run_page_url": RUN_PAGE_URL,
+                },
+            )
+            is None
+        )
+
+    @mock.patch("airflow.providers.databricks.operators.databricks.DatabricksRunNowOperator._get_hook")
+    def test_databricks_run_now_operator_async_hook(self, mock_get_hook):
+        """
+        Asserts that the hook raises TypeError for apache-airflow-providers-databricks>=3.2.0
+        when the DatabricksRunNowOperatorAsync is executed.
+        """
+        mock_get_hook.side_effect = TypeError("test exception")
+        operator = DatabricksRunNowOperatorAsync(
+            task_id="run_now",
+            databricks_conn_id=CONN_ID,
+        )
+
+        with pytest.raises(TypeError):
+            operator.execute(context=create_context(operator))

--- a/tests/databricks/triggers/test_databricks.py
+++ b/tests/databricks/triggers/test_databricks.py
@@ -83,49 +83,8 @@ MOCK_RUN_GET_OUTPUT_RESPONSE_IN_ERROR_2 = {
 }
 
 
-def test_databricks_trigger_serialization():
-    """
-    Asserts that the DatabricksTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = DatabricksTrigger(
-        CONN_ID,
-        TASK_ID,
-        RUN_ID,
-        RETRY_LIMIT,
-        RETRY_DELAY,
-        POLLING_PERIOD_SECONDS,
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.databricks.triggers.databricks.DatabricksTrigger"
-    assert kwargs == {
-        "conn_id": CONN_ID,
-        "task_id": TASK_ID,
-        "run_id": RUN_ID,
-        "retry_limit": 2,
-        "retry_delay": 1.0,
-        "polling_period_seconds": 1.0,
-        "job_id": None,
-        "run_page_url": None,
-    }
-
-
-@pytest.mark.asyncio
-@mock.patch("airflow.providers.databricks.hooks.databricks.RunState")
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
-async def test_databricks_trigger_success(mock_run_response, run_state):
-    """
-    Tests that the DatabricksTrigger only fires once a
-    Databricks run reaches a successful state.
-    """
-    mock_run_response.return_value = {
-        "state": {
-            "life_cycle_state": "TERMINATED",
-            "result_state": "SUCCESS",
-            "state_message": "",
-        }
-    }
-    trigger = DatabricksTrigger(
+class TestDatabricksTrigger:
+    TRIGGER = DatabricksTrigger(
         conn_id=CONN_ID,
         task_id=TASK_ID,
         run_id=RUN_ID,
@@ -134,169 +93,166 @@ async def test_databricks_trigger_success(mock_run_response, run_state):
         polling_period_seconds=POLLING_PERIOD_SECONDS,
     )
 
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
+    def test_databricks_trigger_serialization(self):
+        """
+        Asserts that the DatabricksTrigger correctly serializes its arguments
+        and classpath.
+        """
 
-    # TriggerEvent was returned
-    assert task.done() is True
-
-    # Prevents error when task is destroyed while in "pending" state
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch("airflow.providers.databricks.hooks.databricks.RunState")
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
-async def test_databricks_trigger_running(mock_run_response, run_state, caplog):
-    """
-    Tests that the DatabricksTrigger does not fire while a
-    Databricks run has not yet reached a terminated state.
-    """
-    mock_run_response.return_value = {
-        "state": {
-            "life_cycle_state": "RUNNING",
-            "result_state": "",
-            "state_message": "In run",
-            "user_cancelled_or_timedout": "False",
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == "astronomer.providers.databricks.triggers.databricks.DatabricksTrigger"
+        assert kwargs == {
+            "conn_id": CONN_ID,
+            "task_id": TASK_ID,
+            "run_id": RUN_ID,
+            "retry_limit": 2,
+            "retry_delay": 1.0,
+            "polling_period_seconds": 1.0,
+            "job_id": None,
+            "run_page_url": None,
         }
-    }
 
-    caplog.set_level(logging.INFO)
-
-    trigger = DatabricksTrigger(
-        conn_id=CONN_ID,
-        task_id=TASK_ID,
-        run_id=RUN_ID,
-        retry_limit=RETRY_LIMIT,
-        retry_delay=RETRY_DELAY,
-        polling_period_seconds=POLLING_PERIOD_SECONDS,
-    )
-
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-
-    assert (
-        f"{TASK_ID} in run state: {{'life_cycle_state': 'RUNNING', 'result_state': '', 'state_message': 'In run'}}"
-        in caplog.text
-    )
-    assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
-
-    # Prevents error when task is destroyed while in "pending" state
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch("airflow.providers.databricks.hooks.databricks.RunState")
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
-async def test_databricks_trigger_terminated(mock_run_response, mock_run_state):
-    """
-    Tests that the DatabricksTrigger does not fire once a
-    Databricks run reaches a terminated state.
-    Assert that an exception is thrown instead.
-    """
-    mock_run_response.return_value = {
-        "state": {
-            "life_cycle_state": "TERMINATED",
-            "result_state": "TERMINATED",
-            "state_message": "",
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.databricks.hooks.databricks.RunState")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
+    async def test_databricks_trigger_success(self, mock_run_response, run_state):
+        """
+        Tests that the DatabricksTrigger only fires once a
+        Databricks run reaches a successful state.
+        """
+        mock_run_response.return_value = {
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "SUCCESS",
+                "state_message": "",
+            }
         }
-    }
 
-    trigger = DatabricksTrigger(
-        conn_id=CONN_ID,
-        task_id=TASK_ID,
-        run_id=RUN_ID,
-        retry_limit=RETRY_LIMIT,
-        retry_delay=RETRY_DELAY,
-        polling_period_seconds=POLLING_PERIOD_SECONDS,
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was returned
+        assert task.done() is True
+
+        # Prevents error when task is destroyed while in "pending" state
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.databricks.hooks.databricks.RunState")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
+    async def test_databricks_trigger_running(self, mock_run_response, run_state, caplog):
+        """
+        Tests that the DatabricksTrigger does not fire while a
+        Databricks run has not yet reached a terminated state.
+        """
+        mock_run_response.return_value = {
+            "state": {
+                "life_cycle_state": "RUNNING",
+                "result_state": "",
+                "state_message": "In run",
+                "user_cancelled_or_timedout": "False",
+            }
+        }
+
+        caplog.set_level(logging.INFO)
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+
+        assert (
+            f"{TASK_ID} in run state: {{'life_cycle_state': 'RUNNING', 'result_state': '', 'state_message': 'In run'}}"
+            in caplog.text
+        )
+        assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
+
+        # Prevents error when task is destroyed while in "pending" state
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.databricks.hooks.databricks.RunState")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
+    async def test_databricks_trigger_terminated(self, mock_run_response, mock_run_state):
+        """
+        Tests that the DatabricksTrigger does not fire once a
+        Databricks run reaches a terminated state.
+        Assert that an exception is thrown instead.
+        """
+        mock_run_response.return_value = {
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "TERMINATED",
+                "state_message": "",
+            }
+        }
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert (
+                TriggerEvent(
+                    {
+                        "status": "error",
+                        "message": "databricks_check failed with terminal state: {'life_cycle_state': 'TERMINATED',"
+                                   " 'result_state': 'TERMINATED', 'state_message': ''} and with the error ",
+                    }
+                )
+                == actual
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_run_response, mock_get_output_response",
+        [
+            (MOCK_RUN_RESPONSE_IN_ERROR_1, MOCK_RUN_GET_OUTPUT_RESPONSE_IN_ERROR_1),
+            (MOCK_RUN_RESPONSE_IN_ERROR_1, MOCK_RUN_GET_OUTPUT_RESPONSE_IN_ERROR_2),
+            (MOCK_RUN_RESPONSE_IN_ERROR_2, MOCK_RUN_GET_OUTPUT_RESPONSE_IN_ERROR_2),
+        ],
     )
+    @mock.patch("airflow.providers.databricks.hooks.databricks.RunState")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_output_response")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
+    async def test_databricks_trigger_terminal_status_failed(
+            self, mock_run_response_func, mock_get_run_output, mock_run_state, mock_run_response,
+            mock_get_output_response
+    ):
+        """
+        Tests that the DatabricksTrigger does not fire once a
+        Databricks run reaches a terminated state.
+        Assert that an exception is thrown instead.
+        """
+        mock_run_response_func.return_value = mock_run_response
+        mock_get_run_output.return_value = mock_get_output_response
 
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert (
-        TriggerEvent(
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert (
+                TriggerEvent(
+                    {
+                        "status": "error",
+                        "message": "databricks_check failed with terminal state: {'life_cycle_state': 'TERMINATED',"
+                                   " 'result_state': 'FAILED', 'state_message': 'Test error'}"
+                                   " and with the error Test error",
+                    }
+                )
+                == actual
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
+    async def test_databricks_trigger_exception(self, run_state):
+        """
+        Tests that the DatabricksTrigger yield error in case of exception
+        """
+        run_state.side_effect = AirflowException("Bad request")
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+
+        assert actual == TriggerEvent(
             {
                 "status": "error",
-                "message": "databricks_check failed with terminal state: {'life_cycle_state': 'TERMINATED',"
-                " 'result_state': 'TERMINATED', 'state_message': ''} and with the error ",
+                "message": "Bad request",
             }
         )
-        == actual
-    )
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "mock_run_response, mock_get_output_response",
-    [
-        (MOCK_RUN_RESPONSE_IN_ERROR_1, MOCK_RUN_GET_OUTPUT_RESPONSE_IN_ERROR_1),
-        (MOCK_RUN_RESPONSE_IN_ERROR_1, MOCK_RUN_GET_OUTPUT_RESPONSE_IN_ERROR_2),
-        (MOCK_RUN_RESPONSE_IN_ERROR_2, MOCK_RUN_GET_OUTPUT_RESPONSE_IN_ERROR_2),
-    ],
-)
-@mock.patch("airflow.providers.databricks.hooks.databricks.RunState")
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_output_response")
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
-async def test_databricks_trigger_terminal_status_failed(
-    mock_run_response_func, mock_get_run_output, mock_run_state, mock_run_response, mock_get_output_response
-):
-    """
-    Tests that the DatabricksTrigger does not fire once a
-    Databricks run reaches a terminated state.
-    Assert that an exception is thrown instead.
-    """
-    mock_run_response_func.return_value = mock_run_response
-    mock_get_run_output.return_value = mock_get_output_response
-    trigger = DatabricksTrigger(
-        conn_id=CONN_ID,
-        task_id=TASK_ID,
-        run_id=RUN_ID,
-        retry_limit=RETRY_LIMIT,
-        retry_delay=RETRY_DELAY,
-        polling_period_seconds=POLLING_PERIOD_SECONDS,
-    )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert (
-        TriggerEvent(
-            {
-                "status": "error",
-                "message": "databricks_check failed with terminal state: {'life_cycle_state': 'TERMINATED',"
-                " 'result_state': 'FAILED', 'state_message': 'Test error'}"
-                " and with the error Test error",
-            }
-        )
-        == actual
-    )
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
-async def test_databricks_trigger_exception(run_state):
-    """
-    Tests that the DatabricksTrigger yield error in case of exception
-    """
-    run_state.side_effect = AirflowException("Bad request")
-
-    trigger = DatabricksTrigger(
-        conn_id=CONN_ID,
-        task_id=TASK_ID,
-        run_id=RUN_ID,
-        retry_limit=RETRY_LIMIT,
-        retry_delay=RETRY_DELAY,
-        polling_period_seconds=POLLING_PERIOD_SECONDS,
-    )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-
-    assert actual == TriggerEvent(
-        {
-            "status": "error",
-            "message": "Bad request",
-        }
-    )

--- a/tests/databricks/triggers/test_databricks.py
+++ b/tests/databricks/triggers/test_databricks.py
@@ -191,14 +191,14 @@ class TestDatabricksTrigger:
         generator = self.TRIGGER.run()
         actual = await generator.asend(None)
         assert (
-                TriggerEvent(
-                    {
-                        "status": "error",
-                        "message": "databricks_check failed with terminal state: {'life_cycle_state': 'TERMINATED',"
-                                   " 'result_state': 'TERMINATED', 'state_message': ''} and with the error ",
-                    }
-                )
-                == actual
+            TriggerEvent(
+                {
+                    "status": "error",
+                    "message": "databricks_check failed with terminal state: {'life_cycle_state': 'TERMINATED',"
+                    " 'result_state': 'TERMINATED', 'state_message': ''} and with the error ",
+                }
+            )
+            == actual
         )
 
     @pytest.mark.asyncio
@@ -211,11 +211,17 @@ class TestDatabricksTrigger:
         ],
     )
     @mock.patch("airflow.providers.databricks.hooks.databricks.RunState")
-    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_output_response")
+    @mock.patch(
+        "astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_output_response"
+    )
     @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHookAsync.get_run_response")
     async def test_databricks_trigger_terminal_status_failed(
-            self, mock_run_response_func, mock_get_run_output, mock_run_state, mock_run_response,
-            mock_get_output_response
+        self,
+        mock_run_response_func,
+        mock_get_run_output,
+        mock_run_state,
+        mock_run_response,
+        mock_get_output_response,
     ):
         """
         Tests that the DatabricksTrigger does not fire once a
@@ -228,15 +234,15 @@ class TestDatabricksTrigger:
         generator = self.TRIGGER.run()
         actual = await generator.asend(None)
         assert (
-                TriggerEvent(
-                    {
-                        "status": "error",
-                        "message": "databricks_check failed with terminal state: {'life_cycle_state': 'TERMINATED',"
-                                   " 'result_state': 'FAILED', 'state_message': 'Test error'}"
-                                   " and with the error Test error",
-                    }
-                )
-                == actual
+            TriggerEvent(
+                {
+                    "status": "error",
+                    "message": "databricks_check failed with terminal state: {'life_cycle_state': 'TERMINATED',"
+                    " 'result_state': 'FAILED', 'state_message': 'Test error'}"
+                    " and with the error Test error",
+                }
+            )
+            == actual
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-providers/issues/693
related-to: https://github.com/astronomer/astronomer-providers/issues/568

- convert the function-based test to a class-based
- remove context fixture definition from operator/sensor/extractor and reuse from conftest
- remove function create_context from a couple of test files and reuse it from the util
- remove duplicate code for initializing op/senor/trigger/hook at possible places