### PR TITLE
Snowflake class based tests

### DIFF
--- a/tests/snowflake/extractors/test_snowflake.py
+++ b/tests/snowflake/extractors/test_snowflake.py
@@ -1,10 +1,10 @@
+import datetime
 from typing import Dict
 from unittest import mock
 
 import pytest
 from airflow import DAG
 from airflow.models import Connection
-from airflow.utils.dates import days_ago
 from airflow.version import version as AIRFLOW_VERSION
 from openlineage.airflow.extractors.base import TaskMetadata
 from openlineage.client.facet import SqlJobFacet
@@ -30,165 +30,137 @@ DB_TABLE_COLUMNS = [
     DbColumn(name="STARTS_ON", type="timestamp", ordinal_position=4),
     DbColumn(name="ENDS_ON", type="timestamp", ordinal_position=5),
 ]
-DB_TABLE_SCHEMA = DbTableSchema(
-    schema_name=DB_SCHEMA_NAME, table_name=DB_TABLE_NAME, columns=DB_TABLE_COLUMNS
-)
-NO_DB_TABLE_SCHEMA = []
-
-SQL = f"SELECT * FROM {DB_NAME}.{DB_SCHEMA_NAME}.{DB_TABLE_NAME.name};"
+DB_TABLE_SCHEMA = DbTableSchema(schema_name=DB_SCHEMA_NAME, table_name=DB_TABLE_NAME, columns=DB_TABLE_COLUMNS)
 
 DAG_ID = "email_discounts"
-DAG_OWNER = "datascience"
-DAG_DEFAULT_ARGS = {
-    "owner": DAG_OWNER,
-    "depends_on_past": False,
-    "start_date": days_ago(7),
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "email": ["datascience@example.com"],
-}
-DAG_DESCRIPTION = "Email discounts to customers that have experienced order delays daily"
 
-DAG = dag = DAG(
-    DAG_ID, schedule_interval="@weekly", default_args=DAG_DEFAULT_ARGS, description=DAG_DESCRIPTION
-)
+DAG = DAG(DAG_ID, schedule_interval="@weekly", start_date=datetime.datetime(2023, 1, 1))
 
 TASK_ID = "select"
 TASK = SnowflakeOperatorAsync(
     task_id=TASK_ID,
     snowflake_conn_id=CONN_ID,
-    sql=SQL,
+    sql=f"SELECT * FROM {DB_NAME}.{DB_SCHEMA_NAME}.{DB_TABLE_NAME.name};",
     dag=DAG,
 )
 
 
-@mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_table_schemas")  # noqa
-@mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_connection")
-def test_extract(get_connection, mock_get_table_schemas):
-    source = Source(scheme="snowflake", authority="test_account", connection_url=CONN_URI_URIPARSED)
+class TestSnowflakeAsyncExtractor:
 
-    mock_get_table_schemas.return_value = (
-        [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME)],
-        [],
-    )
+    @mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_table_schemas")  # noqa
+    @mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_connection")
+    def test_extract(self, get_connection, mock_get_table_schemas):
+        source = Source(scheme="snowflake", authority="test_account", connection_url=CONN_URI_URIPARSED)
 
-    conn = Connection()
-    conn.parse_from_uri(uri=CONN_URI)
-    get_connection.return_value = conn
+        mock_get_table_schemas.return_value = (
+            [Dataset.from_table_schema(source, DB_TABLE_SCHEMA, DB_NAME)],
+            [],
+        )
 
-    TASK.get_hook = mock.MagicMock()
-    TASK.get_hook.return_value._get_conn_params.return_value = {
-        "account": "test_account",
-        "database": DB_NAME,
-    }
+        conn = Connection()
+        conn.parse_from_uri(uri=CONN_URI)
+        get_connection.return_value = conn
 
-    expected_inputs = [
-        Dataset(
-            name=f"{DB_NAME}.{DB_SCHEMA_NAME}.{DB_TABLE_NAME.name}",
-            source=source,
-            fields=[Field.from_column(column) for column in DB_TABLE_COLUMNS],
-        ).to_openlineage_dataset()
-    ]
+        TASK.get_hook = mock.MagicMock()
+        TASK.get_hook.return_value._get_conn_params.return_value = {
+            "account": "test_account",
+            "database": DB_NAME,
+        }
 
-    task_metadata = SnowflakeAsyncExtractor(TASK).extract()
+        expected_inputs = [
+            Dataset(
+                name=f"{DB_NAME}.{DB_SCHEMA_NAME}.{DB_TABLE_NAME.name}",
+                source=source,
+                fields=[Field.from_column(column) for column in DB_TABLE_COLUMNS],
+            ).to_openlineage_dataset()
+        ]
 
-    assert task_metadata.name == f"{DAG_ID}.{TASK_ID}"
-    assert task_metadata.inputs == expected_inputs
-    assert task_metadata.outputs == []
+        task_metadata = SnowflakeAsyncExtractor(TASK).extract()
 
+        assert task_metadata.name == f"{DAG_ID}.{TASK_ID}"
+        assert task_metadata.inputs == expected_inputs
+        assert task_metadata.outputs == []
 
-@pytest.mark.skipif(parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"), reason="Airflow 2+ test")  # noqa
-@mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_table_schemas")  # noqa
-@mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_connection")
-def test_extract_query_id(get_connection, mock_get_table_schemas):
-    mock_get_table_schemas.return_value = (
-        [],
-        [],
-    )
+    @pytest.mark.skipif(parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"), reason="Airflow 2+ test")  # noqa
+    @mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_table_schemas")  # noqa
+    @mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_connection")
+    def test_extract_query_id(self, get_connection, mock_get_table_schemas):
+        mock_get_table_schemas.return_value = ([], [])
 
-    conn = Connection()
-    conn.parse_from_uri(uri=CONN_URI)
-    get_connection.return_value = conn
+        conn = Connection()
+        conn.parse_from_uri(uri=CONN_URI)
+        get_connection.return_value = conn
 
-    TASK.get_hook = mock.MagicMock()
-    TASK.get_hook.return_value._get_conn_params.return_value = {
-        "account": "test_account",
-        "database": DB_NAME,
-    }
-    TASK.query_ids = ["1500100900"]
+        TASK.get_hook = mock.MagicMock()
+        TASK.get_hook.return_value._get_conn_params.return_value = {
+            "account": "test_account",
+            "database": DB_NAME,
+        }
+        TASK.query_ids = ["1500100900"]
 
-    task_metadata = SnowflakeAsyncExtractor(TASK).extract()
+        task_metadata = SnowflakeAsyncExtractor(TASK).extract()
 
-    assert task_metadata.run_facets["externalQuery"].externalQueryId == "1500100900"
+        assert task_metadata.run_facets["externalQuery"].externalQueryId == "1500100900"
 
+    @pytest.mark.skipif(parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"), reason="Airflow 2+ test")  # noqa
+    @mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_table_schemas")  # noqa
+    @mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_connection")
+    def test_extract_query_ids(self, get_connection, mock_get_table_schemas):
+        mock_get_table_schemas.return_value = ([], [])
 
-@pytest.mark.skipif(parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"), reason="Airflow 2+ test")  # noqa
-@mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_table_schemas")  # noqa
-@mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_connection")
-def test_extract_query_ids(get_connection, mock_get_table_schemas):
-    mock_get_table_schemas.return_value = (
-        [],
-        [],
-    )
+        conn = Connection()
+        conn.parse_from_uri(uri=CONN_URI)
+        get_connection.return_value = conn
 
-    conn = Connection()
-    conn.parse_from_uri(uri=CONN_URI)
-    get_connection.return_value = conn
+        TASK.get_hook = mock.MagicMock()
+        TASK.get_hook.return_value._get_conn_params.return_value = {
+            "account": "test_account",
+            "database": DB_NAME,
+        }
+        TASK.query_ids = ["1500100900", "1500100911"]
 
-    TASK.get_hook = mock.MagicMock()
-    TASK.get_hook.return_value._get_conn_params.return_value = {
-        "account": "test_account",
-        "database": DB_NAME,
-    }
-    TASK.query_ids = ["1500100900", "1500100911"]
+        task_metadata = SnowflakeAsyncExtractor(TASK).extract()
 
-    task_metadata = SnowflakeAsyncExtractor(TASK).extract()
+        assert task_metadata.run_facets == {}
 
-    assert task_metadata.run_facets == {}
+    def test_extract_without_sql(self):
+        async_task_ = SnowflakeOperatorAsync(
+            task_id="test_1",
+            snowflake_conn_id=CONN_ID,
+            sql=None,
+            dag=DAG,
+        )
+        run_facets: Dict = {}
+        job_facets = {"sql": SqlJobFacet(None)}
+        task_metadata = SnowflakeAsyncExtractor(async_task_).extract()
+        assert task_metadata == TaskMetadata(
+            name="email_discounts.test_1", inputs=[], outputs=[], run_facets=run_facets, job_facets=job_facets
+        )
 
+    def test_get_operator_classnames(self):
+        extractor = SnowflakeAsyncExtractor(TASK)
+        class_name = extractor.get_operator_classnames()
+        assert class_name == ["SnowflakeOperatorAsync"]
 
-def test_extract_without_sql():
-    async_task_ = SnowflakeOperatorAsync(
-        task_id="test_1",
-        snowflake_conn_id=CONN_ID,
-        sql=None,
-        dag=DAG,
-    )
-    run_facets: Dict = {}
-    job_facets = {"sql": SqlJobFacet(None)}
-    task_metadata = SnowflakeAsyncExtractor(async_task_).extract()
-    assert task_metadata == TaskMetadata(
-        name="email_discounts.test_1", inputs=[], outputs=[], run_facets=run_facets, job_facets=job_facets
-    )
+    def test_get_database(self):
+        TASK.database = DB_NAME
+        task_metadata = SnowflakeAsyncExtractor(TASK)
+        response = task_metadata._get_database()
+        assert response == DB_NAME
 
+    def test_get_authority(self):
+        TASK.account = "test_account"
+        TASK.get_hook = mock.MagicMock()
+        TASK.get_hook.return_value._get_conn_params.return_value = {
+            "account": "test_account",
+            "database": DB_NAME,
+        }
+        task_metadata = SnowflakeAsyncExtractor(TASK)
+        response = task_metadata._get_authority()
+        assert response == "test_account"
 
-def test_get_operator_classnames():
-    extractor = SnowflakeAsyncExtractor(TASK)
-    class_name = extractor.get_operator_classnames()
-    assert class_name == ["SnowflakeOperatorAsync"]
-
-
-def test_get_database():
-    TASK.database = DB_NAME
-    task_metadata = SnowflakeAsyncExtractor(TASK)
-    response = task_metadata._get_database()
-    assert response == DB_NAME
-
-
-def test_get_authority():
-    TASK.account = "test_account"
-    TASK.get_hook = mock.MagicMock()
-    TASK.get_hook.return_value._get_conn_params.return_value = {
-        "account": "test_account",
-        "database": DB_NAME,
-    }
-    task_metadata = SnowflakeAsyncExtractor(TASK)
-    response = task_metadata._get_authority()
-    assert response == "test_account"
-
-
-def test_get_query_ids():
-    delattr(TASK, "query_ids")
-    task_metadata = SnowflakeAsyncExtractor(TASK)
-    response = task_metadata._get_query_ids()
-    assert response == []
+    def test_get_query_ids(self):
+        delattr(TASK, "query_ids")
+        task_metadata = SnowflakeAsyncExtractor(TASK)
+        response = task_metadata._get_query_ids()
+        assert response == []

--- a/tests/snowflake/extractors/test_snowflake.py
+++ b/tests/snowflake/extractors/test_snowflake.py
@@ -25,10 +25,8 @@ DB_SCHEMA_NAME = "PUBLIC"
 DB_TABLE_NAME = DbTableMeta("DISCOUNTS")
 DB_TABLE_COLUMNS = [
     DbColumn(name="ID", type="int4", ordinal_position=1),
-    DbColumn(name="AMOUNT_OFF", type="int4", ordinal_position=2),
     DbColumn(name="CUSTOMER_EMAIL", type="varchar", ordinal_position=3),
     DbColumn(name="STARTS_ON", type="timestamp", ordinal_position=4),
-    DbColumn(name="ENDS_ON", type="timestamp", ordinal_position=5),
 ]
 DB_TABLE_SCHEMA = DbTableSchema(schema_name=DB_SCHEMA_NAME, table_name=DB_TABLE_NAME, columns=DB_TABLE_COLUMNS)
 

--- a/tests/snowflake/extractors/test_snowflake.py
+++ b/tests/snowflake/extractors/test_snowflake.py
@@ -28,7 +28,9 @@ DB_TABLE_COLUMNS = [
     DbColumn(name="CUSTOMER_EMAIL", type="varchar", ordinal_position=3),
     DbColumn(name="STARTS_ON", type="timestamp", ordinal_position=4),
 ]
-DB_TABLE_SCHEMA = DbTableSchema(schema_name=DB_SCHEMA_NAME, table_name=DB_TABLE_NAME, columns=DB_TABLE_COLUMNS)
+DB_TABLE_SCHEMA = DbTableSchema(
+    schema_name=DB_SCHEMA_NAME, table_name=DB_TABLE_NAME, columns=DB_TABLE_COLUMNS
+)
 
 DAG_ID = "email_discounts"
 
@@ -44,7 +46,6 @@ TASK = SnowflakeOperatorAsync(
 
 
 class TestSnowflakeAsyncExtractor:
-
     @mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_table_schemas")  # noqa
     @mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_connection")
     def test_extract(self, get_connection, mock_get_table_schemas):
@@ -79,7 +80,9 @@ class TestSnowflakeAsyncExtractor:
         assert task_metadata.inputs == expected_inputs
         assert task_metadata.outputs == []
 
-    @pytest.mark.skipif(parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"), reason="Airflow 2+ test")  # noqa
+    @pytest.mark.skipif(
+        parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"), reason="Airflow 2+ test"
+    )  # noqa
     @mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_table_schemas")  # noqa
     @mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_connection")
     def test_extract_query_id(self, get_connection, mock_get_table_schemas):
@@ -100,7 +103,9 @@ class TestSnowflakeAsyncExtractor:
 
         assert task_metadata.run_facets["externalQuery"].externalQueryId == "1500100900"
 
-    @pytest.mark.skipif(parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"), reason="Airflow 2+ test")  # noqa
+    @pytest.mark.skipif(
+        parse_version(AIRFLOW_VERSION) < parse_version("2.0.0"), reason="Airflow 2+ test"
+    )  # noqa
     @mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_table_schemas")  # noqa
     @mock.patch("astronomer.providers.snowflake.extractors.snowflake.get_connection")
     def test_extract_query_ids(self, get_connection, mock_get_table_schemas):

--- a/tests/snowflake/hooks/test_snowflake_sql_api.py
+++ b/tests/snowflake/hooks/test_snowflake_sql_api.py
@@ -102,6 +102,7 @@ def create_successful_response_mock(content):
     response.status_code = 200
     return response
 
+
 def create_post_side_effect(status_code=429):
     """create mock response for post side effect"""
     response = mock.MagicMock()

--- a/tests/snowflake/hooks/test_snowflake_sql_api.py
+++ b/tests/snowflake/hooks/test_snowflake_sql_api.py
@@ -102,41 +102,6 @@ def create_successful_response_mock(content):
     response.status_code = 200
     return response
 
-
-@pytest.mark.parametrize(
-    "sql,statement_count,expected_response, expected_query_ids",
-    [
-        (SINGLE_STMT, 1, {"statementHandle": "uuid"}, ["uuid"]),
-        (SQL_MULTIPLE_STMTS, 4, {"statementHandles": ["uuid", "uuid1"]}, ["uuid", "uuid1"]),
-    ],
-)
-@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.requests")
-@mock.patch(
-    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync._get_conn_params"
-)
-@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_headers")
-def test_execute_query(
-    mock_get_header,
-    mock_conn_param,
-    mock_requests,
-    sql,
-    statement_count,
-    expected_response,
-    expected_query_ids,
-):
-    """Test execute_query method, run query by mocking post request method and return the query ids"""
-    mock_requests.codes.ok = 200
-    mock_requests.post.side_effect = [
-        create_successful_response_mock(expected_response),
-    ]
-    status_code_mock = mock.PropertyMock(return_value=200)
-    type(mock_requests.post.return_value).status_code = status_code_mock
-
-    hook = SnowflakeSqlApiHookAsync("mock_conn_id")
-    query_ids = hook.execute_query(sql, statement_count)
-    assert query_ids == expected_query_ids
-
-
 def create_post_side_effect(status_code=429):
     """create mock response for post side effect"""
     response = mock.MagicMock()
@@ -146,300 +111,325 @@ def create_post_side_effect(status_code=429):
     return response
 
 
-@pytest.mark.parametrize(
-    "sql,statement_count,expected_response, expected_query_ids",
-    [(SINGLE_STMT, 1, {"statementHandle": "uuid"}, ["uuid"])],
-)
-@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.requests")
-@mock.patch(
-    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync._get_conn_params"
-)
-@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_headers")
-def test_execute_query_exception_without_statement_handel(
-    mock_get_header,
-    mock_conn_param,
-    mock_requests,
-    sql,
-    statement_count,
-    expected_response,
-    expected_query_ids,
-):
-    """
-    Test execute_query method by mocking the exception response and raise airflow exception
-    without statementHandle in the response
-    """
-    side_effect = create_post_side_effect()
-    mock_requests.post.side_effect = side_effect
-    hook = SnowflakeSqlApiHookAsync("mock_conn_id")
+class TestSnowflakeSqlApiHookAsync:
+    @pytest.mark.parametrize(
+        "sql,statement_count,expected_response, expected_query_ids",
+        [
+            (SINGLE_STMT, 1, {"statementHandle": "uuid"}, ["uuid"]),
+            (SQL_MULTIPLE_STMTS, 4, {"statementHandles": ["uuid", "uuid1"]}, ["uuid", "uuid1"]),
+        ],
+    )
+    @mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.requests")
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync._get_conn_params"
+    )
+    @mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_headers")
+    def test_execute_query(
+        self,
+        mock_get_header,
+        mock_conn_param,
+        mock_requests,
+        sql,
+        statement_count,
+        expected_response,
+        expected_query_ids,
+    ):
+        """Test execute_query method, run query by mocking post request method and return the query ids"""
+        mock_requests.codes.ok = 200
+        mock_requests.post.side_effect = [
+            create_successful_response_mock(expected_response),
+        ]
+        status_code_mock = mock.PropertyMock(return_value=200)
+        type(mock_requests.post.return_value).status_code = status_code_mock
 
-    with pytest.raises(AirflowException) as exception_info:
-        hook.execute_query(sql, statement_count)
-    assert exception_info
+        hook = SnowflakeSqlApiHookAsync("mock_conn_id")
+        query_ids = hook.execute_query(sql, statement_count)
+        assert query_ids == expected_query_ids
 
+    @pytest.mark.parametrize(
+        "sql,statement_count,expected_response, expected_query_ids",
+        [(SINGLE_STMT, 1, {"statementHandle": "uuid"}, ["uuid"])],
+    )
+    @mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.requests")
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync._get_conn_params"
+    )
+    @mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_headers")
+    def test_execute_query_exception_without_statement_handel(
+        self,
+        mock_get_header,
+        mock_conn_param,
+        mock_requests,
+        sql,
+        statement_count,
+        expected_response,
+        expected_query_ids,
+    ):
+        """
+        Test execute_query method by mocking the exception response and raise airflow exception
+        without statementHandle in the response
+        """
+        side_effect = create_post_side_effect()
+        mock_requests.post.side_effect = side_effect
+        hook = SnowflakeSqlApiHookAsync("mock_conn_id")
 
-@pytest.mark.parametrize(
-    "query_ids",
-    [
-        (["uuid", "uuid1"]),
-    ],
-)
-@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.requests")
-@mock.patch(
-    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync."
-    "get_request_url_header_params"
-)
-def test_check_query_output(mock_geturl_header_params, mock_requests, query_ids):
-    """Test check_query_output by passing query ids as params and mock get_request_url_header_params"""
-    req_id = uuid.uuid4()
-    params = {"requestId": str(req_id), "page": 2, "pageSize": 10}
-    mock_geturl_header_params.return_value = HEADERS, params, "/test/airflow/"
-    mock_requests.get.return_value.json.return_value = GET_RESPONSE
-    hook = SnowflakeSqlApiHookAsync("mock_conn_id")
-    with mock.patch.object(hook.log, "info") as mock_log_info:
-        hook.check_query_output(query_ids)
-    mock_log_info.assert_called_with(GET_RESPONSE)
+        with pytest.raises(AirflowException) as exception_info:
+            hook.execute_query(sql, statement_count)
+        assert exception_info
 
-
-@pytest.mark.parametrize(
-    "query_ids",
-    [
-        (["uuid", "uuid1"]),
-    ],
-)
-@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.requests.get")
-@mock.patch(
-    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync."
-    "get_request_url_header_params"
-)
-def test_check_query_output_exception(mock_geturl_header_params, mock_requests, query_ids):
-    """
-    Test check_query_output by passing query ids as params and mock get_request_url_header_params
-    to raise airflow exception and mock with http error
-    """
-    req_id = uuid.uuid4()
-    params = {"requestId": str(req_id), "page": 2, "pageSize": 10}
-    mock_geturl_header_params.return_value = HEADERS, params, "/test/airflow/"
-    mock_resp = requests.models.Response()
-    mock_resp.status_code = 404
-    mock_requests.return_value = mock_resp
-    hook = SnowflakeSqlApiHookAsync("mock_conn_id")
-    with mock.patch.object(hook.log, "error"):
-        with pytest.raises(AirflowException) as airflow_exception:
+    @pytest.mark.parametrize(
+        "query_ids",
+        [
+            (["uuid", "uuid1"]),
+        ],
+    )
+    @mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.requests")
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync."
+        "get_request_url_header_params"
+    )
+    def test_check_query_output(self, mock_geturl_header_params, mock_requests, query_ids):
+        """Test check_query_output by passing query ids as params and mock get_request_url_header_params"""
+        req_id = uuid.uuid4()
+        params = {"requestId": str(req_id), "page": 2, "pageSize": 10}
+        mock_geturl_header_params.return_value = HEADERS, params, "/test/airflow/"
+        mock_requests.get.return_value.json.return_value = GET_RESPONSE
+        hook = SnowflakeSqlApiHookAsync("mock_conn_id")
+        with mock.patch.object(hook.log, "info") as mock_log_info:
             hook.check_query_output(query_ids)
-        assert airflow_exception
+        mock_log_info.assert_called_with(GET_RESPONSE)
 
-
-@mock.patch(
-    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync._get_conn_params"
-)
-@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_headers")
-def test_get_request_url_header_params(mock_get_header, mock_conn_param):
-    """Test get_request_url_header_params by mocking _get_conn_params and get_headers"""
-    mock_conn_param.return_value = CONN_PARAMS
-    mock_get_header.return_value = HEADERS
-    hook = SnowflakeSqlApiHookAsync("mock_conn_id")
-    header, params, url = hook.get_request_url_header_params("uuid")
-    assert header == HEADERS
-    assert url == "https://airflow.snowflakecomputing.com/api/v2/statements/uuid"
-
-
-@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_private_key")
-@mock.patch(
-    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync._get_conn_params"
-)
-@mock.patch("astronomer.providers.snowflake.hooks.sql_api_generate_jwt.JWTGenerator.get_token")
-def test_get_headers(mock_get_token, mock_conn_param, mock_private_key):
-    """Test get_headers method by mocking get_private_key and _get_conn_params method"""
-    mock_get_token.return_value = "newT0k3n"
-    mock_conn_param.return_value = CONN_PARAMS
-    hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="mock_conn_id")
-    result = hook.get_headers()
-    assert result == HEADERS
-
-
-@pytest.fixture()
-def non_encrypted_temporary_private_key(tmp_path: Path) -> Path:
-    """Encrypt the pem file from the path"""
-    key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=2048)
-    private_key = key.private_bytes(
-        serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8, serialization.NoEncryption()
+    @pytest.mark.parametrize(
+        "query_ids",
+        [
+            (["uuid", "uuid1"]),
+        ],
     )
-    test_key_file = tmp_path / "test_key.pem"
-    test_key_file.write_bytes(private_key)
-    return test_key_file
-
-
-@pytest.fixture()
-def encrypted_temporary_private_key(tmp_path: Path) -> Path:
-    """Encrypt private key from the temp path"""
-    key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=2048)
-    private_key = key.private_bytes(
-        serialization.Encoding.PEM,
-        serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.BestAvailableEncryption(_PASSWORD.encode()),
+    @mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.requests.get")
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync."
+        "get_request_url_header_params"
     )
-    test_key_file: Path = tmp_path / "test_key.p8"
-    test_key_file.write_bytes(private_key)
-    return test_key_file
+    def test_check_query_output_exception(self, mock_geturl_header_params, mock_requests, query_ids):
+        """
+        Test check_query_output by passing query ids as params and mock get_request_url_header_params
+        to raise airflow exception and mock with http error
+        """
+        req_id = uuid.uuid4()
+        params = {"requestId": str(req_id), "page": 2, "pageSize": 10}
+        mock_geturl_header_params.return_value = HEADERS, params, "/test/airflow/"
+        mock_resp = requests.models.Response()
+        mock_resp.status_code = 404
+        mock_requests.return_value = mock_resp
+        hook = SnowflakeSqlApiHookAsync("mock_conn_id")
+        with mock.patch.object(hook.log, "error"):
+            with pytest.raises(AirflowException) as airflow_exception:
+                hook.check_query_output(query_ids)
+            assert airflow_exception
 
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync._get_conn_params"
+    )
+    @mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_headers")
+    def test_get_request_url_header_params(self, mock_get_header, mock_conn_param):
+        """Test get_request_url_header_params by mocking _get_conn_params and get_headers"""
+        mock_conn_param.return_value = CONN_PARAMS
+        mock_get_header.return_value = HEADERS
+        hook = SnowflakeSqlApiHookAsync("mock_conn_id")
+        header, params, url = hook.get_request_url_header_params("uuid")
+        assert header == HEADERS
+        assert url == "https://airflow.snowflakecomputing.com/api/v2/statements/uuid"
 
-def test_get_private_key_should_support_private_auth_in_connection(encrypted_temporary_private_key: Path):
-    """Test get_private_key function with private_key_content in connection"""
-    connection_kwargs: Any = {
-        **BASE_CONNECTION_KWARGS,
-        "password": _PASSWORD,
-        "extra": {
-            "database": "db",
-            "account": "airflow",
-            "warehouse": "af_wh",
-            "region": "af_region",
-            "role": "af_role",
-            "private_key_content": str(encrypted_temporary_private_key.read_text()),
-        },
-    }
-    with unittest.mock.patch.dict(
-        "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
-    ):
-        hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
-        hook.get_private_key()
-        assert hook.private_key is not None
+    @mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_private_key")
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync._get_conn_params"
+    )
+    @mock.patch("astronomer.providers.snowflake.hooks.sql_api_generate_jwt.JWTGenerator.get_token")
+    def test_get_headers(self, mock_get_token, mock_conn_param, mock_private_key):
+        """Test get_headers method by mocking get_private_key and _get_conn_params method"""
+        mock_get_token.return_value = "newT0k3n"
+        mock_conn_param.return_value = CONN_PARAMS
+        hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="mock_conn_id")
+        result = hook.get_headers()
+        assert result == HEADERS
 
+    @pytest.fixture()
+    def non_encrypted_temporary_private_key(self, tmp_path: Path) -> Path:
+        """Encrypt the pem file from the path"""
+        key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=2048)
+        private_key = key.private_bytes(
+            serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8, serialization.NoEncryption()
+        )
+        test_key_file = tmp_path / "test_key.pem"
+        test_key_file.write_bytes(private_key)
+        return test_key_file
 
-def test_get_private_key_raise_exception(encrypted_temporary_private_key: Path):
-    """
-    Test get_private_key function with private_key_content and private_key_file in connection
-    and raise airflow exception
-    """
-    connection_kwargs: Any = {
-        **BASE_CONNECTION_KWARGS,
-        "password": _PASSWORD,
-        "extra": {
-            "database": "db",
-            "account": "airflow",
-            "warehouse": "af_wh",
-            "region": "af_region",
-            "role": "af_role",
-            "private_key_content": str(encrypted_temporary_private_key.read_text()),
-            "private_key_file": str(encrypted_temporary_private_key),
-        },
-    }
-    hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
-    with unittest.mock.patch.dict(
-        "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
-    ), pytest.raises(
-        AirflowException,
-        match="The private_key_file and private_key_content extra fields are mutually "
-        "exclusive. Please remove one.",
-    ):
-        hook.get_private_key()
+    @pytest.fixture()
+    def encrypted_temporary_private_key(self, tmp_path: Path) -> Path:
+        """Encrypt private key from the temp path"""
+        key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=2048)
+        private_key = key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.BestAvailableEncryption(_PASSWORD.encode()),
+        )
+        test_key_file: Path = tmp_path / "test_key.p8"
+        test_key_file.write_bytes(private_key)
+        return test_key_file
 
-
-def test_get_private_key_should_support_private_auth_with_encrypted_key(encrypted_temporary_private_key):
-    """Test get_private_key method by supporting for private auth encrypted_key"""
-    connection_kwargs = {
-        **BASE_CONNECTION_KWARGS,
-        "password": _PASSWORD,
-        "extra": {
-            "database": "db",
-            "account": "airflow",
-            "warehouse": "af_wh",
-            "region": "af_region",
-            "role": "af_role",
-            "private_key_file": str(encrypted_temporary_private_key),
-        },
-    }
-    with unittest.mock.patch.dict(
-        "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
-    ):
-        hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
-        hook.get_private_key()
-        assert hook.private_key is not None
-
-
-def test_get_private_key_should_support_private_auth_with_unencrypted_key(
-    non_encrypted_temporary_private_key,
-):
-    connection_kwargs = {
-        **BASE_CONNECTION_KWARGS,
-        "password": None,
-        "extra": {
-            "database": "db",
-            "account": "airflow",
-            "warehouse": "af_wh",
-            "region": "af_region",
-            "role": "af_role",
-            "private_key_file": str(non_encrypted_temporary_private_key),
-        },
-    }
-    with unittest.mock.patch.dict(
-        "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
-    ):
-        hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
-        hook.get_private_key()
-        assert hook.private_key is not None
-    connection_kwargs["password"] = ""
-    with unittest.mock.patch.dict(
-        "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
-    ):
-        hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
-        hook.get_private_key()
-        assert hook.private_key is not None
-    connection_kwargs["password"] = _PASSWORD
-    with unittest.mock.patch.dict(
-        "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
-    ), pytest.raises(TypeError, match="Password was given but private key is not encrypted."):
-        SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn").get_private_key()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "status_code,response,expected_response",
-    [
-        (
-            200,
-            {
-                "status": "success",
-                "message": "Statement executed successfully.",
-                "statementHandle": "uuid",
+    def test_get_private_key_should_support_private_auth_in_connection(self, encrypted_temporary_private_key: Path):
+        """Test get_private_key function with private_key_content in connection"""
+        connection_kwargs: Any = {
+            **BASE_CONNECTION_KWARGS,
+            "password": _PASSWORD,
+            "extra": {
+                "database": "db",
+                "account": "airflow",
+                "warehouse": "af_wh",
+                "region": "af_region",
+                "role": "af_role",
+                "private_key_content": str(encrypted_temporary_private_key.read_text()),
             },
-            {
-                "status": "success",
-                "message": "Statement executed successfully.",
-                "statement_handles": ["uuid"],
+        }
+        with unittest.mock.patch.dict(
+            "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
+        ):
+            hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
+            hook.get_private_key()
+            assert hook.private_key is not None
+
+    def test_get_private_key_raise_exception(self, encrypted_temporary_private_key: Path):
+        """
+        Test get_private_key function with private_key_content and private_key_file in connection
+        and raise airflow exception
+        """
+        connection_kwargs: Any = {
+            **BASE_CONNECTION_KWARGS,
+            "password": _PASSWORD,
+            "extra": {
+                "database": "db",
+                "account": "airflow",
+                "warehouse": "af_wh",
+                "region": "af_region",
+                "role": "af_role",
+                "private_key_content": str(encrypted_temporary_private_key.read_text()),
+                "private_key_file": str(encrypted_temporary_private_key),
             },
-        ),
-        (
-            200,
-            {
-                "status": "success",
-                "message": "Statement executed successfully.",
-                "statementHandles": ["uuid", "uuid1"],
+        }
+        hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
+        with unittest.mock.patch.dict(
+            "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
+        ), pytest.raises(
+            AirflowException,
+            match="The private_key_file and private_key_content extra fields are mutually "
+            "exclusive. Please remove one.",
+        ):
+            hook.get_private_key()
+
+    def test_get_private_key_should_support_private_auth_with_encrypted_key(self, encrypted_temporary_private_key):
+        """Test get_private_key method by supporting for private auth encrypted_key"""
+        connection_kwargs = {
+            **BASE_CONNECTION_KWARGS,
+            "password": _PASSWORD,
+            "extra": {
+                "database": "db",
+                "account": "airflow",
+                "warehouse": "af_wh",
+                "region": "af_region",
+                "role": "af_role",
+                "private_key_file": str(encrypted_temporary_private_key),
             },
-            {
-                "status": "success",
-                "message": "Statement executed successfully.",
-                "statement_handles": ["uuid", "uuid1"],
+        }
+        with unittest.mock.patch.dict(
+            "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
+        ):
+            hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
+            hook.get_private_key()
+            assert hook.private_key is not None
+
+    def test_get_private_key_should_support_private_auth_with_unencrypted_key(
+        self, non_encrypted_temporary_private_key,
+    ):
+        connection_kwargs = {
+            **BASE_CONNECTION_KWARGS,
+            "password": None,
+            "extra": {
+                "database": "db",
+                "account": "airflow",
+                "warehouse": "af_wh",
+                "region": "af_region",
+                "role": "af_role",
+                "private_key_file": str(non_encrypted_temporary_private_key),
             },
-        ),
-        (202, {}, {"status": "running", "message": "Query statements are still running"}),
-        (422, {"status": "error", "message": "test"}, {"status": "error", "message": "test"}),
-        (404, {"status": "error", "message": "test"}, {"status": "error", "message": "test"}),
-    ],
-)
-@mock.patch(
-    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync."
-    "get_request_url_header_params"
-)
-@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.aiohttp.ClientSession.get")
-async def test_get_sql_api_query_status(
-    mock_get, mock_geturl_header_params, status_code, response, expected_response
-):
-    """Test Async get_sql_api_query_status function by mocking the status, response and expected response"""
-    req_id = uuid.uuid4()
-    params = {"requestId": str(req_id), "page": 2, "pageSize": 10}
-    mock_geturl_header_params.return_value = HEADERS, params, "/test/airflow/"
-    mock_get.return_value.__aenter__.return_value.status = status_code
-    mock_get.return_value.__aenter__.return_value.json = AsyncMock(return_value=response)
-    hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
-    response = await hook.get_sql_api_query_status("uuid")
-    assert response == expected_response
+        }
+        with unittest.mock.patch.dict(
+            "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
+        ):
+            hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
+            hook.get_private_key()
+            assert hook.private_key is not None
+        connection_kwargs["password"] = ""
+        with unittest.mock.patch.dict(
+            "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
+        ):
+            hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
+            hook.get_private_key()
+            assert hook.private_key is not None
+        connection_kwargs["password"] = _PASSWORD
+        with unittest.mock.patch.dict(
+            "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
+        ), pytest.raises(TypeError, match="Password was given but private key is not encrypted."):
+            SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn").get_private_key()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status_code,response,expected_response",
+        [
+            (
+                200,
+                {
+                    "status": "success",
+                    "message": "Statement executed successfully.",
+                    "statementHandle": "uuid",
+                },
+                {
+                    "status": "success",
+                    "message": "Statement executed successfully.",
+                    "statement_handles": ["uuid"],
+                },
+            ),
+            (
+                200,
+                {
+                    "status": "success",
+                    "message": "Statement executed successfully.",
+                    "statementHandles": ["uuid", "uuid1"],
+                },
+                {
+                    "status": "success",
+                    "message": "Statement executed successfully.",
+                    "statement_handles": ["uuid", "uuid1"],
+                },
+            ),
+            (202, {}, {"status": "running", "message": "Query statements are still running"}),
+            (422, {"status": "error", "message": "test"}, {"status": "error", "message": "test"}),
+            (404, {"status": "error", "message": "test"}, {"status": "error", "message": "test"}),
+        ],
+    )
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync."
+        "get_request_url_header_params"
+    )
+    @mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.aiohttp.ClientSession.get")
+    async def test_get_sql_api_query_status(
+        self, mock_get, mock_geturl_header_params, status_code, response, expected_response
+    ):
+        """Test Async get_sql_api_query_status function by mocking the status, response and expected response"""
+        req_id = uuid.uuid4()
+        params = {"requestId": str(req_id), "page": 2, "pageSize": 10}
+        mock_geturl_header_params.return_value = HEADERS, params, "/test/airflow/"
+        mock_get.return_value.__aenter__.return_value.status = status_code
+        mock_get.return_value.__aenter__.return_value.json = AsyncMock(return_value=response)
+        hook = SnowflakeSqlApiHookAsync(snowflake_conn_id="test_conn")
+        response = await hook.get_sql_api_query_status("uuid")
+        assert response == expected_response

--- a/tests/snowflake/hooks/test_snowflake_sql_api.py
+++ b/tests/snowflake/hooks/test_snowflake_sql_api.py
@@ -241,7 +241,9 @@ class TestSnowflakeSqlApiHookAsync:
         assert header == HEADERS
         assert url == "https://airflow.snowflakecomputing.com/api/v2/statements/uuid"
 
-    @mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_private_key")
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_private_key"
+    )
     @mock.patch(
         "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync._get_conn_params"
     )
@@ -278,7 +280,9 @@ class TestSnowflakeSqlApiHookAsync:
         test_key_file.write_bytes(private_key)
         return test_key_file
 
-    def test_get_private_key_should_support_private_auth_in_connection(self, encrypted_temporary_private_key: Path):
+    def test_get_private_key_should_support_private_auth_in_connection(
+        self, encrypted_temporary_private_key: Path
+    ):
         """Test get_private_key function with private_key_content in connection"""
         connection_kwargs: Any = {
             **BASE_CONNECTION_KWARGS,
@@ -327,7 +331,9 @@ class TestSnowflakeSqlApiHookAsync:
         ):
             hook.get_private_key()
 
-    def test_get_private_key_should_support_private_auth_with_encrypted_key(self, encrypted_temporary_private_key):
+    def test_get_private_key_should_support_private_auth_with_encrypted_key(
+        self, encrypted_temporary_private_key
+    ):
         """Test get_private_key method by supporting for private auth encrypted_key"""
         connection_kwargs = {
             **BASE_CONNECTION_KWARGS,
@@ -349,7 +355,8 @@ class TestSnowflakeSqlApiHookAsync:
             assert hook.private_key is not None
 
     def test_get_private_key_should_support_private_auth_with_unencrypted_key(
-        self, non_encrypted_temporary_private_key,
+        self,
+        non_encrypted_temporary_private_key,
     ):
         connection_kwargs = {
             **BASE_CONNECTION_KWARGS,

--- a/tests/snowflake/hooks/test_sql_api_generate_jwt.py
+++ b/tests/snowflake/hooks/test_sql_api_generate_jwt.py
@@ -16,18 +16,21 @@ private_key = key.private_bytes(
 )
 
 
-@pytest.mark.parametrize(
-    "account_name, expected_account_name",
-    [("test.us-east-1", "TEST"), ("test.global", "TEST.GLOBAL"), ("test", "TEST")],
-)
-def test_prepare_account_name_for_jwt(account_name, expected_account_name):
-    """Test prepare_account_name_for_jwt by passing the account identifier and get the proper account name in caps"""
-    jwt_generator = JWTGenerator(account_name, "test_user", private_key)
-    response = jwt_generator.prepare_account_name_for_jwt(account_name)
-    assert response == expected_account_name
+class TestJWTGenerator:
+    @pytest.mark.parametrize(
+        "account_name, expected_account_name",
+        [("test.us-east-1", "TEST"), ("test.global", "TEST.GLOBAL"), ("test", "TEST")],
+    )
+    def test_prepare_account_name_for_jwt(self, account_name, expected_account_name):
+        """
+        Test prepare_account_name_for_jwt by passing the account identifier and
+        get the proper account name in caps
+        """
+        jwt_generator = JWTGenerator(account_name, "test_user", private_key)
+        response = jwt_generator.prepare_account_name_for_jwt(account_name)
+        assert response == expected_account_name
 
-
-def test_calculate_public_key_fingerprint():
-    """Asserting get_token and calculate_public_key_fingerprint by passing key and generating token"""
-    jwt_generator = JWTGenerator("test.us-east-1", "test_user", key)
-    assert jwt_generator.get_token()
+    def test_calculate_public_key_fingerprint(self):
+        """Asserting get_token and calculate_public_key_fingerprint by passing key and generating token"""
+        jwt_generator = JWTGenerator("test.us-east-1", "test_user", key)
+        assert jwt_generator.get_token()

--- a/tests/snowflake/operators/test_snowflake.py
+++ b/tests/snowflake/operators/test_snowflake.py
@@ -16,8 +16,7 @@ from astronomer.providers.snowflake.triggers.snowflake_trigger import (
     SnowflakeTrigger,
 )
 
-LONG_MOCK_PATH = "astronomer.providers.snowflake.operators.snowflake."
-LONG_MOCK_PATH += "SnowflakeOperatorAsync.get_db_hook"
+MODULE = "astronomer.providers.snowflake"
 TASK_ID = "snowflake_check"
 CONN_ID = "my_snowflake_conn"
 TEST_SQL = "select * from any;"
@@ -33,7 +32,7 @@ SINGLE_STMT = "select i from user_test order by i;"
 class TestSnowflakeOperatorAsync:
 
     @pytest.mark.parametrize("mock_sql", [TEST_SQL, [TEST_SQL]])
-    @mock.patch(LONG_MOCK_PATH)
+    @mock.patch(f"{MODULE}.operators.snowflake.SnowflakeOperatorAsync.get_db_hook")
     def test_snowflake_execute_operator_async(self, mock_db_hook, mock_sql):
         """
         Asserts that a task is deferred and an SnowflakeTrigger will be fired
@@ -73,7 +72,7 @@ class TestSnowflakeOperatorAsync:
             ({"status": "success", "query_ids": ["uuid", "uuid"]}, False),
         ],
     )
-    @mock.patch(LONG_MOCK_PATH)
+    @mock.patch(f"{MODULE}.operators.snowflake.SnowflakeOperatorAsync.get_db_hook")
     def test_snowflake_async_execute_complete(self, mock_conn, mock_event, mock_xcom_push):
         """Tests execute_complete assert with successful message"""
 
@@ -88,7 +87,7 @@ class TestSnowflakeOperatorAsync:
             operator.execute_complete(context=None, event=mock_event)
         mock_log_info.assert_called_with("%s completed successfully.", "execute_complete")
 
-    @mock.patch(LONG_MOCK_PATH)
+    @mock.patch(f"{MODULE}.operators.snowflake.SnowflakeOperatorAsync.get_db_hook")
     def test_snowflake_sql_api_execute_complete_event_none(self, mock_conn):
         """Tests execute_complete assert with successful message"""
 

--- a/tests/snowflake/operators/test_snowflake.py
+++ b/tests/snowflake/operators/test_snowflake.py
@@ -1,14 +1,10 @@
 import datetime
-from datetime import timedelta
 from unittest import mock
 
 import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.models.dag import DAG
-from airflow.models.dagrun import DagRun
-from airflow.models.taskinstance import TaskInstance
-from airflow.utils import timezone
-from airflow.utils.types import DagRunType
+from tests.utils.airflow_util import create_context
 
 from astronomer.providers.snowflake.hooks.snowflake import SnowflakeHookAsync
 from astronomer.providers.snowflake.operators.snowflake import (
@@ -20,25 +16,12 @@ from astronomer.providers.snowflake.triggers.snowflake_trigger import (
     SnowflakeTrigger,
 )
 
-DEFAULT_DATE = timezone.datetime(2015, 1, 1)
-DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
-DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
-TEST_DAG_ID = "unit_test_dag"
 LONG_MOCK_PATH = "astronomer.providers.snowflake.operators.snowflake."
 LONG_MOCK_PATH += "SnowflakeOperatorAsync.get_db_hook"
 TASK_ID = "snowflake_check"
 CONN_ID = "my_snowflake_conn"
-RUN_ID = "1"
-RUN_PAGE_URL = "https://www.test.com"
-RETRY_LIMIT = 2
-RETRY_DELAY = 1.0
-POLL_INTERVAL = 1.0
-XCOM_RUN_ID_KEY = "run_id"
-XCOM_RUN_PAGE_URL_KEY = "run_page_url"
 TEST_SQL = "select * from any;"
 
-LIFETIME = timedelta(minutes=59)
-RENEWAL_DELTA = timedelta(minutes=54)
 SQL_MULTIPLE_STMTS = (
     "create or replace table user_test (i int); insert into user_test (i) "
     "values (200); insert into user_test (i) values (300); select i from user_test order by i;"
@@ -47,189 +30,144 @@ SQL_MULTIPLE_STMTS = (
 SINGLE_STMT = "select i from user_test order by i;"
 
 
-@pytest.fixture
-def context():
-    """
-    Creates an empty context.
-    """
-    context = {}
-    yield context
+class TestSnowflakeOperatorAsync:
 
-
-def create_context(task, dag):
-    execution_date = datetime.datetime(2022, 1, 1, 0, 0, 0)
-    dag_run = DagRun(
-        dag_id=dag.dag_id,
-        execution_date=execution_date,
-        run_id=DagRun.generate_run_id(DagRunType.MANUAL, execution_date),
-    )
-    task_instance = TaskInstance(task=task)
-    task_instance.dag_run = dag_run
-    task_instance.dag_id = dag.dag_id
-    task_instance.xcom_push = mock.Mock()
-    return {
-        "dag": dag,
-        "run_id": dag_run.run_id,
-        "task": task,
-        "ti": task_instance,
-        "task_instance": task_instance,
-    }
-
-
-@pytest.mark.parametrize("mock_sql", [TEST_SQL, [TEST_SQL]])
-@mock.patch(LONG_MOCK_PATH)
-def test_snowflake_execute_operator_async(mock_db_hook, mock_sql):
-    """
-    Asserts that a task is deferred and an SnowflakeTrigger will be fired
-    when the SnowflakeOperatorAsync is executed.
-    """
-    args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
-    dag = DAG("test_snowflake_async_execute_complete_failure", default_args=args)
-
-    operator = SnowflakeOperatorAsync(
-        task_id="execute_run",
-        snowflake_conn_id=CONN_ID,
-        dag=dag,
-        sql=mock_sql,
-    )
-
-    with pytest.raises(TaskDeferred) as exc:
-        operator.execute(create_context(operator, dag))
-
-    assert isinstance(exc.value.trigger, SnowflakeTrigger), "Trigger is not a SnowflakeTrigger"
-
-
-def test_snowflake_async_execute_complete_failure():
-    """Tests that an AirflowException is raised in case of error event"""
-
-    args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
-    dag = DAG("test_snowflake_async_execute_complete_failure", default_args=args)
-    operator = SnowflakeOperatorAsync(
-        task_id="execute_complete",
-        snowflake_conn_id=CONN_ID,
-        dag=dag,
-        sql=TEST_SQL,
-    )
-    with pytest.raises(AirflowException):
-        operator.execute_complete(
-            context=None,
-            event={"status": "error", "message": "Test failure message", "type": "FAILED_WITH_ERROR"},
+    @pytest.mark.parametrize("mock_sql", [TEST_SQL, [TEST_SQL]])
+    @mock.patch(LONG_MOCK_PATH)
+    def test_snowflake_execute_operator_async(self, mock_db_hook, mock_sql):
+        """
+        Asserts that a task is deferred and an SnowflakeTrigger will be fired
+        when the SnowflakeOperatorAsync is executed.
+        """
+        dag = DAG("test_snowflake_async_execute_complete_failure", start_date=datetime.datetime(2023, 1, 1))
+        operator = SnowflakeOperatorAsync(
+            task_id="execute_run",
+            snowflake_conn_id=CONN_ID,
+            dag=dag,
+            sql=mock_sql,
         )
 
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute(create_context(operator))
 
-@pytest.mark.parametrize(
-    "mock_event, mock_xcom_push",
-    [
-        ({"status": "success", "query_ids": ["uuid", "uuid"]}, True),
-        ({"status": "success", "query_ids": ["uuid", "uuid"]}, False),
-    ],
-)
-@mock.patch(LONG_MOCK_PATH)
-def test_snowflake_async_execute_complete(mock_conn, mock_event, mock_xcom_push):
-    """Tests execute_complete assert with successful message"""
+        assert isinstance(exc.value.trigger, SnowflakeTrigger), "Trigger is not a SnowflakeTrigger"
 
-    args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
-    dag = DAG("test_snowflake_async_execute_complete", default_args=args)
-    operator = SnowflakeOperatorAsync(
-        task_id="execute_complete",
-        snowflake_conn_id=CONN_ID,
-        sql=TEST_SQL,
-        do_xcom_push=mock_xcom_push,
-        dag=dag,
+    def test_snowflake_async_execute_complete_failure(self):
+        """Tests that an AirflowException is raised in case of error event"""
+
+        operator = SnowflakeOperatorAsync(
+            task_id="execute_complete",
+            snowflake_conn_id=CONN_ID,
+            sql=TEST_SQL,
+        )
+        with pytest.raises(AirflowException):
+            operator.execute_complete(
+                context=None,
+                event={"status": "error", "message": "Test failure message", "type": ""},
+            )
+
+    @pytest.mark.parametrize(
+        "mock_event, mock_xcom_push",
+        [
+            ({"status": "success", "query_ids": ["uuid", "uuid"]}, True),
+            ({"status": "success", "query_ids": ["uuid", "uuid"]}, False),
+        ],
     )
+    @mock.patch(LONG_MOCK_PATH)
+    def test_snowflake_async_execute_complete(self, mock_conn, mock_event, mock_xcom_push):
+        """Tests execute_complete assert with successful message"""
 
-    with mock.patch.object(operator.log, "info") as mock_log_info:
-        operator.execute_complete(context=None, event=mock_event)
-    mock_log_info.assert_called_with("%s completed successfully.", "execute_complete")
-
-
-@mock.patch(LONG_MOCK_PATH)
-def test_snowflake_sql_api_execute_complete_event_none(mock_conn):
-    """Tests execute_complete assert with successful message"""
-
-    operator = SnowflakeOperatorAsync(
-        task_id="execute_complete",
-        snowflake_conn_id=CONN_ID,
-        sql=TEST_SQL,
-    )
-
-    with pytest.raises(AirflowException):
-        operator.execute_complete(context=None, event=None)
-
-
-def test_get_db_hook():
-    """Test get_db_hook with async hook"""
-
-    args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
-    dag = DAG("test_get_db_hook", default_args=args)
-    operator = SnowflakeOperatorAsync(
-        task_id="execute_complete",
-        snowflake_conn_id=CONN_ID,
-        sql=TEST_SQL,
-        dag=dag,
-    )
-    result = operator.get_db_hook()
-    assert isinstance(result, SnowflakeHookAsync)
-
-
-@pytest.mark.parametrize("mock_sql, statement_count", [(SQL_MULTIPLE_STMTS, 4), (SINGLE_STMT, 1)])
-@mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.execute_query")
-def test_snowflake_sql_api_execute_operator_async(mock_db_hook, mock_sql, statement_count):
-    """
-    Asserts that a task is deferred and an SnowflakeSqlApiTrigger will be fired
-    when the SnowflakeSqlApiOperatorAsync is executed.
-    """
-    args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
-    dag = DAG("test_snowflake_async_execute_complete_failure", default_args=args)
-    operator = SnowflakeSqlApiOperatorAsync(
-        task_id=TASK_ID,
-        snowflake_conn_id=CONN_ID,
-        sql=mock_sql,
-        statement_count=statement_count,
-    )
-
-    with pytest.raises(TaskDeferred) as exc:
-        operator.execute(create_context(operator, dag=dag))
-
-    assert isinstance(exc.value.trigger, SnowflakeSqlApiTrigger), "Trigger is not a SnowflakeSqlApiTrigger"
-
-
-def test_snowflake_sql_api_execute_complete_failure():
-    """Test SnowflakeSqlApiOperatorAsync raise AirflowException of error event"""
-
-    operator = SnowflakeSqlApiOperatorAsync(
-        task_id=TASK_ID,
-        snowflake_conn_id=CONN_ID,
-        sql=SQL_MULTIPLE_STMTS,
-        statement_count=4,
-    )
-    with pytest.raises(AirflowException):
-        operator.execute_complete(
-            context=None,
-            event={"status": "error", "message": "Test failure message", "type": "FAILED_WITH_ERROR"},
+        operator = SnowflakeOperatorAsync(
+            task_id="execute_complete",
+            snowflake_conn_id=CONN_ID,
+            sql=TEST_SQL,
+            do_xcom_push=mock_xcom_push,
         )
 
+        with mock.patch.object(operator.log, "info") as mock_log_info:
+            operator.execute_complete(context=None, event=mock_event)
+        mock_log_info.assert_called_with("%s completed successfully.", "execute_complete")
 
-@pytest.mark.parametrize(
-    "mock_event",
-    [
-        None,
-        ({"status": "success", "statement_query_ids": ["uuid", "uuid"]}),
-    ],
-)
-@mock.patch(
-    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.check_query_output"
-)
-def test_snowflake_sql_api_execute_complete(mock_conn, mock_event):
-    """Tests execute_complete assert with successful message"""
+    @mock.patch(LONG_MOCK_PATH)
+    def test_snowflake_sql_api_execute_complete_event_none(self, mock_conn):
+        """Tests execute_complete assert with successful message"""
 
-    operator = SnowflakeSqlApiOperatorAsync(
-        task_id=TASK_ID,
-        snowflake_conn_id=CONN_ID,
-        sql=SQL_MULTIPLE_STMTS,
-        statement_count=4,
+        operator = SnowflakeOperatorAsync(
+            task_id="execute_complete",
+            snowflake_conn_id=CONN_ID,
+            sql=TEST_SQL,
+        )
+
+        with pytest.raises(AirflowException):
+            operator.execute_complete(context=None, event=None)
+
+    def test_get_db_hook(self):
+        """Test get_db_hook with async hook"""
+
+        operator = SnowflakeOperatorAsync(
+            task_id="execute_complete",
+            snowflake_conn_id=CONN_ID,
+            sql=TEST_SQL,
+        )
+        result = operator.get_db_hook()
+        assert isinstance(result, SnowflakeHookAsync)
+
+
+class TestSnowflakeSqlApiOperatorAsync:
+    @pytest.mark.parametrize("mock_sql, statement_count", [(SQL_MULTIPLE_STMTS, 4), (SINGLE_STMT, 1)])
+    @mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.execute_query")
+    def test_snowflake_sql_api_execute_operator_async(self, mock_db_hook, mock_sql, statement_count):
+        """
+        Asserts that a task is deferred and an SnowflakeSqlApiTrigger will be fired
+        when the SnowflakeSqlApiOperatorAsync is executed.
+        """
+        operator = SnowflakeSqlApiOperatorAsync(
+            task_id=TASK_ID,
+            snowflake_conn_id=CONN_ID,
+            sql=mock_sql,
+            statement_count=statement_count,
+        )
+
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute(create_context(operator))
+
+        assert isinstance(exc.value.trigger, SnowflakeSqlApiTrigger), "Trigger is not a SnowflakeSqlApiTrigger"
+
+    def test_snowflake_sql_api_execute_complete_failure(self):
+        """Test SnowflakeSqlApiOperatorAsync raise AirflowException of error event"""
+
+        operator = SnowflakeSqlApiOperatorAsync(
+            task_id=TASK_ID,
+            snowflake_conn_id=CONN_ID,
+            sql=SQL_MULTIPLE_STMTS,
+            statement_count=4,
+        )
+        with pytest.raises(AirflowException):
+            operator.execute_complete(
+                context=None,
+                event={"status": "error", "message": "Test failure message", "type": "FAILED_WITH_ERROR"},
+            )
+
+    @pytest.mark.parametrize(
+        "mock_event",
+        [
+            None,
+            ({"status": "success", "statement_query_ids": ["uuid", "uuid"]}),
+        ],
     )
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.check_query_output"
+    )
+    def test_snowflake_sql_api_execute_complete(self, mock_conn, mock_event):
+        """Tests execute_complete assert with successful message"""
 
-    with mock.patch.object(operator.log, "info") as mock_log_info:
-        operator.execute_complete(context=None, event=mock_event)
-    mock_log_info.assert_called_with("%s completed successfully.", TASK_ID)
+        operator = SnowflakeSqlApiOperatorAsync(
+            task_id=TASK_ID,
+            snowflake_conn_id=CONN_ID,
+            sql=SQL_MULTIPLE_STMTS,
+            statement_count=4,
+        )
+
+        with mock.patch.object(operator.log, "info") as mock_log_info:
+            operator.execute_complete(context=None, event=mock_event)
+        mock_log_info.assert_called_with("%s completed successfully.", TASK_ID)

--- a/tests/snowflake/operators/test_snowflake.py
+++ b/tests/snowflake/operators/test_snowflake.py
@@ -4,7 +4,6 @@ from unittest import mock
 import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.models.dag import DAG
-from tests.utils.airflow_util import create_context
 
 from astronomer.providers.snowflake.hooks.snowflake import SnowflakeHookAsync
 from astronomer.providers.snowflake.operators.snowflake import (
@@ -15,6 +14,7 @@ from astronomer.providers.snowflake.triggers.snowflake_trigger import (
     SnowflakeSqlApiTrigger,
     SnowflakeTrigger,
 )
+from tests.utils.airflow_util import create_context
 
 MODULE = "astronomer.providers.snowflake"
 TASK_ID = "snowflake_check"
@@ -30,7 +30,6 @@ SINGLE_STMT = "select i from user_test order by i;"
 
 
 class TestSnowflakeOperatorAsync:
-
     @pytest.mark.parametrize("mock_sql", [TEST_SQL, [TEST_SQL]])
     @mock.patch(f"{MODULE}.operators.snowflake.SnowflakeOperatorAsync.get_db_hook")
     def test_snowflake_execute_operator_async(self, mock_db_hook, mock_sql):
@@ -114,7 +113,9 @@ class TestSnowflakeOperatorAsync:
 
 class TestSnowflakeSqlApiOperatorAsync:
     @pytest.mark.parametrize("mock_sql, statement_count", [(SQL_MULTIPLE_STMTS, 4), (SINGLE_STMT, 1)])
-    @mock.patch("astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.execute_query")
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.execute_query"
+    )
     def test_snowflake_sql_api_execute_operator_async(self, mock_db_hook, mock_sql, statement_count):
         """
         Asserts that a task is deferred and an SnowflakeSqlApiTrigger will be fired
@@ -130,7 +131,9 @@ class TestSnowflakeSqlApiOperatorAsync:
         with pytest.raises(TaskDeferred) as exc:
             operator.execute(create_context(operator))
 
-        assert isinstance(exc.value.trigger, SnowflakeSqlApiTrigger), "Trigger is not a SnowflakeSqlApiTrigger"
+        assert isinstance(
+            exc.value.trigger, SnowflakeSqlApiTrigger
+        ), "Trigger is not a SnowflakeSqlApiTrigger"
 
     def test_snowflake_sql_api_execute_complete_failure(self):
         """Test SnowflakeSqlApiOperatorAsync raise AirflowException of error event"""

--- a/tests/snowflake/triggers/test_snowflake.py
+++ b/tests/snowflake/triggers/test_snowflake.py
@@ -14,6 +14,7 @@ TASK_ID = "snowflake_check"
 POLL_INTERVAL = 1.0
 LIFETIME = timedelta(minutes=59)
 RENEWAL_DELTA = timedelta(minutes=54)
+MODULE = "astronomer.providers.snowflake"
 
 
 class TestSnowflakeTrigger:
@@ -143,12 +144,8 @@ class TestSnowflakeSqlApiTrigger:
         }
 
     @pytest.mark.asyncio
-    @mock.patch(
-        "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
-    )
-    @mock.patch(
-        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
-    )
+    @mock.patch(f"{MODULE}.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running")
+    @mock.patch(f"{MODULE}.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status")
     async def test_snowflake_sql_trigger_running(self, mock_get_sql_api_query_status, mock_is_still_running):
         """Tests that the SnowflakeSqlApiTrigger in running by mocking is_still_running to true"""
         mock_is_still_running.return_value = True
@@ -161,12 +158,8 @@ class TestSnowflakeSqlApiTrigger:
         asyncio.get_event_loop().stop()
 
     @pytest.mark.asyncio
-    @mock.patch(
-        "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
-    )
-    @mock.patch(
-        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
-    )
+    @mock.patch(f"{MODULE}.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running")
+    @mock.patch(f"{MODULE}.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status")
     async def test_snowflake_sql_trigger_completed(self, mock_get_sql_api_query_status, mock_is_still_running):
         """
         Test SnowflakeSqlApiTrigger run method with success status and mock the get_sql_api_query_status result
@@ -185,12 +178,8 @@ class TestSnowflakeSqlApiTrigger:
         assert TriggerEvent({"status": "success", "statement_query_ids": statement_query_ids}) == actual
 
     @pytest.mark.asyncio
-    @mock.patch(
-        "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
-    )
-    @mock.patch(
-        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
-    )
+    @mock.patch(f"{MODULE}.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running")
+    @mock.patch(f"{MODULE}.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status")
     async def test_snowflake_sql_trigger_failure_status(self, mock_get_sql_api_query_status, mock_is_still_running):
         """Test SnowflakeSqlApiTrigger task is executed and triggered with failure status."""
         mock_is_still_running.return_value = False
@@ -206,12 +195,8 @@ class TestSnowflakeSqlApiTrigger:
         assert TriggerEvent(mock_response) == actual
 
     @pytest.mark.asyncio
-    @mock.patch(
-        "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
-    )
-    @mock.patch(
-        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
-    )
+    @mock.patch(f"{MODULE}.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running")
+    @mock.patch(f"{MODULE}.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status")
     async def test_snowflake_sql_trigger_exception(self, mock_get_sql_api_query_status, mock_is_still_running):
         """Tests the SnowflakeSqlApiTrigger does not fire if there is an exception."""
         mock_is_still_running.return_value = False
@@ -230,9 +215,7 @@ class TestSnowflakeSqlApiTrigger:
             ({"status": "running"}, True),
         ],
     )
-    @mock.patch(
-        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
-    )
+    @mock.patch(f"{MODULE}.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status")
     async def test_snowflake_sql_trigger_is_still_running(
         self, mock_get_sql_api_query_status, mock_response, expected_status
     ):

--- a/tests/snowflake/triggers/test_snowflake.py
+++ b/tests/snowflake/triggers/test_snowflake.py
@@ -160,7 +160,9 @@ class TestSnowflakeSqlApiTrigger:
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running")
     @mock.patch(f"{MODULE}.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status")
-    async def test_snowflake_sql_trigger_completed(self, mock_get_sql_api_query_status, mock_is_still_running):
+    async def test_snowflake_sql_trigger_completed(
+        self, mock_get_sql_api_query_status, mock_is_still_running
+    ):
         """
         Test SnowflakeSqlApiTrigger run method with success status and mock the get_sql_api_query_status result
         and  is_still_running to False.
@@ -180,7 +182,9 @@ class TestSnowflakeSqlApiTrigger:
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running")
     @mock.patch(f"{MODULE}.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status")
-    async def test_snowflake_sql_trigger_failure_status(self, mock_get_sql_api_query_status, mock_is_still_running):
+    async def test_snowflake_sql_trigger_failure_status(
+        self, mock_get_sql_api_query_status, mock_is_still_running
+    ):
         """Test SnowflakeSqlApiTrigger task is executed and triggered with failure status."""
         mock_is_still_running.return_value = False
         mock_response = {
@@ -197,7 +201,9 @@ class TestSnowflakeSqlApiTrigger:
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running")
     @mock.patch(f"{MODULE}.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status")
-    async def test_snowflake_sql_trigger_exception(self, mock_get_sql_api_query_status, mock_is_still_running):
+    async def test_snowflake_sql_trigger_exception(
+        self, mock_get_sql_api_query_status, mock_is_still_running
+    ):
         """Tests the SnowflakeSqlApiTrigger does not fire if there is an exception."""
         mock_is_still_running.return_value = False
         mock_get_sql_api_query_status.side_effect = Exception("Test exception")

--- a/tests/snowflake/triggers/test_snowflake.py
+++ b/tests/snowflake/triggers/test_snowflake.py
@@ -16,192 +16,110 @@ LIFETIME = timedelta(minutes=59)
 RENEWAL_DELTA = timedelta(minutes=54)
 
 
-def test_snowflake_trigger_serialization():
-    """
-    Asserts that the SnowflakeTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = SnowflakeTrigger(
+class TestSnowflakeTrigger:
+    TRIGGER = SnowflakeTrigger(
         task_id=TASK_ID,
         poll_interval=POLL_INTERVAL,
-        query_ids=[],
+        query_ids=["uuid", "uuid"],
         snowflake_conn_id="test_conn",
     )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeTrigger"
-    assert kwargs == {
-        "task_id": TASK_ID,
-        "poll_interval": 1.0,
-        "query_ids": [],
-        "snowflake_conn_id": "test_conn",
-    }
 
+    def test_snowflake_trigger_serialization(self):
+        """
+        Asserts that the SnowflakeTrigger correctly serializes its arguments
+        and classpath.
+        """
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeTrigger"
+        assert kwargs == {
+            "task_id": TASK_ID,
+            "poll_interval": 1.0,
+            "query_ids": ["uuid", "uuid"],
+            "snowflake_conn_id": "test_conn",
+        }
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "query_ids,return_value,response",
-    [
-        (
-            ["uuid", "uuid"],
-            {"status": "error", "message": "test error"},
-            TriggerEvent({"status": "error", "message": "test error"}),
-        ),
-        (
-            ["uuid", "uuid"],
-            {"status": "success", "query_ids": ["uuid", "uuid"]},
-            TriggerEvent({"status": "success", "query_ids": ["uuid", "uuid"]}),
-        ),
-        (
-            ["uuid", "uuid"],
-            False,
-            TriggerEvent(
-                {
-                    "status": "error",
-                    "message": f"{TASK_ID} " f"failed with terminal state: False",
-                }
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "return_value,response",
+        [
+            (
+                {"status": "error", "message": "test error"},
+                TriggerEvent({"status": "error", "message": "test error"}),
             ),
-        ),
-    ],
-)
-@mock.patch("astronomer.providers.snowflake.hooks.snowflake.SnowflakeHookAsync.get_query_status")
-async def test_snowflake_trigger_running(mock_get_query_status, query_ids, return_value, response):
-    """Tests that the SnowflakeTrigger in"""
-    mock_get_query_status.return_value = return_value
-    trigger = SnowflakeTrigger(
-        task_id=TASK_ID,
-        poll_interval=POLL_INTERVAL,
-        query_ids=query_ids,
-        snowflake_conn_id="test_conn",
+            (
+                {"status": "success", "query_ids": ["uuid", "uuid"]},
+                TriggerEvent({"status": "success", "query_ids": ["uuid", "uuid"]}),
+            ),
+            (
+                False,
+                TriggerEvent(
+                    {
+                        "status": "error",
+                        "message": f"{TASK_ID} " f"failed with terminal state: False",
+                    }
+                ),
+            ),
+        ],
     )
+    @mock.patch("astronomer.providers.snowflake.hooks.snowflake.SnowflakeHookAsync.get_query_status")
+    async def test_snowflake_trigger_running(self, mock_get_query_status, return_value, response):
+        """Tests that the SnowflakeTrigger in"""
+        mock_get_query_status.return_value = return_value
 
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert response == actual
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert response == actual
 
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.snowflake.hooks.snowflake.SnowflakeHookAsync.get_query_status")
+    async def test_snowflake_trigger_success(self, mock_get_first):
+        """Tests that the SnowflakeTrigger in success case"""
+        mock_get_first.return_value = {"status": "success", "query_ids": ["uuid", "uuid"]}
 
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.snowflake.hooks.snowflake.SnowflakeHookAsync.get_query_status")
-@pytest.mark.parametrize(
-    "query_ids",
-    [
-        (["uuid", "uuid"]),
-    ],
-)
-async def test_snowflake_trigger_success(mock_get_first, query_ids):
-    """Tests that the SnowflakeTrigger in success case"""
-    mock_get_first.return_value = {"status": "success", "query_ids": query_ids}
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
 
-    trigger = SnowflakeTrigger(
-        task_id=TASK_ID,
-        poll_interval=POLL_INTERVAL,
-        query_ids=query_ids,
-        snowflake_conn_id="test_conn",
-    )
+        # TriggerEvent was returned
+        assert task.done() is True
+        # Prevents error when task is destroyed while in "pending" state
+        asyncio.get_event_loop().stop()
 
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was returned
-    assert task.done() is True
-    # Prevents error when task is destroyed while in "pending" state
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.snowflake.hooks.snowflake.SnowflakeHookAsync.get_query_status")
-@pytest.mark.parametrize(
-    "query_ids",
-    [
-        (["uuid", "uuid"]),
-    ],
-)
-async def test_snowflake_trigger_failed(mock_get_first, query_ids):
-    """Tests the SnowflakeTrigger does not fire if it reaches a failed state."""
-    mock_get_first.return_value = {
-        "status": "error",
-        "message": "The query is in the process of being aborted on the server side.",
-        "type": "ABORTING",
-    }
-
-    trigger = SnowflakeTrigger(
-        task_id=TASK_ID,
-        poll_interval=0.5,
-        query_ids=query_ids,
-        snowflake_conn_id="test_conn",
-    )
-
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(1)
-
-    # TriggerEvent was returned
-    assert task.done() is True
-    assert task.result() == TriggerEvent(
-        {
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.snowflake.hooks.snowflake.SnowflakeHookAsync.get_query_status")
+    async def test_snowflake_trigger_failed(self, mock_get_first):
+        """Tests the SnowflakeTrigger does not fire if it reaches a failed state."""
+        mock_get_first.return_value = {
             "status": "error",
             "message": "The query is in the process of being aborted on the server side.",
             "type": "ABORTING",
         }
-    )
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(1)
+
+        # TriggerEvent was returned
+        assert task.done() is True
+        assert task.result() == TriggerEvent(
+            {
+                "status": "error",
+                "message": "The query is in the process of being aborted on the server side.",
+                "type": "ABORTING",
+            }
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.snowflake.hooks.snowflake.SnowflakeHookAsync.get_query_status")
+    async def test_snowflake_trigger_exception(self, mock_query_status):
+        """Tests the SnowflakeTrigger does not fire if there is an exception."""
+        mock_query_status.side_effect = Exception("Test exception")
+
+        task = [i async for i in self.TRIGGER.run()]
+        assert len(task) == 1
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "query_ids",
-    [
-        (["uuid", "uuid"]),
-    ],
-)
-@mock.patch("astronomer.providers.snowflake.hooks.snowflake.SnowflakeHookAsync.get_query_status")
-async def test_snowflake_trigger_exception(mock_query_status, query_ids):
-    """Tests the SnowflakeTrigger does not fire if there is an exception."""
-    mock_query_status.side_effect = Exception("Test exception")
-
-    trigger = SnowflakeTrigger(
-        task_id=TASK_ID,
-        poll_interval=0.5,
-        query_ids=query_ids,
-        snowflake_conn_id="test_conn",
-    )
-
-    task = [i async for i in trigger.run()]
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
-
-
-def test_snowflake_sql_trigger_serialization():
-    """
-    Asserts that the SnowflakeSqlApiTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = SnowflakeSqlApiTrigger(
-        poll_interval=POLL_INTERVAL,
-        query_ids=[],
-        snowflake_conn_id="test_conn",
-        token_life_time=LIFETIME,
-        token_renewal_delta=RENEWAL_DELTA,
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger"
-    assert kwargs == {
-        "poll_interval": POLL_INTERVAL,
-        "query_ids": [],
-        "snowflake_conn_id": "test_conn",
-        "token_life_time": LIFETIME,
-        "token_renewal_delta": RENEWAL_DELTA,
-    }
-
-
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
-)
-@mock.patch(
-    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
-)
-async def test_snowflake_sql_trigger_running(mock_get_sql_api_query_status, mock_is_still_running):
-    """Tests that the SnowflakeSqlApiTrigger in running by mocking is_still_running to true"""
-    mock_is_still_running.return_value = True
-    trigger = SnowflakeSqlApiTrigger(
+class TestSnowflakeSqlApiTrigger:
+    TRIGGER = SnowflakeSqlApiTrigger(
         poll_interval=POLL_INTERVAL,
         query_ids=["uuid"],
         snowflake_conn_id="test_conn",
@@ -209,120 +127,116 @@ async def test_snowflake_sql_trigger_running(mock_get_sql_api_query_status, mock
         token_renewal_delta=RENEWAL_DELTA,
     )
 
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
+    def test_snowflake_sql_trigger_serialization(self):
+        """
+        Asserts that the SnowflakeSqlApiTrigger correctly serializes its arguments
+        and classpath.
+        """
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger"
+        assert kwargs == {
+            "poll_interval": POLL_INTERVAL,
+            "query_ids": ["uuid"],
+            "snowflake_conn_id": "test_conn",
+            "token_life_time": LIFETIME,
+            "token_renewal_delta": RENEWAL_DELTA,
+        }
 
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
-)
-@mock.patch(
-    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
-)
-async def test_snowflake_sql_trigger_completed(mock_get_sql_api_query_status, mock_is_still_running):
-    """
-    Test SnowflakeSqlApiTrigger run method with success status and mock the get_sql_api_query_status result
-    and  is_still_running to False.
-    """
-    mock_is_still_running.return_value = False
-    statement_query_ids = ["uuid", "uuid1"]
-    mock_get_sql_api_query_status.return_value = {
-        "message": "Statement executed successfully.",
-        "status": "success",
-        "statement_handles": statement_query_ids,
-    }
-    trigger = SnowflakeSqlApiTrigger(
-        poll_interval=POLL_INTERVAL,
-        query_ids=["uuid"],
-        snowflake_conn_id="test_conn",
-        token_life_time=LIFETIME,
-        token_renewal_delta=RENEWAL_DELTA,
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
     )
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent({"status": "success", "statement_query_ids": statement_query_ids}) == actual
-
-
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
-)
-@mock.patch(
-    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
-)
-async def test_snowflake_sql_trigger_failure_status(mock_get_sql_api_query_status, mock_is_still_running):
-    """Test SnowflakeSqlApiTrigger task is executed and triggered with failure status."""
-    mock_is_still_running.return_value = False
-    mock_response = {
-        "status": "error",
-        "message": "An error occurred when executing the statement. Check "
-        "the error code and error message for details",
-    }
-    mock_get_sql_api_query_status.return_value = mock_response
-    trigger = SnowflakeSqlApiTrigger(
-        poll_interval=POLL_INTERVAL,
-        query_ids=["uuid"],
-        snowflake_conn_id="test_conn",
-        token_life_time=LIFETIME,
-        token_renewal_delta=RENEWAL_DELTA,
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
     )
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent(mock_response) == actual
+    async def test_snowflake_sql_trigger_running(self, mock_get_sql_api_query_status, mock_is_still_running):
+        """Tests that the SnowflakeSqlApiTrigger in running by mocking is_still_running to true"""
+        mock_is_still_running.return_value = True
 
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
 
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
-)
-@mock.patch(
-    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
-)
-async def test_snowflake_sql_trigger_exception(mock_get_sql_api_query_status, mock_is_still_running):
-    """Tests the SnowflakeSqlApiTrigger does not fire if there is an exception."""
-    mock_is_still_running.return_value = False
-    mock_get_sql_api_query_status.side_effect = Exception("Test exception")
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
 
-    trigger = SnowflakeSqlApiTrigger(
-        poll_interval=POLL_INTERVAL,
-        query_ids=["uuid"],
-        snowflake_conn_id="test_conn",
-        token_life_time=LIFETIME,
-        token_renewal_delta=RENEWAL_DELTA,
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
     )
-
-    task = [i async for i in trigger.run()]
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "mock_query_id, mock_response, expected_status",
-    [
-        (["uuid"], {"status": "success"}, False),
-        (["uuid"], {"status": "error"}, False),
-        (["uuid"], {"status": "running"}, True),
-    ],
-)
-@mock.patch(
-    "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
-)
-async def test_snowflake_sql_trigger_is_still_running(
-    mock_get_sql_api_query_status, mock_query_id, mock_response, expected_status
-):
-    mock_get_sql_api_query_status.return_value = mock_response
-    trigger = SnowflakeSqlApiTrigger(
-        poll_interval=POLL_INTERVAL,
-        query_ids=mock_query_id,
-        snowflake_conn_id="test_conn",
-        token_life_time=LIFETIME,
-        token_renewal_delta=RENEWAL_DELTA,
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
     )
-    response = await trigger.is_still_running(mock_query_id)
-    assert response == expected_status
+    async def test_snowflake_sql_trigger_completed(self, mock_get_sql_api_query_status, mock_is_still_running):
+        """
+        Test SnowflakeSqlApiTrigger run method with success status and mock the get_sql_api_query_status result
+        and  is_still_running to False.
+        """
+        mock_is_still_running.return_value = False
+        statement_query_ids = ["uuid", "uuid1"]
+        mock_get_sql_api_query_status.return_value = {
+            "message": "Statement executed successfully.",
+            "status": "success",
+            "statement_handles": statement_query_ids,
+        }
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "success", "statement_query_ids": statement_query_ids}) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
+    )
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
+    )
+    async def test_snowflake_sql_trigger_failure_status(self, mock_get_sql_api_query_status, mock_is_still_running):
+        """Test SnowflakeSqlApiTrigger task is executed and triggered with failure status."""
+        mock_is_still_running.return_value = False
+        mock_response = {
+            "status": "error",
+            "message": "An error occurred when executing the statement. Check "
+            "the error code and error message for details",
+        }
+        mock_get_sql_api_query_status.return_value = mock_response
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent(mock_response) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.snowflake.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.is_still_running"
+    )
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
+    )
+    async def test_snowflake_sql_trigger_exception(self, mock_get_sql_api_query_status, mock_is_still_running):
+        """Tests the SnowflakeSqlApiTrigger does not fire if there is an exception."""
+        mock_is_still_running.return_value = False
+        mock_get_sql_api_query_status.side_effect = Exception("Test exception")
+
+        task = [i async for i in self.TRIGGER.run()]
+        assert len(task) == 1
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_response, expected_status",
+        [
+            ({"status": "success"}, False),
+            ({"status": "error"}, False),
+            ({"status": "running"}, True),
+        ],
+    )
+    @mock.patch(
+        "astronomer.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHookAsync.get_sql_api_query_status"
+    )
+    async def test_snowflake_sql_trigger_is_still_running(
+        self, mock_get_sql_api_query_status, mock_response, expected_status
+    ):
+        mock_get_sql_api_query_status.return_value = mock_response
+
+        response = await self.TRIGGER.is_still_running(["uuid"])
+        assert response == expected_status


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-providers/issues/697
related-to: https://github.com/astronomer/astronomer-providers/issues/568

convert the function-based test to a class-based
remove context fixture definition from operator/sensor/extractor and reuse from conftest
remove function create_context from a couple of test files and reuse it from the util
remove duplicate code for initializing op/senor/trigger/hook at possible places