### PR TITLE
Install gke-gcloud-auth-plugin to fix auth failures

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -29,7 +29,8 @@ RUN apt-get update -y \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
     apt-get update -y && \
-    apt-get install google-cloud-sdk -y
+    apt-get install google-cloud-sdk -y && \
+    apt-get install google-cloud-sdk-gke-gcloud-auth-plugin -y
 
 # Set Hive and Hadoop versions.
 ENV HIVE_LIBRARY_VERSION=hive-2.3.9

--- a/dev/Dockerfile.google_cloud
+++ b/dev/Dockerfile.google_cloud
@@ -13,7 +13,8 @@ RUN apt-get install -y --no-install-recommends \
         echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
         apt-get update -y && \
-        apt-get install google-cloud-sdk -y
+        apt-get install google-cloud-sdk -y && \
+        apt-get install google-cloud-sdk-gke-gcloud-auth-plugin -y
 
 COPY setup.cfg ${AIRFLOW_HOME}/astronomer_providers/setup.cfg
 COPY pyproject.toml ${AIRFLOW_HOME}/astronomer_providers/pyproject.toml


### PR DESCRIPTION
With kubectl v1.26, the auth mechanism has been altered and now it needs the gke-gcloud-auth-plugin for authentication to succeed. Install the same in the docker image getting built to be run in CI.

closes: #842 