### PR TITLE
Add microsoft class based tests

### DIFF
--- a/tests/microsoft/azure/hooks/test_data_factory.py
+++ b/tests/microsoft/azure/hooks/test_data_factory.py
@@ -11,209 +11,178 @@ from astronomer.providers.microsoft.azure.hooks.data_factory import (
 )
 
 DEFAULT_RESOURCE_GROUP = "defaultResourceGroup"
-DEFAULT_FACTORY = "defaultFactory"
 AZURE_DATA_FACTORY_CONN_ID = "azure_data_factory_default"
 RESOURCE_GROUP_NAME = "team_provider_resource_group_test"
 DATAFACTORY_NAME = "ADFProvidersTeamDataFactory"
 TASK_ID = "test_adf_pipeline_run_status_sensor"
 RUN_ID = "7f8c6c72-c093-11ec-a83d-0242ac120007"
-
 DEFAULT_CONNECTION_CLIENT_SECRET = "azure_data_factory_test_client_secret"
-DEFAULT_CONNECTION_DEFAULT_CREDENTIAL = "azure_data_factory_test_default_credential"
+MODULE = "astronomer.providers.microsoft.azure"
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "mock_status",
-    ["Queued", "InProgress", "Succeeded", "Failed", "Cancelled"],
-)
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn"
-)
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_pipeline_run"
-)
-async def test_get_adf_pipeline_run_status(mock_get_pipeline_run, mock_conn, mock_status):
-    """Test get_adf_pipeline_run_status function with mocked status"""
-    mock_get_pipeline_run.return_value.status = mock_status
-    hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
-    response = await hook.get_adf_pipeline_run_status(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)
-    assert response == mock_status
-
-
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn"
-)
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_pipeline_run"
-)
-async def test_get_adf_pipeline_run_status_exception(mock_get_pipeline_run, mock_conn):
-    """Test get_adf_pipeline_run_status function with exception"""
-    mock_get_pipeline_run.side_effect = Exception("Test exception")
-    hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
-    with pytest.raises(AirflowException):
-        await hook.get_adf_pipeline_run_status(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)
-
-
-@pytest.mark.asyncio
-@mock.patch("azure.mgmt.datafactory.models._models_py3.PipelineRun")
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn"
-)
-async def test_get_pipeline_run(mock_async_connection, mock_pipeline_run):
-    """Test get_pipeline_run run function"""
-    mock_async_connection.return_value.__aenter__.return_value.pipeline_runs.get.return_value = (
-        mock_pipeline_run
+class TestAzureDataFactoryHookAsync:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_status",
+        ["Queued", "InProgress", "Succeeded", "Failed", "Cancelled"],
     )
-    hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
-    response = await hook.get_pipeline_run(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)
-    assert response == mock_pipeline_run
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn")
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_pipeline_run")
+    async def test_get_adf_pipeline_run_status(self, mock_get_pipeline_run, mock_conn, mock_status):
+        """Test get_adf_pipeline_run_status function with mocked status"""
+        mock_get_pipeline_run.return_value.status = mock_status
+        hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
+        response = await hook.get_adf_pipeline_run_status(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)
+        assert response == mock_status
 
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn")
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_pipeline_run")
+    async def test_get_adf_pipeline_run_status_exception(self, mock_get_pipeline_run, mock_conn):
+        """Test get_adf_pipeline_run_status function with exception"""
+        mock_get_pipeline_run.side_effect = Exception("Test exception")
+        hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
+        with pytest.raises(AirflowException):
+            await hook.get_adf_pipeline_run_status(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)
 
-@pytest.mark.asyncio
-@mock.patch("azure.mgmt.datafactory.models._models_py3.PipelineRun")
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_connection"
-)
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn"
-)
-async def test_get_pipeline_run_without_resource_name(
-    mock_async_connection, mock_get_connection, mock_pipeline_run
-):
-    """Test get_pipeline_run run function without passing the resource name to check the decorator function"""
-    mock_connection = Connection(
-        extra=json.dumps(
-            {
-                "extra__azure_data_factory__resource_group_name": RESOURCE_GROUP_NAME,
-                "extra__azure_data_factory__factory_name": DATAFACTORY_NAME,
-            }
+    @pytest.mark.asyncio
+    @mock.patch("azure.mgmt.datafactory.models._models_py3.PipelineRun")
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn")
+    async def test_get_pipeline_run(self, mock_async_connection, mock_pipeline_run):
+        """Test get_pipeline_run run function"""
+        mock_async_connection.return_value.__aenter__.return_value.pipeline_runs.get.return_value = (
+            mock_pipeline_run
         )
-    )
-    mock_get_connection.return_value = mock_connection
-    mock_async_connection.return_value.__aenter__.return_value.pipeline_runs.get.return_value = (
-        mock_pipeline_run
-    )
-    hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
-    response = await hook.get_pipeline_run(RUN_ID, None, DATAFACTORY_NAME)
-    assert response == mock_pipeline_run
+        hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
+        response = await hook.get_pipeline_run(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)
+        assert response == mock_pipeline_run
 
+    @pytest.mark.asyncio
+    @mock.patch("azure.mgmt.datafactory.models._models_py3.PipelineRun")
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_connection")
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn")
+    async def test_get_pipeline_run_without_resource_name(
+        self, mock_async_connection, mock_get_connection, mock_pipeline_run
+    ):
+        """Test get_pipeline_run run function without passing the resource name to check the decorator function"""
+        mock_connection = Connection(
+            extra=json.dumps(
+                {
+                    "extra__azure_data_factory__resource_group_name": RESOURCE_GROUP_NAME,
+                    "extra__azure_data_factory__factory_name": DATAFACTORY_NAME,
+                }
+            )
+        )
+        mock_get_connection.return_value = mock_connection
+        mock_async_connection.return_value.__aenter__.return_value.pipeline_runs.get.return_value = (
+            mock_pipeline_run
+        )
+        hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
+        response = await hook.get_pipeline_run(RUN_ID, None, DATAFACTORY_NAME)
+        assert response == mock_pipeline_run
 
-@pytest.mark.asyncio
-@mock.patch("azure.mgmt.datafactory.models._models_py3.PipelineRun")
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_connection"
-)
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn"
-)
-async def test_get_pipeline_run_exception_without_resource(mock_conn, mock_get_connection, mock_pipeline_run):
-    """
-    Test get_pipeline_run function without passing the resource name to check the decorator function and
-    raise exception
-    """
-    mock_connection = Connection(
-        extra=json.dumps({"extra__azure_data_factory__factory_name": DATAFACTORY_NAME})
-    )
-    mock_get_connection.return_value = mock_connection
-    mock_conn.return_value.__aenter__.return_value.pipeline_runs.get.return_value = mock_pipeline_run
-    hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
-    with pytest.raises(AirflowException):
-        await hook.get_pipeline_run(RUN_ID, None, DATAFACTORY_NAME)
+    @pytest.mark.asyncio
+    @mock.patch("azure.mgmt.datafactory.models._models_py3.PipelineRun")
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_connection")
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn")
+    async def test_get_pipeline_run_exception_without_resource(
+        self, mock_conn, mock_get_connection, mock_pipeline_run
+    ):
+        """
+        Test get_pipeline_run function without passing the resource name to check the decorator function and
+        raise exception
+        """
+        mock_connection = Connection(
+            extra=json.dumps({"extra__azure_data_factory__factory_name": DATAFACTORY_NAME})
+        )
+        mock_get_connection.return_value = mock_connection
+        mock_conn.return_value.__aenter__.return_value.pipeline_runs.get.return_value = mock_pipeline_run
+        hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
+        with pytest.raises(AirflowException):
+            await hook.get_pipeline_run(RUN_ID, None, DATAFACTORY_NAME)
 
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn")
+    async def test_get_pipeline_run_exception(self, mock_conn):
+        """Test get_pipeline_run function with exception"""
+        mock_conn.return_value.__aenter__.return_value.pipeline_runs.get.side_effect = Exception(
+            "Test exception"
+        )
+        hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
+        with pytest.raises(AirflowException):
+            await hook.get_pipeline_run(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)
 
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_async_conn"
-)
-async def test_get_pipeline_run_exception(mock_conn):
-    """Test get_pipeline_run function with exception"""
-    mock_conn.return_value.__aenter__.return_value.pipeline_runs.get.side_effect = Exception("Test exception")
-    hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
-    with pytest.raises(AirflowException):
-        await hook.get_pipeline_run(RUN_ID, RESOURCE_GROUP_NAME, DATAFACTORY_NAME)
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_connection")
+    async def test_get_async_conn(self, mock_connection):
+        """"""
+        mock_conn = Connection(
+            conn_id=DEFAULT_CONNECTION_CLIENT_SECRET,
+            conn_type="azure_data_factory",
+            login="clientId",
+            password="clientSecret",
+            extra=json.dumps(
+                {
+                    "extra__azure_data_factory__tenantId": "tenantId",
+                    "extra__azure_data_factory__subscriptionId": "subscriptionId",
+                    "extra__azure_data_factory__resource_group_name": RESOURCE_GROUP_NAME,
+                    "extra__azure_data_factory__factory_name": DATAFACTORY_NAME,
+                }
+            ),
+        )
+        mock_connection.return_value = mock_conn
+        hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
+        response = await hook.get_async_conn()
+        assert isinstance(response, DataFactoryManagementClient)
 
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_connection")
+    async def test_get_async_conn_without_login_id(self, mock_connection):
+        """Test get_async_conn function without login id"""
+        mock_conn = Connection(
+            conn_id=DEFAULT_CONNECTION_CLIENT_SECRET,
+            conn_type="azure_data_factory",
+            extra=json.dumps(
+                {
+                    "extra__azure_data_factory__tenantId": "tenantId",
+                    "extra__azure_data_factory__subscriptionId": "subscriptionId",
+                    "extra__azure_data_factory__resource_group_name": RESOURCE_GROUP_NAME,
+                    "extra__azure_data_factory__factory_name": DATAFACTORY_NAME,
+                }
+            ),
+        )
+        mock_connection.return_value = mock_conn
+        hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
+        response = await hook.get_async_conn()
+        assert isinstance(response, DataFactoryManagementClient)
 
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_connection"
-)
-async def test_get_async_conn(mock_connection):
-    """"""
-    mock_conn = Connection(
-        conn_id=DEFAULT_CONNECTION_CLIENT_SECRET,
-        conn_type="azure_data_factory",
-        login="clientId",
-        password="clientSecret",
-        extra=json.dumps(
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_connection_params",
+        [
             {
                 "extra__azure_data_factory__tenantId": "tenantId",
+                "extra__azure_data_factory__resource_group_name": RESOURCE_GROUP_NAME,
+                "extra__azure_data_factory__factory_name": DATAFACTORY_NAME,
+            },
+            {
                 "extra__azure_data_factory__subscriptionId": "subscriptionId",
                 "extra__azure_data_factory__resource_group_name": RESOURCE_GROUP_NAME,
                 "extra__azure_data_factory__factory_name": DATAFACTORY_NAME,
-            }
-        ),
+            },
+        ],
     )
-    mock_connection.return_value = mock_conn
-    hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
-    response = await hook.get_async_conn()
-    assert isinstance(response, DataFactoryManagementClient)
-
-
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_connection"
-)
-async def test_get_async_conn_without_login_id(mock_connection):
-    """Test get_async_conn function without login id"""
-    mock_conn = Connection(
-        conn_id=DEFAULT_CONNECTION_CLIENT_SECRET,
-        conn_type="azure_data_factory",
-        extra=json.dumps(
-            {
-                "extra__azure_data_factory__tenantId": "tenantId",
-                "extra__azure_data_factory__subscriptionId": "subscriptionId",
-                "extra__azure_data_factory__resource_group_name": RESOURCE_GROUP_NAME,
-                "extra__azure_data_factory__factory_name": DATAFACTORY_NAME,
-            }
-        ),
-    )
-    mock_connection.return_value = mock_conn
-    hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
-    response = await hook.get_async_conn()
-    assert isinstance(response, DataFactoryManagementClient)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "mock_connection_params",
-    [
-        {
-            "extra__azure_data_factory__tenantId": "tenantId",
-            "extra__azure_data_factory__resource_group_name": RESOURCE_GROUP_NAME,
-            "extra__azure_data_factory__factory_name": DATAFACTORY_NAME,
-        },
-        {
-            "extra__azure_data_factory__subscriptionId": "subscriptionId",
-            "extra__azure_data_factory__resource_group_name": RESOURCE_GROUP_NAME,
-            "extra__azure_data_factory__factory_name": DATAFACTORY_NAME,
-        },
-    ],
-)
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_connection"
-)
-async def test_get_async_conn_key_error(mock_connection, mock_connection_params):
-    """Test get_async_conn function with raising key error"""
-    mock_conn = Connection(
-        conn_id=DEFAULT_CONNECTION_CLIENT_SECRET,
-        conn_type="azure_data_factory",
-        login="clientId",
-        password="clientSecret",
-        extra=json.dumps(mock_connection_params),
-    )
-    mock_connection.return_value = mock_conn
-    hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
-    with pytest.raises(ValueError):
-        await hook.get_async_conn()
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_connection")
+    async def test_get_async_conn_key_error(self, mock_connection, mock_connection_params):
+        """Test get_async_conn function with raising key error"""
+        mock_conn = Connection(
+            conn_id=DEFAULT_CONNECTION_CLIENT_SECRET,
+            conn_type="azure_data_factory",
+            login="clientId",
+            password="clientSecret",
+            extra=json.dumps(mock_connection_params),
+        )
+        mock_connection.return_value = mock_conn
+        hook = AzureDataFactoryHookAsync(AZURE_DATA_FACTORY_CONN_ID)
+        with pytest.raises(ValueError):
+            await hook.get_async_conn()

--- a/tests/microsoft/azure/operators/test_data_factory.py
+++ b/tests/microsoft/azure/operators/test_data_factory.py
@@ -1,12 +1,7 @@
-from datetime import datetime
 from unittest import mock
 
 import pytest
-from airflow import DAG
 from airflow.exceptions import AirflowException, TaskDeferred
-from airflow.models.dagrun import DagRun
-from airflow.models.taskinstance import TaskInstance
-from airflow.utils.types import DagRunType
 
 from astronomer.providers.microsoft.azure.operators.data_factory import (
     AzureDataFactoryRunPipelineOperatorAsync,
@@ -14,86 +9,50 @@ from astronomer.providers.microsoft.azure.operators.data_factory import (
 from astronomer.providers.microsoft.azure.triggers.data_factory import (
     AzureDataFactoryTrigger,
 )
+from tests.utils.airflow_util import create_context
 
-AZ_PIPELINE_RUN_ID = "123"
-
-
-def create_context(task):
-    dag = DAG(dag_id="dag")
-    execution_date = datetime(2022, 1, 1, 0, 0, 0)
-    dag_run = DagRun(
-        dag_id=dag.dag_id,
-        execution_date=execution_date,
-        run_id=DagRun.generate_run_id(DagRunType.MANUAL, execution_date),
-    )
-    task_instance = TaskInstance(task=task)
-    task_instance.dag_run = dag_run
-    task_instance.dag_id = dag.dag_id
-    task_instance.xcom_push = mock.Mock()
-    return {
-        "dag": dag,
-        "run_id": dag_run.run_id,
-        "task": task,
-        "ti": task_instance,
-        "task_instance": task_instance,
-    }
+AZ_PIPELINE_RUN_ID = "7f8c6c72-c093-11ec-a83d-0242ac120007"
 
 
-@pytest.fixture
-def context():
-    """
-    Creates an empty context.
-    """
-    context = {}
-    yield context
-
-
-@mock.patch("airflow.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHook.run_pipeline")
-def test_azure_data_factory_run_pipeline_operator_async(mock_run_pipeline):
-    """Assert that AzureDataFactoryRunPipelineOperatorAsync deferred"""
-
-    class CreateRunResponse:
-        pass
-
-    CreateRunResponse.run_id = AZ_PIPELINE_RUN_ID
-    mock_run_pipeline.return_value = CreateRunResponse
-    op = AzureDataFactoryRunPipelineOperatorAsync(
-        task_id="run_pipeline",
-        pipeline_name="pipeline",
-        parameters={"myParam": "value"},
-    )
-    with pytest.raises(TaskDeferred) as exc:
-        op.execute(context=create_context(op))
-
-    assert isinstance(exc.value.trigger, AzureDataFactoryTrigger), "Trigger is not a AzureDataFactoryTrigger"
-
-
-def test_azure_data_factory_run_pipeline_operator_async_execute_complete_success():
-    """Assert that execute_complete log success message"""
-    op = AzureDataFactoryRunPipelineOperatorAsync(
+class TestAzureDataFactoryRunPipelineOperatorAsync:
+    OPERATOR = AzureDataFactoryRunPipelineOperatorAsync(
         task_id="run_pipeline",
         pipeline_name="pipeline",
         parameters={"myParam": "value"},
     )
 
-    with mock.patch.object(op.log, "info") as mock_log_info:
-        op.execute_complete(
-            context=create_context(op),
-            event={"status": "success", "message": "success", "run_id": AZ_PIPELINE_RUN_ID},
-        )
-    mock_log_info.assert_called_with("success")
+    @mock.patch("airflow.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHook.run_pipeline")
+    def test_azure_data_factory_run_pipeline_operator_async(self, mock_run_pipeline):
+        """Assert that AzureDataFactoryRunPipelineOperatorAsync deferred"""
 
+        class CreateRunResponse:
+            pass
 
-def test_azure_data_factory_run_pipeline_operator_async_execute_complete_fail():
-    """Assert that execute_complete raise exception on error"""
-    op = AzureDataFactoryRunPipelineOperatorAsync(
-        task_id="run_pipeline",
-        pipeline_name="pipeline",
-        parameters={"myParam": "value"},
-    )
+        CreateRunResponse.run_id = AZ_PIPELINE_RUN_ID
+        mock_run_pipeline.return_value = CreateRunResponse
 
-    with pytest.raises(AirflowException):
-        op.execute_complete(
-            context=create_context(op),
-            event={"status": "error", "message": "error", "run_id": AZ_PIPELINE_RUN_ID},
-        )
+        with pytest.raises(TaskDeferred) as exc:
+            self.OPERATOR.execute(context=create_context(self.OPERATOR))
+
+        assert isinstance(
+            exc.value.trigger, AzureDataFactoryTrigger
+        ), "Trigger is not a AzureDataFactoryTrigger"
+
+    def test_azure_data_factory_run_pipeline_operator_async_execute_complete_success(self):
+        """Assert that execute_complete log success message"""
+
+        with mock.patch.object(self.OPERATOR.log, "info") as mock_log_info:
+            self.OPERATOR.execute_complete(
+                context=create_context(self.OPERATOR),
+                event={"status": "success", "message": "success", "run_id": AZ_PIPELINE_RUN_ID},
+            )
+        mock_log_info.assert_called_with("success")
+
+    def test_azure_data_factory_run_pipeline_operator_async_execute_complete_fail(self):
+        """Assert that execute_complete raise exception on error"""
+
+        with pytest.raises(AirflowException):
+            self.OPERATOR.execute_complete(
+                context=create_context(self.OPERATOR),
+                event={"status": "error", "message": "error", "run_id": AZ_PIPELINE_RUN_ID},
+            )

--- a/tests/microsoft/azure/sensors/test_data_factory.py
+++ b/tests/microsoft/azure/sensors/test_data_factory.py
@@ -6,61 +6,44 @@ from airflow.exceptions import AirflowException, TaskDeferred
 from astronomer.providers.microsoft.azure.sensors.data_factory import (
     AzureDataFactoryPipelineRunStatusSensorAsync,
 )
-from astronomer.providers.microsoft.azure.triggers.data_factory import (
-    ADFPipelineRunStatusSensorTrigger,
-)
-
-RUN_ID = "7f8c6c72-c093-11ec-a83d-0242ac120007"
-TASK_ID = "test_pipeline_run_sensor_async"
+from astronomer.providers.microsoft.azure.triggers.data_factory import ADFPipelineRunStatusSensorTrigger
+from tests.utils.airflow_util import create_context
 
 
-@pytest.fixture
-def context():
-    """Creates an empty context."""
-    context = {}
-    yield context
-
-
-def test_adf_pipeline_status_sensor_async():
-    """Assert execute method defer for Azure Data factory pipeline run status sensor"""
-    task = AzureDataFactoryPipelineRunStatusSensorAsync(
-        task_id="pipeline_run_sensor_async",
-        run_id=RUN_ID,
-    )
-    with pytest.raises(TaskDeferred) as exc:
-        task.execute(context)
-    assert isinstance(
-        exc.value.trigger, ADFPipelineRunStatusSensorTrigger
-    ), "Trigger is not a ADFPipelineRunStatusSensorTrigger"
-
-
-def test_adf_pipeline_status_sensor_execute_complete_success():
-    """Assert execute_complete log success message when trigger fire with target status"""
-    task = AzureDataFactoryPipelineRunStatusSensorAsync(
+class TestAzureDataFactoryPipelineRunStatusSensorAsync:
+    RUN_ID = "7f8c6c72-c093-11ec-a83d-0242ac120007"
+    SENSOR = AzureDataFactoryPipelineRunStatusSensorAsync(
         task_id="pipeline_run_sensor_async",
         run_id=RUN_ID,
     )
 
-    msg = f"Pipeline run {RUN_ID} has been succeeded."
-    with mock.patch.object(task.log, "info") as mock_log_info:
-        task.execute_complete(context={}, event={"status": "success", "message": msg})
-    mock_log_info.assert_called_with(msg)
+    def test_adf_pipeline_status_sensor_async(self):
+        """Assert execute method defer for Azure Data factory pipeline run status sensor"""
 
+        with pytest.raises(TaskDeferred) as exc:
+            self.SENSOR.execute(create_context(self.SENSOR))
+        assert isinstance(
+            exc.value.trigger, ADFPipelineRunStatusSensorTrigger
+        ), "Trigger is not a ADFPipelineRunStatusSensorTrigger"
 
-def test_adf_pipeline_status_sensor_execute_complete_failure():
-    """Assert execute_complete method fail"""
-    task = AzureDataFactoryPipelineRunStatusSensorAsync(
-        task_id="pipeline_run_sensor_async",
-        run_id=RUN_ID,
-    )
-    with pytest.raises(AirflowException):
-        task.execute_complete(context={}, event={"status": "error", "message": ""})
+    def test_adf_pipeline_status_sensor_execute_complete_success(self):
+        """Assert execute_complete log success message when trigger fire with target status"""
 
+        msg = f"Pipeline run {self.RUN_ID} has been succeeded."
+        with mock.patch.object(self.SENSOR.log, "info") as mock_log_info:
+            self.SENSOR.execute_complete(context={}, event={"status": "success", "message": msg})
+        mock_log_info.assert_called_with(msg)
 
-def test_poll_interval_deprecation_warning():
-    """Test DeprecationWarning for AzureDataFactoryPipelineRunStatusSensorAsync by setting param poll_interval"""
-    # TODO: Remove once deprecated
-    with pytest.warns(expected_warning=DeprecationWarning):
-        AzureDataFactoryPipelineRunStatusSensorAsync(
-            task_id="pipeline_run_sensor_async", run_id=RUN_ID, poll_interval=5.0
-        )
+    def test_adf_pipeline_status_sensor_execute_complete_failure(self):
+        """Assert execute_complete method fail"""
+
+        with pytest.raises(AirflowException):
+            self.SENSOR.execute_complete(context={}, event={"status": "error", "message": ""})
+
+    def test_poll_interval_deprecation_warning(self):
+        """Test DeprecationWarning for AzureDataFactoryPipelineRunStatusSensorAsync by setting param poll_interval"""
+        # TODO: Remove once deprecated
+        with pytest.warns(expected_warning=DeprecationWarning):
+            AzureDataFactoryPipelineRunStatusSensorAsync(
+                task_id="pipeline_run_sensor_async", run_id=self.RUN_ID, poll_interval=5.0
+            )

--- a/tests/microsoft/azure/sensors/test_wasb.py
+++ b/tests/microsoft/azure/sensors/test_wasb.py
@@ -11,128 +11,106 @@ from astronomer.providers.microsoft.azure.triggers.wasb import (
     WasbBlobSensorTrigger,
     WasbPrefixSensorTrigger,
 )
+from tests.utils.airflow_util import create_context
 
 TEST_DATA_STORAGE_BLOB_NAME = "test_blob_providers_team.txt"
 TEST_DATA_STORAGE_CONTAINER_NAME = "test-container-providers-team"
 TEST_DATA_STORAGE_BLOB_PREFIX = TEST_DATA_STORAGE_BLOB_NAME[:10]
 
 
-@pytest.fixture
-def context():
-    """Creates an empty context."""
-    context = {}
-    yield context
-
-
-def test_wasb_blob_sensor_async(context):
-    """Assert execute method defer for wasb blob sensor"""
-    task = WasbBlobSensorAsync(
-        task_id="wasb_blob_sensor_async",
-        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-        blob_name=TEST_DATA_STORAGE_BLOB_NAME,
-    )
-    with pytest.raises(TaskDeferred) as exc:
-        task.execute(context)
-    assert isinstance(exc.value.trigger, WasbBlobSensorTrigger), "Trigger is not a WasbBlobSensorTrigger"
-
-
-@pytest.mark.parametrize(
-    "event",
-    [None, {"status": "success", "message": "Job completed"}],
-)
-def test_wasb_blob_sensor_execute_complete_success(event):
-    """Assert execute_complete log success message when trigger fire with target status."""
-    task = WasbBlobSensorAsync(
+class TestWasbBlobSensorAsync:
+    SENSOR = WasbBlobSensorAsync(
         task_id="wasb_blob_sensor_async",
         container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
         blob_name=TEST_DATA_STORAGE_BLOB_NAME,
     )
 
-    if not event:
-        with pytest.raises(AirflowException) as exception_info:
-            task.execute_complete(context=None, event=None)
-        assert exception_info.value.args[0] == "Did not receive valid event from the triggerer"
-    else:
-        with mock.patch.object(task.log, "info") as mock_log_info:
-            task.execute_complete(context={}, event=event)
-        mock_log_info.assert_called_with(event["message"])
+    def test_wasb_blob_sensor_async(self):
+        """Assert execute method defer for wasb blob sensor"""
 
+        with pytest.raises(TaskDeferred) as exc:
+            self.SENSOR.execute(create_context(self.SENSOR))
+        assert isinstance(exc.value.trigger, WasbBlobSensorTrigger), "Trigger is not a WasbBlobSensorTrigger"
 
-def test_wasb_blob_sensor_execute_complete_failure():
-    """Assert execute_complete method raises an exception when the triggerer fires an error event."""
-    task = WasbBlobSensorAsync(
-        task_id="wasb_blob_sensor_async",
-        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-        blob_name=TEST_DATA_STORAGE_BLOB_NAME,
+    @pytest.mark.parametrize(
+        "event",
+        [None, {"status": "success", "message": "Job completed"}],
     )
-    with pytest.raises(AirflowException):
-        task.execute_complete(context={}, event={"status": "error", "message": ""})
+    def test_wasb_blob_sensor_execute_complete_success(self, event):
+        """Assert execute_complete log success message when trigger fire with target status."""
+
+        if not event:
+            with pytest.raises(AirflowException) as exception_info:
+                self.SENSOR.execute_complete(context=None, event=None)
+            assert exception_info.value.args[0] == "Did not receive valid event from the triggerer"
+        else:
+            with mock.patch.object(self.SENSOR.log, "info") as mock_log_info:
+                self.SENSOR.execute_complete(context={}, event=event)
+            mock_log_info.assert_called_with(event["message"])
+
+    def test_wasb_blob_sensor_execute_complete_failure(self):
+        """Assert execute_complete method raises an exception when the triggerer fires an error event."""
+
+        with pytest.raises(AirflowException):
+            self.SENSOR.execute_complete(context={}, event={"status": "error", "message": ""})
+
+    def test_poll_interval_deprecation_warning_wasb_blob(self):
+        """Test DeprecationWarning for WasbBlobSensorAsync by setting param poll_interval"""
+        # TODO: Remove once deprecated
+        with pytest.warns(expected_warning=DeprecationWarning):
+            WasbBlobSensorAsync(
+                task_id="wasb_blob_sensor_async",
+                container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+                blob_name=TEST_DATA_STORAGE_BLOB_NAME,
+                poll_interval=5.0,
+            )
 
 
-def test_poll_interval_deprecation_warning_wasb_blob():
-    """Test DeprecationWarning for WasbBlobSensorAsync by setting param poll_interval"""
-    # TODO: Remove once deprecated
-    with pytest.warns(expected_warning=DeprecationWarning):
-        WasbBlobSensorAsync(
-            task_id="wasb_blob_sensor_async",
-            container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-            blob_name=TEST_DATA_STORAGE_BLOB_NAME,
-            poll_interval=5.0,
-        )
-
-
-def test_wasb_prefix_sensor_async(context):
-    """Assert execute method defer for wasb prefix sensor"""
-    task = WasbPrefixSensorAsync(
+class TestWasbPrefixSensorAsync:
+    SENSOR = WasbPrefixSensorAsync(
         task_id="wasb_prefix_sensor_async",
         container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
         prefix=TEST_DATA_STORAGE_BLOB_PREFIX,
     )
-    with pytest.raises(TaskDeferred) as exc:
-        task.execute(context)
-    assert isinstance(exc.value.trigger, WasbPrefixSensorTrigger), "Trigger is not a WasbPrefixSensorTrigger"
 
+    def test_wasb_prefix_sensor_async(self):
+        """Assert execute method defer for wasb prefix sensor"""
 
-@pytest.mark.parametrize(
-    "event",
-    [None, {"status": "success", "message": "Job completed"}],
-)
-def test_wasb_prefix_sensor_execute_complete_success(event):
-    """Assert execute_complete log success message when trigger fire with target status."""
-    task = WasbPrefixSensorAsync(
-        task_id="wasb_prefix_sensor_async",
-        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-        prefix=TEST_DATA_STORAGE_BLOB_NAME,
+        with pytest.raises(TaskDeferred) as exc:
+            self.SENSOR.execute(create_context(self.SENSOR))
+        assert isinstance(
+            exc.value.trigger, WasbPrefixSensorTrigger
+        ), "Trigger is not a WasbPrefixSensorTrigger"
+
+    @pytest.mark.parametrize(
+        "event",
+        [None, {"status": "success", "message": "Job completed"}],
     )
+    def test_wasb_prefix_sensor_execute_complete_success(self, event):
+        """Assert execute_complete log success message when trigger fire with target status."""
 
-    if not event:
-        with pytest.raises(AirflowException) as exception_info:
-            task.execute_complete(context=None, event=None)
-        assert exception_info.value.args[0] == "Did not receive valid event from the triggerer"
-    else:
-        with mock.patch.object(task.log, "info") as mock_log_info:
-            task.execute_complete(context={}, event=event)
-        mock_log_info.assert_called_with(event["message"])
+        if not event:
+            with pytest.raises(AirflowException) as exception_info:
+                self.SENSOR.execute_complete(context=None, event=None)
+            assert exception_info.value.args[0] == "Did not receive valid event from the triggerer"
+        else:
+            with mock.patch.object(self.SENSOR.log, "info") as mock_log_info:
+                self.SENSOR.execute_complete(context={}, event=event)
+            mock_log_info.assert_called_with(event["message"])
 
+    def test_wasb_prefix_sensor_execute_complete_failure(self):
+        """Assert execute_complete method raises an exception when the triggerer fires an error event."""
 
-def test_wasb_prefix_sensor_execute_complete_failure():
-    """Assert execute_complete method raises an exception when the triggerer fires an error event."""
-    task = WasbPrefixSensorAsync(
-        task_id="wasb_prefix_sensor_async",
-        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-        prefix=TEST_DATA_STORAGE_BLOB_NAME,
-    )
-    with pytest.raises(AirflowException):
-        task.execute_complete(context={}, event={"status": "error", "message": ""})
+        with pytest.raises(AirflowException):
+            self.SENSOR.execute_complete(context={}, event={"status": "error", "message": ""})
 
-
-def test_poll_interval_deprecation_warning():
-    """Test DeprecationWarning for WasbPrefixSensorAsync by setting param poll_interval"""
-    # TODO: Remove once deprecated
-    with pytest.warns(expected_warning=DeprecationWarning):
-        WasbPrefixSensorAsync(
-            task_id="wasb_prefix_sensor_async",
-            container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-            prefix=TEST_DATA_STORAGE_BLOB_NAME,
-            poll_interval=5.0,
-        )
+    def test_poll_interval_deprecation_warning(self):
+        """Test DeprecationWarning for WasbPrefixSensorAsync by setting param poll_interval"""
+        # TODO: Remove once deprecated
+        with pytest.warns(expected_warning=DeprecationWarning):
+            WasbPrefixSensorAsync(
+                task_id="wasb_prefix_sensor_async",
+                container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
+                prefix=TEST_DATA_STORAGE_BLOB_NAME,
+                poll_interval=5.0,
+            )

--- a/tests/microsoft/azure/triggers/test_data_factory.py
+++ b/tests/microsoft/azure/triggers/test_data_factory.py
@@ -12,7 +12,6 @@ from astronomer.providers.microsoft.azure.triggers.data_factory import (
 
 RESOURCE_GROUP_NAME = "team_provider_resource_group_test"
 DATAFACTORY_NAME = "ADFProvidersTeamDataFactory"
-TASK_ID = "test_adf_pipeline_run_status_sensor"
 AZURE_DATA_FACTORY_CONN_ID = "azure_data_factory_default"
 RUN_ID = "7f8c6c72-c093-11ec-a83d-0242ac120007"
 POKE_INTERVAL = 5
@@ -21,322 +20,247 @@ AZ_RESOURCE_GROUP_NAME = "test-rg"
 AZ_FACTORY_NAME = "test-factory"
 AZ_DATA_FACTORY_CONN_ID = "test-conn"
 AZ_PIPELINE_END_TIME = time.time() + 60 * 60 * 24 * 7
+MODULE = "astronomer.providers.microsoft.azure"
 
 
-def test_adf_pipeline_run_status_sensors_trigger_serialization():
-    """
-    Asserts that the TaskStateTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = ADFPipelineRunStatusSensorTrigger(
+class TestADFPipelineRunStatusSensorTrigger:
+    TRIGGER = ADFPipelineRunStatusSensorTrigger(
         run_id=RUN_ID,
         azure_data_factory_conn_id=AZURE_DATA_FACTORY_CONN_ID,
         resource_group_name=RESOURCE_GROUP_NAME,
         factory_name=DATAFACTORY_NAME,
         poke_interval=POKE_INTERVAL,
     )
-    classpath, kwargs = trigger.serialize()
-    assert (
-        classpath
-        == "astronomer.providers.microsoft.azure.triggers.data_factory.ADFPipelineRunStatusSensorTrigger"
-    )
-    assert kwargs == {
-        "run_id": RUN_ID,
-        "azure_data_factory_conn_id": AZURE_DATA_FACTORY_CONN_ID,
-        "resource_group_name": RESOURCE_GROUP_NAME,
-        "factory_name": DATAFACTORY_NAME,
-        "poke_interval": POKE_INTERVAL,
-    }
 
+    def test_adf_pipeline_run_status_sensors_trigger_serialization(self):
+        """
+        Asserts that the TaskStateTrigger correctly serializes its arguments
+        and classpath.
+        """
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "mock_status",
-    [
-        "Queued",
-        "InProgress",
-    ],
-)
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status"
-)
-async def test_adf_pipeline_run_status_sensors_trigger_run(mock_data_factory, mock_status):
-    """
-    Test if the task is run is in trigger successfully.
-    """
-    mock_data_factory.return_value = mock_status
-    trigger = ADFPipelineRunStatusSensorTrigger(
-        run_id=RUN_ID,
-        azure_data_factory_conn_id=AZURE_DATA_FACTORY_CONN_ID,
-        resource_group_name=RESOURCE_GROUP_NAME,
-        factory_name=DATAFACTORY_NAME,
-        poke_interval=POKE_INTERVAL,
-    )
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "mock_status",
-    ["Succeeded"],
-)
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status"
-)
-async def test_adf_pipeline_run_status_sensors_trigger_completed(mock_data_factory, mock_status):
-    """Test if the task pipeline status is in succeeded status."""
-    mock_data_factory.return_value = mock_status
-    trigger = ADFPipelineRunStatusSensorTrigger(
-        run_id=RUN_ID,
-        azure_data_factory_conn_id=AZURE_DATA_FACTORY_CONN_ID,
-        resource_group_name=RESOURCE_GROUP_NAME,
-        factory_name=DATAFACTORY_NAME,
-        poke_interval=POKE_INTERVAL,
-    )
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    msg = f"Pipeline run {RUN_ID} has been Succeeded."
-    assert TriggerEvent({"status": "success", "message": msg}) == actual
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "mock_status, mock_message",
-    [
-        ("Failed", f"Pipeline run {RUN_ID} has Failed."),
-        ("Cancelled", f"Pipeline run {RUN_ID} has been Cancelled."),
-    ],
-)
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status"
-)
-async def test_adf_pipeline_run_status_sensors_trigger_failure_status(
-    mock_data_factory, mock_status, mock_message
-):
-    """Test if the task is run is in trigger failure status."""
-    mock_data_factory.return_value = mock_status
-    trigger = ADFPipelineRunStatusSensorTrigger(
-        run_id=RUN_ID,
-        azure_data_factory_conn_id=AZURE_DATA_FACTORY_CONN_ID,
-        resource_group_name=RESOURCE_GROUP_NAME,
-        factory_name=DATAFACTORY_NAME,
-        poke_interval=POKE_INTERVAL,
-    )
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent({"status": "error", "message": mock_message}) == actual
-
-
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status"
-)
-async def test_adf_pipeline_run_status_sensors_trigger_exception(mock_data_factory):
-    """Test EMR container sensors with raise exception"""
-    mock_data_factory.side_effect = Exception("Test exception")
-    trigger = ADFPipelineRunStatusSensorTrigger(
-        run_id=RUN_ID,
-        azure_data_factory_conn_id=AZURE_DATA_FACTORY_CONN_ID,
-        resource_group_name=RESOURCE_GROUP_NAME,
-        factory_name=DATAFACTORY_NAME,
-        poke_interval=POKE_INTERVAL,
-    )
-    task = [i async for i in trigger.run()]
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
-
-
-def test_azure_data_factory_trigger_serialization():
-    """Asserts that the AzureDataFactoryTrigger correctly serializes its arguments and classpath."""
-    trigger = AzureDataFactoryTrigger(
-        run_id=AZ_PIPELINE_RUN_ID,
-        resource_group_name=AZ_RESOURCE_GROUP_NAME,
-        factory_name=AZ_FACTORY_NAME,
-        azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
-        end_time=AZ_PIPELINE_END_TIME,
-    )
-
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.microsoft.azure.triggers.data_factory.AzureDataFactoryTrigger"
-    assert kwargs == {
-        "run_id": AZ_PIPELINE_RUN_ID,
-        "resource_group_name": AZ_RESOURCE_GROUP_NAME,
-        "factory_name": AZ_FACTORY_NAME,
-        "azure_data_factory_conn_id": AZ_DATA_FACTORY_CONN_ID,
-        "end_time": AZ_PIPELINE_END_TIME,
-        "wait_for_termination": True,
-        "check_interval": 60,
-    }
-
-
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status"
-)
-async def test_azure_data_factory_trigger_run_without_wait(mock_pipeline_run_status):
-    """Assert that run trigger without waiting if wait_for_termination is set to false"""
-    mock_pipeline_run_status.return_value = AzureDataFactoryTrigger.SUCCEEDED
-    trigger = AzureDataFactoryTrigger(
-        run_id=AZ_PIPELINE_RUN_ID,
-        resource_group_name=AZ_RESOURCE_GROUP_NAME,
-        factory_name=AZ_FACTORY_NAME,
-        azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
-        wait_for_termination=False,
-        end_time=AZ_PIPELINE_END_TIME,
-    )
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    expected = TriggerEvent(
-        {
-            "status": "success",
-            "message": f"The pipeline run {AZ_PIPELINE_RUN_ID} has {AzureDataFactoryTrigger.SUCCEEDED} status.",
-            "run_id": AZ_PIPELINE_RUN_ID,
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == f"{MODULE}.triggers.data_factory.ADFPipelineRunStatusSensorTrigger"
+        assert kwargs == {
+            "run_id": RUN_ID,
+            "azure_data_factory_conn_id": AZURE_DATA_FACTORY_CONN_ID,
+            "resource_group_name": RESOURCE_GROUP_NAME,
+            "factory_name": DATAFACTORY_NAME,
+            "poke_interval": POKE_INTERVAL,
         }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_status",
+        [
+            "Queued",
+            "InProgress",
+        ],
     )
-    assert actual == expected
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status")
+    async def test_adf_pipeline_run_status_sensors_trigger_run(self, mock_data_factory, mock_status):
+        """
+        Test if the task is run is in trigger successfully.
+        """
+        mock_data_factory.return_value = mock_status
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_status",
+        ["Succeeded"],
+    )
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status")
+    async def test_adf_pipeline_run_status_sensors_trigger_completed(self, mock_data_factory, mock_status):
+        """Test if the task pipeline status is in succeeded status."""
+        mock_data_factory.return_value = mock_status
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        msg = f"Pipeline run {RUN_ID} has been Succeeded."
+        assert TriggerEvent({"status": "success", "message": msg}) == actual
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_status, mock_message",
+        [
+            ("Failed", f"Pipeline run {RUN_ID} has Failed."),
+            ("Cancelled", f"Pipeline run {RUN_ID} has been Cancelled."),
+        ],
+    )
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status")
+    async def test_adf_pipeline_run_status_sensors_trigger_failure_status(
+        self, mock_data_factory, mock_status, mock_message
+    ):
+        """Test if the task is run is in trigger failure status."""
+        mock_data_factory.return_value = mock_status
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "error", "message": mock_message}) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status")
+    async def test_adf_pipeline_run_status_sensors_trigger_exception(self, mock_data_factory):
+        """Test EMR container sensors with raise exception"""
+        mock_data_factory.side_effect = Exception("Test exception")
+
+        task = [i async for i in self.TRIGGER.run()]
+        assert len(task) == 1
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "status",
-    [
-        AzureDataFactoryTrigger.QUEUED,
-        AzureDataFactoryTrigger.IN_PROGRESS,
-        AzureDataFactoryTrigger.CANCELING,
-    ],
-)
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status"
-)
-async def test_azure_data_factory_trigger_run_pending(mock_pipeline_run_status, status):
-    """Assert that run wait if pipeline run is in intermediate state"""
-    mock_pipeline_run_status.return_value = status
-    trigger = AzureDataFactoryTrigger(
+class TestAzureDataFactoryTrigger:
+    TRIGGER = AzureDataFactoryTrigger(
         run_id=AZ_PIPELINE_RUN_ID,
         resource_group_name=AZ_RESOURCE_GROUP_NAME,
         factory_name=AZ_FACTORY_NAME,
         azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
         end_time=AZ_PIPELINE_END_TIME,
     )
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
 
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
+    def test_azure_data_factory_trigger_serialization(self):
+        """Asserts that the AzureDataFactoryTrigger correctly serializes its arguments and classpath."""
 
-
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status"
-)
-async def test_azure_data_factory_trigger_run_success(mock_pipeline_run_status):
-    """Assert that run trigger success message in case of pipeline success"""
-    mock_pipeline_run_status.return_value = AzureDataFactoryTrigger.SUCCEEDED
-    trigger = AzureDataFactoryTrigger(
-        run_id=AZ_PIPELINE_RUN_ID,
-        resource_group_name=AZ_RESOURCE_GROUP_NAME,
-        factory_name=AZ_FACTORY_NAME,
-        azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
-        end_time=AZ_PIPELINE_END_TIME,
-    )
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    expected = TriggerEvent(
-        {
-            "status": "success",
-            "message": f"The pipeline run {AZ_PIPELINE_RUN_ID} has {AzureDataFactoryTrigger.SUCCEEDED}.",
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == f"{MODULE}.triggers.data_factory.AzureDataFactoryTrigger"
+        assert kwargs == {
             "run_id": AZ_PIPELINE_RUN_ID,
+            "resource_group_name": AZ_RESOURCE_GROUP_NAME,
+            "factory_name": AZ_FACTORY_NAME,
+            "azure_data_factory_conn_id": AZ_DATA_FACTORY_CONN_ID,
+            "end_time": AZ_PIPELINE_END_TIME,
+            "wait_for_termination": True,
+            "check_interval": 60,
         }
-    )
-    assert expected == actual
 
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status")
+    async def test_azure_data_factory_trigger_run_without_wait(self, mock_pipeline_run_status):
+        """Assert that run trigger without waiting if wait_for_termination is set to false"""
+        mock_pipeline_run_status.return_value = AzureDataFactoryTrigger.SUCCEEDED
+        trigger = AzureDataFactoryTrigger(
+            run_id=AZ_PIPELINE_RUN_ID,
+            resource_group_name=AZ_RESOURCE_GROUP_NAME,
+            factory_name=AZ_FACTORY_NAME,
+            azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
+            wait_for_termination=False,
+            end_time=AZ_PIPELINE_END_TIME,
+        )
+        generator = trigger.run()
+        actual = await generator.asend(None)
+        expected = TriggerEvent(
+            {
+                "status": "success",
+                "message": f"The pipeline run {AZ_PIPELINE_RUN_ID} has {AzureDataFactoryTrigger.SUCCEEDED} status.",
+                "run_id": AZ_PIPELINE_RUN_ID,
+            }
+        )
+        assert actual == expected
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "status",
-    [
-        AzureDataFactoryTrigger.FAILED,
-        AzureDataFactoryTrigger.CANCELLED,
-    ],
-)
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status"
-)
-async def test_azure_data_factory_trigger_run_fail(mock_pipeline_run_status, status):
-    """Assert that run trigger error message in case of pipeline fail"""
-    mock_pipeline_run_status.return_value = status
-    trigger = AzureDataFactoryTrigger(
-        run_id=AZ_PIPELINE_RUN_ID,
-        resource_group_name=AZ_RESOURCE_GROUP_NAME,
-        factory_name=AZ_FACTORY_NAME,
-        azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
-        end_time=AZ_PIPELINE_END_TIME,
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status",
+        [
+            AzureDataFactoryTrigger.QUEUED,
+            AzureDataFactoryTrigger.IN_PROGRESS,
+            AzureDataFactoryTrigger.CANCELING,
+        ],
     )
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    expected = TriggerEvent(
-        {
-            "status": "error",
-            "message": f"The pipeline run {AZ_PIPELINE_RUN_ID} has {status}.",
-            "run_id": AZ_PIPELINE_RUN_ID,
-        }
-    )
-    assert expected == actual
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status")
+    async def test_azure_data_factory_trigger_run_pending(self, mock_pipeline_run_status, status):
+        """Assert that run wait if pipeline run is in intermediate state"""
+        mock_pipeline_run_status.return_value = status
 
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
 
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status"
-)
-async def test_azure_data_factory_trigger_run_exception(mock_pipeline_run_status):
-    """Assert that run catch exception if Azure API throw exception"""
-    mock_pipeline_run_status.side_effect = Exception("Test exception")
-    trigger = AzureDataFactoryTrigger(
-        run_id=AZ_PIPELINE_RUN_ID,
-        resource_group_name=AZ_RESOURCE_GROUP_NAME,
-        factory_name=AZ_FACTORY_NAME,
-        azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
-        end_time=AZ_PIPELINE_END_TIME,
-    )
-    task = [i async for i in trigger.run()]
-    response = TriggerEvent(
-        {
-            "status": "error",
-            "message": "Test exception",
-            "run_id": AZ_PIPELINE_RUN_ID,
-        }
-    )
-    assert len(task) == 1
-    assert response in task
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
 
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status")
+    async def test_azure_data_factory_trigger_run_success(self, mock_pipeline_run_status):
+        """Assert that run trigger success message in case of pipeline success"""
+        mock_pipeline_run_status.return_value = AzureDataFactoryTrigger.SUCCEEDED
 
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status"
-)
-async def test_azure_data_factory_trigger_run_timeout(mock_pipeline_run_status):
-    """Assert that run timeout after end_time elapsed"""
-    mock_pipeline_run_status.return_value = AzureDataFactoryTrigger.QUEUED
-    trigger = AzureDataFactoryTrigger(
-        run_id=AZ_PIPELINE_RUN_ID,
-        resource_group_name=AZ_RESOURCE_GROUP_NAME,
-        factory_name=AZ_FACTORY_NAME,
-        azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
-        end_time=time.time(),
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        expected = TriggerEvent(
+            {
+                "status": "success",
+                "message": f"The pipeline run {AZ_PIPELINE_RUN_ID} has {AzureDataFactoryTrigger.SUCCEEDED}.",
+                "run_id": AZ_PIPELINE_RUN_ID,
+            }
+        )
+        assert expected == actual
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status",
+        [
+            AzureDataFactoryTrigger.FAILED,
+            AzureDataFactoryTrigger.CANCELLED,
+        ],
     )
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    expected = TriggerEvent(
-        {
-            "status": "error",
-            "message": f"Timeout: The pipeline run {AZ_PIPELINE_RUN_ID} has {AzureDataFactoryTrigger.QUEUED}.",
-            "run_id": AZ_PIPELINE_RUN_ID,
-        }
-    )
-    assert expected == actual
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status")
+    async def test_azure_data_factory_trigger_run_fail(self, mock_pipeline_run_status, status):
+        """Assert that run trigger error message in case of pipeline fail"""
+        mock_pipeline_run_status.return_value = status
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        expected = TriggerEvent(
+            {
+                "status": "error",
+                "message": f"The pipeline run {AZ_PIPELINE_RUN_ID} has {status}.",
+                "run_id": AZ_PIPELINE_RUN_ID,
+            }
+        )
+        assert expected == actual
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status")
+    async def test_azure_data_factory_trigger_run_exception(self, mock_pipeline_run_status):
+        """Assert that run catch exception if Azure API throw exception"""
+        mock_pipeline_run_status.side_effect = Exception("Test exception")
+
+        task = [i async for i in self.TRIGGER.run()]
+        response = TriggerEvent(
+            {
+                "status": "error",
+                "message": "Test exception",
+                "run_id": AZ_PIPELINE_RUN_ID,
+            }
+        )
+        assert len(task) == 1
+        assert response in task
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.hooks.data_factory.AzureDataFactoryHookAsync.get_adf_pipeline_run_status")
+    async def test_azure_data_factory_trigger_run_timeout(self, mock_pipeline_run_status):
+        """Assert that run timeout after end_time elapsed"""
+        mock_pipeline_run_status.return_value = AzureDataFactoryTrigger.QUEUED
+        trigger = AzureDataFactoryTrigger(
+            run_id=AZ_PIPELINE_RUN_ID,
+            resource_group_name=AZ_RESOURCE_GROUP_NAME,
+            factory_name=AZ_FACTORY_NAME,
+            azure_data_factory_conn_id=AZ_DATA_FACTORY_CONN_ID,
+            end_time=time.time(),
+        )
+        generator = trigger.run()
+        actual = await generator.asend(None)
+        expected = TriggerEvent(
+            {
+                "status": "error",
+                "message": f"Timeout: The pipeline run {AZ_PIPELINE_RUN_ID} has {AzureDataFactoryTrigger.QUEUED}.",
+                "run_id": AZ_PIPELINE_RUN_ID,
+            }
+        )
+        assert expected == actual

--- a/tests/microsoft/azure/triggers/test_wasb.py
+++ b/tests/microsoft/azure/triggers/test_wasb.py
@@ -13,242 +13,182 @@ from astronomer.providers.microsoft.azure.triggers.wasb import (
 TEST_DATA_STORAGE_BLOB_NAME = "test_blob_providers_team.txt"
 TEST_DATA_STORAGE_CONTAINER_NAME = "test-container-providers-team"
 TEST_DATA_STORAGE_BLOB_PREFIX = TEST_DATA_STORAGE_BLOB_NAME[:10]
-
 TEST_WASB_CONN_ID = "wasb_default"
 POKE_INTERVAL = 5.0
 
 
-def test_wasb_blob_sensor_trigger_serialization():
-    """
-    Asserts that the WasbBlobSensorTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = WasbBlobSensorTrigger(
-        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-        blob_name=TEST_DATA_STORAGE_BLOB_NAME,
-        wasb_conn_id=TEST_WASB_CONN_ID,
-        poke_interval=POKE_INTERVAL,
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.microsoft.azure.triggers.wasb.WasbBlobSensorTrigger"
-    assert kwargs == {
-        "container_name": TEST_DATA_STORAGE_CONTAINER_NAME,
-        "blob_name": TEST_DATA_STORAGE_BLOB_NAME,
-        "wasb_conn_id": TEST_WASB_CONN_ID,
-        "poke_interval": POKE_INTERVAL,
-        "public_read": False,
-    }
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "blob_exists",
-    [
-        True,
-        False,
-    ],
-)
-@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_blob_async")
-async def test_wasb_blob_sensor_trigger_running(mock_check_for_blob, blob_exists):
-    """
-    Test if the task is run in trigger successfully.
-    """
-    mock_check_for_blob.return_value = blob_exists
-    trigger = WasbBlobSensorTrigger(
-        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-        blob_name=TEST_DATA_STORAGE_BLOB_NAME,
-        wasb_conn_id=TEST_WASB_CONN_ID,
-        poke_interval=POKE_INTERVAL,
-    )
-    task = asyncio.create_task(trigger.run().__anext__())
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_blob_async")
-async def test_wasb_blob_sensor_trigger_success(mock_check_for_blob):
-    """Tests the success state for that the WasbBlobSensorTrigger."""
-    mock_check_for_blob.return_value = True
-    trigger = WasbBlobSensorTrigger(
+class TestWasbBlobSensorTrigger:
+    TRIGGER = WasbBlobSensorTrigger(
         container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
         blob_name=TEST_DATA_STORAGE_BLOB_NAME,
         wasb_conn_id=TEST_WASB_CONN_ID,
         poke_interval=POKE_INTERVAL,
     )
 
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
+    def test_wasb_blob_sensor_trigger_serialization(self):
+        """
+        Asserts that the WasbBlobSensorTrigger correctly serializes its arguments
+        and classpath.
+        """
 
-    # TriggerEvent was returned
-    assert task.done() is True
-    asyncio.get_event_loop().stop()
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == "astronomer.providers.microsoft.azure.triggers.wasb.WasbBlobSensorTrigger"
+        assert kwargs == {
+            "container_name": TEST_DATA_STORAGE_CONTAINER_NAME,
+            "blob_name": TEST_DATA_STORAGE_BLOB_NAME,
+            "wasb_conn_id": TEST_WASB_CONN_ID,
+            "poke_interval": POKE_INTERVAL,
+            "public_read": False,
+        }
 
-    message = f"Blob {TEST_DATA_STORAGE_BLOB_NAME} found in container {TEST_DATA_STORAGE_CONTAINER_NAME}."
-    assert task.result() == TriggerEvent({"status": "success", "message": message})
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "blob_exists",
+        [True, False],
+    )
+    @mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_blob_async")
+    async def test_wasb_blob_sensor_trigger_running(self, mock_check_for_blob, blob_exists):
+        """
+        Test if the task is run in trigger successfully.
+        """
+        mock_check_for_blob.return_value = blob_exists
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_blob_async")
+    async def test_wasb_blob_sensor_trigger_success(self, mock_check_for_blob):
+        """Tests the success state for that the WasbBlobSensorTrigger."""
+        mock_check_for_blob.return_value = True
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was returned
+        assert task.done() is True
+        asyncio.get_event_loop().stop()
+
+        message = f"Blob {TEST_DATA_STORAGE_BLOB_NAME} found in container {TEST_DATA_STORAGE_CONTAINER_NAME}."
+        assert task.result() == TriggerEvent({"status": "success", "message": message})
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_blob_async")
+    async def test_wasb_blob_sensor_trigger_waiting_for_blob(self, mock_check_for_blob, caplog):
+        """Tests the WasbBlobSensorTrigger sleeps waiting for the blob to arrive."""
+        mock_check_for_blob.side_effect = [False, True]
+        caplog.set_level(logging.INFO)
+
+        with mock.patch.object(self.TRIGGER.log, "info"):
+            task = asyncio.create_task(self.TRIGGER.run().__anext__())
+
+        await asyncio.sleep(POKE_INTERVAL + 0.5)
+
+        if not task.done():
+            message = (
+                f"Blob {TEST_DATA_STORAGE_BLOB_NAME} not available yet in container {TEST_DATA_STORAGE_CONTAINER_NAME}."
+                f" Sleeping for {POKE_INTERVAL} seconds"
+            )
+            assert message in caplog.text
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_blob_async")
+    async def test_wasb_blob_sensor_trigger_trigger_exception(self, mock_check_for_blob):
+        """Tests the WasbBlobSensorTrigger yields an error event if there is an exception."""
+        mock_check_for_blob.side_effect = Exception("Test exception")
+
+        task = [i async for i in self.TRIGGER.run()]
+        assert len(task) == 1
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
 
 
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_blob_async")
-async def test_wasb_blob_sensor_trigger_waiting_for_blob(mock_check_for_blob, caplog):
-    """Tests the WasbBlobSensorTrigger sleeps waiting for the blob to arrive."""
-    mock_check_for_blob.side_effect = [False, True]
-    caplog.set_level(logging.INFO)
-    trigger = WasbBlobSensorTrigger(
+class TestWasbPrefixSensorTrigger:
+    TRIGGER = WasbPrefixSensorTrigger(
         container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-        blob_name=TEST_DATA_STORAGE_BLOB_NAME,
+        prefix=TEST_DATA_STORAGE_BLOB_PREFIX,
         wasb_conn_id=TEST_WASB_CONN_ID,
         poke_interval=POKE_INTERVAL,
     )
 
-    with mock.patch.object(trigger.log, "info"):
-        task = asyncio.create_task(trigger.run().__anext__())
+    def test_wasb_prefix_sensor_trigger_serialization(self):
+        """
+        Asserts that the WasbPrefixSensorTrigger correctly serializes its arguments and classpath."""
 
-    await asyncio.sleep(POKE_INTERVAL + 0.5)
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == "astronomer.providers.microsoft.azure.triggers.wasb.WasbPrefixSensorTrigger"
+        assert kwargs == {
+            "container_name": TEST_DATA_STORAGE_CONTAINER_NAME,
+            "prefix": TEST_DATA_STORAGE_BLOB_PREFIX,
+            "include": None,
+            "delimiter": "/",
+            "wasb_conn_id": TEST_WASB_CONN_ID,
+            "poke_interval": POKE_INTERVAL,
+            "public_read": False,
+        }
 
-    if not task.done():
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "prefix_exists",
+        [True, False],
+    )
+    @mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_prefix_async")
+    async def test_wasb_prefix_sensor_trigger_running(self, mock_check_for_prefix, prefix_exists):
+        """Test if the task is run in trigger successfully."""
+        mock_check_for_prefix.return_value = prefix_exists
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_prefix_async")
+    async def test_wasb_prefix_sensor_trigger_success(self, mock_check_for_prefix):
+        """Tests the success state for that the WasbPrefixSensorTrigger."""
+        mock_check_for_prefix.return_value = True
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was returned
+        assert task.done() is True
+        asyncio.get_event_loop().stop()
+
         message = (
-            f"Blob {TEST_DATA_STORAGE_BLOB_NAME} not available yet in container {TEST_DATA_STORAGE_CONTAINER_NAME}."
-            f" Sleeping for {POKE_INTERVAL} seconds"
+            f"Prefix {TEST_DATA_STORAGE_BLOB_PREFIX} found in container {TEST_DATA_STORAGE_CONTAINER_NAME}."
         )
-        assert message in caplog.text
-    asyncio.get_event_loop().stop()
+        assert task.result() == TriggerEvent({"status": "success", "message": message})
 
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_prefix_async")
+    async def test_wasb_prefix_sensor_trigger_waiting_for_blob(self, mock_check_for_prefix):
+        """Tests the WasbPrefixSensorTrigger sleeps waiting for the blob to arrive."""
+        mock_check_for_prefix.side_effect = [False, True]
 
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_blob_async")
-async def test_wasb_blob_sensor_trigger_trigger_exception(mock_check_for_blob):
-    """Tests the WasbBlobSensorTrigger yields an error event if there is an exception."""
-    mock_check_for_blob.side_effect = Exception("Test exception")
+        with mock.patch.object(self.TRIGGER.log, "info") as mock_log_info:
+            task = asyncio.create_task(self.TRIGGER.run().__anext__())
 
-    trigger = WasbBlobSensorTrigger(
-        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-        blob_name=TEST_DATA_STORAGE_BLOB_NAME,
-        wasb_conn_id=TEST_WASB_CONN_ID,
-        poke_interval=POKE_INTERVAL,
-    )
+        await asyncio.sleep(POKE_INTERVAL + 0.5)
 
-    task = [i async for i in trigger.run()]
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+        if not task.done():
+            message = (
+                f"Prefix {TEST_DATA_STORAGE_BLOB_PREFIX} not available yet in container "
+                f"{TEST_DATA_STORAGE_CONTAINER_NAME}. Sleeping for {POKE_INTERVAL} seconds"
+            )
+            mock_log_info.assert_called_once_with(message)
+        asyncio.get_event_loop().stop()
 
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_prefix_async")
+    async def test_wasb_prefix_sensor_trigger_trigger_exception(self, mock_check_for_prefix):
+        """Tests the WasbPrefixSensorTrigger yields an error event if there is an exception."""
+        mock_check_for_prefix.side_effect = Exception("Test exception")
 
-def test_wasb_prefix_sensor_trigger_serialization():
-    """
-    Asserts that the WasbPrefixSensorTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = WasbPrefixSensorTrigger(
-        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-        prefix=TEST_DATA_STORAGE_BLOB_PREFIX,
-        wasb_conn_id=TEST_WASB_CONN_ID,
-        poke_interval=POKE_INTERVAL,
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.microsoft.azure.triggers.wasb.WasbPrefixSensorTrigger"
-    assert kwargs == {
-        "container_name": TEST_DATA_STORAGE_CONTAINER_NAME,
-        "prefix": TEST_DATA_STORAGE_BLOB_PREFIX,
-        "include": None,
-        "delimiter": "/",
-        "wasb_conn_id": TEST_WASB_CONN_ID,
-        "poke_interval": POKE_INTERVAL,
-        "public_read": False,
-    }
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "prefix_exists",
-    [
-        True,
-        False,
-    ],
-)
-@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_prefix_async")
-async def test_wasb_prefix_sensor_trigger_running(mock_check_for_prefix, prefix_exists):
-    """
-    Test if the task is run in trigger successfully.
-    """
-    mock_check_for_prefix.return_value = prefix_exists
-    trigger = WasbPrefixSensorTrigger(
-        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-        prefix=TEST_DATA_STORAGE_BLOB_PREFIX,
-        wasb_conn_id=TEST_WASB_CONN_ID,
-        poke_interval=POKE_INTERVAL,
-    )
-    task = asyncio.create_task(trigger.run().__anext__())
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_prefix_async")
-async def test_wasb_prefix_sensor_trigger_success(mock_check_for_prefix):
-    """Tests the success state for that the WasbPrefixSensorTrigger."""
-    mock_check_for_prefix.return_value = True
-    trigger = WasbPrefixSensorTrigger(
-        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-        prefix=TEST_DATA_STORAGE_BLOB_PREFIX,
-        wasb_conn_id=TEST_WASB_CONN_ID,
-        poke_interval=POKE_INTERVAL,
-    )
-
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was returned
-    assert task.done() is True
-    asyncio.get_event_loop().stop()
-
-    message = f"Prefix {TEST_DATA_STORAGE_BLOB_PREFIX} found in container {TEST_DATA_STORAGE_CONTAINER_NAME}."
-    assert task.result() == TriggerEvent({"status": "success", "message": message})
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_prefix_async")
-async def test_wasb_prefix_sensor_trigger_waiting_for_blob(mock_check_for_prefix):
-    """Tests the WasbPrefixSensorTrigger sleeps waiting for the blob to arrive."""
-    mock_check_for_prefix.side_effect = [False, True]
-
-    trigger = WasbPrefixSensorTrigger(
-        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-        prefix=TEST_DATA_STORAGE_BLOB_PREFIX,
-        wasb_conn_id=TEST_WASB_CONN_ID,
-        poke_interval=POKE_INTERVAL,
-    )
-
-    with mock.patch.object(trigger.log, "info") as mock_log_info:
-        task = asyncio.create_task(trigger.run().__anext__())
-
-    await asyncio.sleep(POKE_INTERVAL + 0.5)
-
-    if not task.done():
-        message = (
-            f"Prefix {TEST_DATA_STORAGE_BLOB_PREFIX} not available yet in container "
-            f"{TEST_DATA_STORAGE_CONTAINER_NAME}. Sleeping for {POKE_INTERVAL} seconds"
-        )
-        mock_log_info.assert_called_once_with(message)
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.microsoft.azure.hooks.wasb.WasbHookAsync.check_for_prefix_async")
-async def test_wasb_prefix_sensor_trigger_trigger_exception(mock_check_for_prefix):
-    """Tests the WasbPrefixSensorTrigger yields an error event if there is an exception."""
-    mock_check_for_prefix.side_effect = Exception("Test exception")
-
-    trigger = WasbPrefixSensorTrigger(
-        container_name=TEST_DATA_STORAGE_CONTAINER_NAME,
-        prefix=TEST_DATA_STORAGE_BLOB_PREFIX,
-        wasb_conn_id=TEST_WASB_CONN_ID,
-        poke_interval=POKE_INTERVAL,
-    )
-
-    task = [i async for i in trigger.run()]
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+        task = [i async for i in self.TRIGGER.run()]
+        assert len(task) == 1
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) in task


### PR DESCRIPTION
google class-based tests

closes: https://github.com/astronomer/astronomer-providers/issues/696
related-to: https://github.com/astronomer/astronomer-providers/issues/568

convert the function-based test to a class-based
remove context fixture definition from operator/sensor/extractor and reuse from conftest
remove function create_context from a couple of test files and reuse it from the util
remove duplicate code for initializing op/senor/trigger/hook at possible places