### PR TITLE
google class based tests

### DIFF
--- a/tests/google/cloud/extractors/test_bigquery.py
+++ b/tests/google/cloud/extractors/test_bigquery.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 
 import pytest
 from airflow.exceptions import TaskDeferred
-from airflow.models import DAG
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils.timezone import datetime
@@ -21,6 +20,7 @@ from astronomer.providers.google.cloud.extractors.bigquery import BigQueryAsyncE
 from astronomer.providers.google.cloud.operators.bigquery import (
     BigQueryInsertJobOperatorAsync,
 )
+from tests.utils.airflow_util import create_context
 
 TEST_DATASET_LOCATION = "EU"
 TEST_GCP_PROJECT_ID = "test-project"
@@ -62,133 +62,107 @@ RUN_FACETS = {
 }
 
 
-@pytest.fixture
-def context():
-    """
-    Creates an empty context.
-    """
-    context = {}
-    yield context
-
-
-def create_context(task):
-    dag = DAG(dag_id="dag")
-    logical_date = datetime(2022, 1, 1, 0, 0, 0)
-    dag_run = DagRun(
-        dag_id=dag.dag_id,
-        execution_date=logical_date,
-        run_id=DagRun.generate_run_id(DagRunType.MANUAL, logical_date),
-    )
-    task_instance = TaskInstance(task=task)
-    task_instance.dag_run = dag_run
-    task_instance.dag_id = dag.dag_id
-    task_instance.xcom_push = mock.Mock()
-    return {
-        "dag": dag,
-        "run_id": dag_run.run_id,
-        "task": task,
-        "ti": task_instance,
-        "task_instance": task_instance,
-        "logical_date": logical_date,
-    }
-
-
-@mock.patch("astronomer.providers.google.cloud.extractors.bigquery.BigQueryHook")
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
-@mock.patch("airflow.models.TaskInstance.xcom_pull")
-@mock.patch("openlineage.common.provider.bigquery.BigQueryDatasetsProvider.get_facets")
-def test_extract_on_complete(mock_bg_dataset_provider, mock_xcom_pull, mock_hook, mock_extractor_hook):
-    """
-    Tests that  the custom extractor's implementation for the BigQueryInsertJobOperatorAsync is able to process the
-    operator's metadata that needs to be extracted as per OpenLineage.
-    """
-    configuration = {
-        "query": {
-            "query": INSERT_ROWS_QUERY,
-            "useLegacySql": False,
+class TestBigQueryAsyncExtractor:
+    @mock.patch("astronomer.providers.google.cloud.extractors.bigquery.BigQueryHook")
+    @mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
+    @mock.patch("airflow.models.TaskInstance.xcom_pull")
+    @mock.patch("openlineage.common.provider.bigquery.BigQueryDatasetsProvider.get_facets")
+    def test_extract_on_complete(
+        self, mock_bg_dataset_provider, mock_xcom_pull, mock_hook, mock_extractor_hook
+    ):
+        """
+        Tests that  the custom extractor's implementation for the BigQueryInsertJobOperatorAsync is able to process the
+        operator's metadata that needs to be extracted as per OpenLineage.
+        """
+        configuration = {
+            "query": {
+                "query": INSERT_ROWS_QUERY,
+                "useLegacySql": False,
+            }
         }
-    }
-    job_id = "123456"
-    mock_hook.return_value.insert_job.return_value = MagicMock(job_id=job_id, error_result=False)
-    mock_extractor_hook.return_value.insert_job.return_value = MagicMock(job_id=job_id, error_result=False)
-    mock_bg_dataset_provider.return_value = BigQueryFacets(
-        run_facets=RUN_FACETS, inputs=INPUT_STATS, output=OUTPUT_STATS
-    )
+        job_id = "123456"
+        mock_hook.return_value.insert_job.return_value = MagicMock(job_id=job_id, error_result=False)
+        mock_extractor_hook.return_value.insert_job.return_value = MagicMock(
+            job_id=job_id, error_result=False
+        )
+        mock_bg_dataset_provider.return_value = BigQueryFacets(
+            run_facets=RUN_FACETS, inputs=INPUT_STATS, output=OUTPUT_STATS
+        )
 
-    task_id = "insert_query_job"
-    operator = BigQueryInsertJobOperatorAsync(
-        task_id=task_id,
-        configuration=configuration,
-        location=TEST_DATASET_LOCATION,
-        job_id=job_id,
-        project_id=TEST_GCP_PROJECT_ID,
-    )
+        task_id = "insert_query_job"
+        operator = BigQueryInsertJobOperatorAsync(
+            task_id=task_id,
+            configuration=configuration,
+            location=TEST_DATASET_LOCATION,
+            job_id=job_id,
+            project_id=TEST_GCP_PROJECT_ID,
+        )
 
-    task_instance = TaskInstance(task=operator)
-    with pytest.raises(TaskDeferred):
-        operator.execute(create_context(operator))
+        task_instance = TaskInstance(task=operator)
+        with pytest.raises(TaskDeferred):
+            operator.execute(create_context(operator))
 
-    bq_extractor = BigQueryAsyncExtractor(operator)
-    task_meta_extract = bq_extractor.extract()
-    assert task_meta_extract is None
+        bq_extractor = BigQueryAsyncExtractor(operator)
+        task_meta_extract = bq_extractor.extract()
+        assert task_meta_extract is None
 
-    task_meta = bq_extractor.extract_on_complete(task_instance)
-
-    mock_xcom_pull.assert_called_once_with(task_ids=task_instance.task_id, key="job_id")
-
-    assert task_meta.name == f"adhoc_airflow.{task_id}"
-
-    assert task_meta.inputs[0].facets["dataSource"].name == INPUT_STATS[0].source.scheme
-    assert task_meta.inputs[0].name == INPUT_STATS[0].name
-
-    assert task_meta.outputs[0].name == OUTPUT_STATS.name
-    assert task_meta.outputs[0].facets["stats"].rowCount == 2
-    assert task_meta.outputs[0].facets["stats"].size == 0
-
-    assert task_meta.run_facets["bigQuery_job"].billedBytes == 0
-    run_facet_properties = json.loads(task_meta.run_facets["bigQuery_job"].properties)
-    assert run_facet_properties == JOB_PROPERTIES
-
-
-def test_extractor_works_on_operator():
-    """Tests that the custom extractor implementation is available for the BigQueryInsertJobOperatorAsync Operator."""
-    task_id = "insert_query_job"
-    operator = BigQueryInsertJobOperatorAsync(task_id=task_id, configuration={})
-    assert type(operator).__name__ in BigQueryAsyncExtractor.get_operator_classnames()
-
-
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
-def test_unavailable_xcom_raises_exception(mock_hook):
-    """
-    Tests that an exception is raised when the custom extractor is not available to retrieve required XCOM for the
-    BigQueryInsertJobOperatorAsync Operator.
-    """
-    configuration = {
-        "query": {
-            "query": INSERT_ROWS_QUERY,
-            "useLegacySql": False,
-        }
-    }
-    job_id = "123456"
-    mock_hook.return_value.insert_job.return_value = MagicMock(job_id=job_id, error_result=False)
-    task_id = "insert_query_job"
-    operator = BigQueryInsertJobOperatorAsync(
-        task_id=task_id,
-        configuration=configuration,
-        location=TEST_DATASET_LOCATION,
-        job_id=job_id,
-        project_id=TEST_GCP_PROJECT_ID,
-    )
-
-    task_instance = TaskInstance(task=operator)
-    execution_date = datetime(2022, 1, 1, 0, 0, 0)
-    task_instance.run_id = DagRun.generate_run_id(DagRunType.MANUAL, execution_date)
-
-    with pytest.raises(TaskDeferred):
-        operator.execute(create_context(operator))
-    bq_extractor = BigQueryAsyncExtractor(operator)
-    with mock.patch.object(bq_extractor.log, "exception") as mock_log_exception:
         task_meta = bq_extractor.extract_on_complete(task_instance)
 
-    mock_log_exception.assert_called_with("%s", "Could not pull relevant BigQuery job ID from XCOM")
-    assert task_meta.name == f"adhoc_airflow.{task_id}"
+        mock_xcom_pull.assert_called_once_with(task_ids=task_instance.task_id, key="job_id")
+
+        assert task_meta.name == f"adhoc_airflow.{task_id}"
+
+        assert task_meta.inputs[0].facets["dataSource"].name == INPUT_STATS[0].source.scheme
+        assert task_meta.inputs[0].name == INPUT_STATS[0].name
+
+        assert task_meta.outputs[0].name == OUTPUT_STATS.name
+        assert task_meta.outputs[0].facets["stats"].rowCount == 2
+        assert task_meta.outputs[0].facets["stats"].size == 0
+
+        assert task_meta.run_facets["bigQuery_job"].billedBytes == 0
+        run_facet_properties = json.loads(task_meta.run_facets["bigQuery_job"].properties)
+        assert run_facet_properties == JOB_PROPERTIES
+
+    def test_extractor_works_on_operator(self):
+        """
+        Tests that the custom extractor implementation is available for the BigQueryInsertJobOperatorAsync Operator.
+        """
+        task_id = "insert_query_job"
+        operator = BigQueryInsertJobOperatorAsync(task_id=task_id, configuration={})
+        assert type(operator).__name__ in BigQueryAsyncExtractor.get_operator_classnames()
+
+    @mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
+    def test_unavailable_xcom_raises_exception(self, mock_hook):
+        """
+        Tests that an exception is raised when the custom extractor is not available to retrieve required XCOM for the
+        BigQueryInsertJobOperatorAsync Operator.
+        """
+        configuration = {
+            "query": {
+                "query": INSERT_ROWS_QUERY,
+                "useLegacySql": False,
+            }
+        }
+        job_id = "123456"
+        mock_hook.return_value.insert_job.return_value = MagicMock(job_id=job_id, error_result=False)
+        task_id = "insert_query_job"
+        operator = BigQueryInsertJobOperatorAsync(
+            task_id=task_id,
+            configuration=configuration,
+            location=TEST_DATASET_LOCATION,
+            job_id=job_id,
+            project_id=TEST_GCP_PROJECT_ID,
+        )
+
+        task_instance = TaskInstance(task=operator)
+        execution_date = datetime(2022, 1, 1, 0, 0, 0)
+        task_instance.run_id = DagRun.generate_run_id(DagRunType.MANUAL, execution_date)
+
+        with pytest.raises(TaskDeferred):
+            operator.execute(create_context(operator))
+        bq_extractor = BigQueryAsyncExtractor(operator)
+        with mock.patch.object(bq_extractor.log, "exception") as mock_log_exception:
+            task_meta = bq_extractor.extract_on_complete(task_instance)
+
+        mock_log_exception.assert_called_with("%s", "Could not pull relevant BigQuery job ID from XCOM")
+        assert task_meta.name == f"adhoc_airflow.{task_id}"

--- a/tests/google/cloud/hooks/test_dataproc.py
+++ b/tests/google/cloud/hooks/test_dataproc.py
@@ -11,55 +11,53 @@ from google.cloud.dataproc_v1 import (
 from astronomer.providers.google.cloud.hooks.dataproc import DataprocHookAsync
 
 
-@mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_credentials")
-def test_get_cluster_client(mock_get_credentials):
-    """assert that get_cluster_client return ClusterControllerAsyncClient"""
-    mock_get_credentials.return_value = ga_credentials.AnonymousCredentials()
-    hook = DataprocHookAsync()
-    assert isinstance(hook.get_cluster_client(location="us-west"), ClusterControllerAsyncClient)
+class TestDataprocHookAsync:
+    @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_credentials")
+    def test_get_cluster_client(self, mock_get_credentials):
+        """assert that get_cluster_client return ClusterControllerAsyncClient"""
+        mock_get_credentials.return_value = ga_credentials.AnonymousCredentials()
+        hook = DataprocHookAsync()
+        assert isinstance(hook.get_cluster_client(location="us-west"), ClusterControllerAsyncClient)
 
+    @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_credentials")
+    def test_get_job_client(self, mock_get_credentials):
+        """assert that get_job_client return JobControllerAsyncClient"""
+        mock_get_credentials.return_value = ga_credentials.AnonymousCredentials()
+        hook = DataprocHookAsync()
+        assert isinstance(hook.get_job_client(location="us-west"), JobControllerAsyncClient)
 
-@mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_credentials")
-def test_get_job_client(mock_get_credentials):
-    """assert that get_job_client return JobControllerAsyncClient"""
-    mock_get_credentials.return_value = ga_credentials.AnonymousCredentials()
-    hook = DataprocHookAsync()
-    assert isinstance(hook.get_job_client(location="us-west"), JobControllerAsyncClient)
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_credentials")
+    @mock.patch("google.cloud.dataproc_v1.ClusterControllerAsyncClient.get_cluster")
+    async def test_get_cluster(self, mock_get_cluster, mock_get_cluster_client):
+        """assert that get_cluster called with correct param"""
+        mock_get_cluster_client.return_value = ga_credentials.AnonymousCredentials()
+        hook = DataprocHookAsync()
+        await hook.get_cluster(region="us-west", cluster_name="test_cluster", project_id="test_project")
 
+        mock_get_cluster.assert_called_once_with(
+            region="us-west",
+            cluster_name="test_cluster",
+            project_id="test_project",
+            retry=gapic_v1.method.DEFAULT,
+            metadata=(),
+        )
 
-@pytest.mark.asyncio
-@mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_credentials")
-@mock.patch("google.cloud.dataproc_v1.ClusterControllerAsyncClient.get_cluster")
-async def test_get_cluster(mock_get_cluster, mock_get_cluster_client):
-    """assert that get_cluster called with correct param"""
-    mock_get_cluster_client.return_value = ga_credentials.AnonymousCredentials()
-    hook = DataprocHookAsync()
-    await hook.get_cluster(region="us-west", cluster_name="test_cluster", project_id="test_project")
-
-    mock_get_cluster.assert_called_once_with(
-        region="us-west",
-        cluster_name="test_cluster",
-        project_id="test_project",
-        retry=gapic_v1.method.DEFAULT,
-        metadata=(),
-    )
-
-
-@pytest.mark.asyncio
-@mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_credentials")
-@mock.patch("google.cloud.dataproc_v1.JobControllerAsyncClient.get_job")
-async def test_get_job(mock_get_job, mock_get_cred):
-    """Test to get the job from Google cloud dataproc"""
-    mock_get_cred.return_value = ga_credentials.AnonymousCredentials()
-    hook = DataprocHookAsync()
-    await hook.get_job(region="us-west", job_id="test-id", project_id="test-project")
-    mock_get_job.assert_called_once_with(
-        request={
-            "region": "us-west",
-            "job_id": "test-id",
-            "project_id": "test-project",
-        },
-        retry=gapic_v1.method.DEFAULT,
-        timeout=5,
-        metadata=(),
-    )
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_credentials")
+    @mock.patch("google.cloud.dataproc_v1.JobControllerAsyncClient.get_job")
+    async def test_get_job(self, mock_get_job, mock_get_cred):
+        """Test to get the job from Google cloud dataproc"""
+        mock_get_cred.return_value = ga_credentials.AnonymousCredentials()
+        hook = DataprocHookAsync()
+        await hook.get_job(region="us-west", job_id="test-id", project_id="test-project")
+        mock_get_job.assert_called_once_with(
+            request={
+                "region": "us-west",
+                "job_id": "test-id",
+                "project_id": "test-project",
+            },
+            retry=gapic_v1.method.DEFAULT,
+            timeout=5,
+            metadata=(),
+        )

--- a/tests/google/cloud/hooks/test_gcs.py
+++ b/tests/google/cloud/hooks/test_gcs.py
@@ -6,9 +6,10 @@ from gcloud.aio.storage import Storage
 from astronomer.providers.google.cloud.hooks.gcs import GCSHookAsync
 
 
-@pytest.mark.asyncio
-@mock.patch("aiohttp.client.ClientSession")
-async def test_get_job_status(mock_session):
-    hook = GCSHookAsync()
-    result = await hook.get_storage_client(mock_session)
-    assert isinstance(result, Storage)
+class TestGCSHookAsync:
+    @pytest.mark.asyncio
+    @mock.patch("aiohttp.client.ClientSession")
+    async def test_get_job_status(self, mock_session):
+        hook = GCSHookAsync()
+        result = await hook.get_storage_client(mock_session)
+        assert isinstance(result, Storage)

--- a/tests/google/cloud/operators/test_bigquery.py
+++ b/tests/google/cloud/operators/test_bigquery.py
@@ -3,11 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
-from airflow.models import DAG
-from airflow.models.dagrun import DagRun
-from airflow.models.taskinstance import TaskInstance
 from airflow.utils.timezone import datetime
-from airflow.utils.types import DagRunType
 from google.cloud.exceptions import Conflict
 
 from astronomer.providers.google.cloud.operators.bigquery import (
@@ -24,6 +20,7 @@ from astronomer.providers.google.cloud.triggers.bigquery import (
     BigQueryIntervalCheckTrigger,
     BigQueryValueCheckTrigger,
 )
+from tests.utils.airflow_util import create_context
 
 TEST_DATASET_LOCATION = "EU"
 TEST_GCP_PROJECT_ID = "test-project"
@@ -31,543 +28,520 @@ TEST_DATASET = "test-dataset"
 TEST_TABLE = "test-table"
 
 
-@pytest.fixture
-def context():
-    """
-    Creates an empty context.
-    """
-    context = {}
-    yield context
+class TestBigQueryInsertJobOperatorAsync:
+    @mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
+    def test_bigquery_insert_job_operator_async(self, mock_hook):
+        """
+        Asserts that a task is deferred and a BigQueryInsertJobTrigger will be fired
+        when the BigQueryInsertJobOperatorAsync is executed.
+        """
+        job_id = "123456"
+        hash_ = "hash"
+        real_job_id = f"{job_id}_{hash_}"
 
-
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
-def test_bigquery_insert_job_operator_async(mock_hook):
-    """
-    Asserts that a task is deferred and a BigQueryInsertJobTrigger will be fired
-    when the BigQueryInsertJobOperatorAsync is executed.
-    """
-    job_id = "123456"
-    hash_ = "hash"
-    real_job_id = f"{job_id}_{hash_}"
-
-    configuration = {
-        "query": {
-            "query": "SELECT * FROM any",
-            "useLegacySql": False,
+        configuration = {
+            "query": {
+                "query": "SELECT * FROM any",
+                "useLegacySql": False,
+            }
         }
-    }
-    mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
+        mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
 
-    op = BigQueryInsertJobOperatorAsync(
-        task_id="insert_query_job",
-        configuration=configuration,
-        location=TEST_DATASET_LOCATION,
-        job_id=job_id,
-        project_id=TEST_GCP_PROJECT_ID,
-    )
-
-    with pytest.raises(TaskDeferred) as exc:
-        op.execute(create_context(op))
-
-    assert isinstance(
-        exc.value.trigger, BigQueryInsertJobTrigger
-    ), "Trigger is not a BigQueryInsertJobTrigger"
-
-
-def test_bigquery_insert_job_operator_execute_failure(context):
-    """Tests that an AirflowException is raised in case of error event"""
-    configuration = {
-        "query": {
-            "query": "SELECT * FROM any",
-            "useLegacySql": False,
-        }
-    }
-    job_id = "123456"
-
-    operator = BigQueryInsertJobOperatorAsync(
-        task_id="insert_query_job",
-        configuration=configuration,
-        location=TEST_DATASET_LOCATION,
-        job_id=job_id,
-        project_id=TEST_GCP_PROJECT_ID,
-    )
-
-    with pytest.raises(AirflowException):
-        operator.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
-
-
-def create_context(task):
-    dag = DAG(dag_id="dag")
-    logical_date = datetime(2022, 1, 1, 0, 0, 0)
-    dag_run = DagRun(
-        dag_id=dag.dag_id,
-        execution_date=logical_date,
-        run_id=DagRun.generate_run_id(DagRunType.MANUAL, logical_date),
-    )
-    task_instance = TaskInstance(task=task)
-    task_instance.dag_run = dag_run
-    task_instance.dag_id = dag.dag_id
-    task_instance.xcom_push = mock.Mock()
-    return {
-        "dag": dag,
-        "run_id": dag_run.run_id,
-        "task": task,
-        "ti": task_instance,
-        "task_instance": task_instance,
-        "logical_date": logical_date,
-    }
-
-
-def test_bigquery_insert_job_operator_execute_complete():
-    """Asserts that logging occurs as expected"""
-    configuration = {
-        "query": {
-            "query": "SELECT * FROM any",
-            "useLegacySql": False,
-        }
-    }
-    job_id = "123456"
-
-    operator = BigQueryInsertJobOperatorAsync(
-        task_id="insert_query_job",
-        configuration=configuration,
-        location=TEST_DATASET_LOCATION,
-        job_id=job_id,
-        project_id=TEST_GCP_PROJECT_ID,
-    )
-    with mock.patch.object(operator.log, "info") as mock_log_info:
-        operator.execute_complete(
-            context=create_context(operator),
-            event={"status": "success", "message": "Job completed", "job_id": job_id},
+        op = BigQueryInsertJobOperatorAsync(
+            task_id="insert_query_job",
+            configuration=configuration,
+            location=TEST_DATASET_LOCATION,
+            job_id=job_id,
+            project_id=TEST_GCP_PROJECT_ID,
         )
-    mock_log_info.assert_called_with("%s completed with response %s ", "insert_query_job", "Job completed")
 
+        with pytest.raises(TaskDeferred) as exc:
+            op.execute(create_context(op))
 
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
-def test_bigquery_insert_job_operator_with_job_id_generate(mock_hook):
-    job_id = "123456"
-    hash_ = "hash"
-    real_job_id = f"{job_id}_{hash_}"
+        assert isinstance(
+            exc.value.trigger, BigQueryInsertJobTrigger
+        ), "Trigger is not a BigQueryInsertJobTrigger"
 
-    configuration = {
-        "query": {
-            "query": "SELECT * FROM any",
-            "useLegacySql": False,
+    def test_bigquery_insert_job_operator_execute_failure(self, context):
+        """Tests that an AirflowException is raised in case of error event"""
+        configuration = {
+            "query": {
+                "query": "SELECT * FROM any",
+                "useLegacySql": False,
+            }
         }
-    }
+        job_id = "123456"
 
-    mock_hook.return_value.insert_job.side_effect = Conflict("any")
-    job = MagicMock(
-        job_id=real_job_id,
-        error_result=False,
-        state="PENDING",
-        done=lambda: False,
-    )
-    mock_hook.return_value.get_job.return_value = job
+        operator = BigQueryInsertJobOperatorAsync(
+            task_id="insert_query_job",
+            configuration=configuration,
+            location=TEST_DATASET_LOCATION,
+            job_id=job_id,
+            project_id=TEST_GCP_PROJECT_ID,
+        )
 
-    op = BigQueryInsertJobOperatorAsync(
-        task_id="insert_query_job",
-        configuration=configuration,
-        location=TEST_DATASET_LOCATION,
-        job_id=job_id,
-        project_id=TEST_GCP_PROJECT_ID,
-        reattach_states={"PENDING"},
-    )
+        with pytest.raises(AirflowException):
+            operator.execute_complete(
+                context=None, event={"status": "error", "message": "test failure message"}
+            )
 
-    with pytest.raises(TaskDeferred):
-        op.execute(create_context(op))
-
-    mock_hook.return_value.generate_job_id.assert_called_once_with(
-        job_id=job_id,
-        dag_id="adhoc_airflow",
-        task_id="insert_query_job",
-        logical_date=datetime(2022, 1, 1, 0, 0),
-        configuration=configuration,
-        force_rerun=True,
-    )
-
-
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
-def test_execute_reattach(mock_hook):
-    job_id = "123456"
-    hash_ = "hash"
-    real_job_id = f"{job_id}_{hash_}"
-    mock_hook.return_value.generate_job_id.return_value = f"{job_id}_{hash_}"
-
-    configuration = {
-        "query": {
-            "query": "SELECT * FROM any",
-            "useLegacySql": False,
+    def test_bigquery_insert_job_operator_execute_complete(self):
+        """Asserts that logging occurs as expected"""
+        configuration = {
+            "query": {
+                "query": "SELECT * FROM any",
+                "useLegacySql": False,
+            }
         }
-    }
+        job_id = "123456"
 
-    mock_hook.return_value.insert_job.side_effect = Conflict("any")
-    job = MagicMock(
-        job_id=real_job_id,
-        error_result=False,
-        state="PENDING",
-        done=lambda: False,
-    )
-    mock_hook.return_value.get_job.return_value = job
+        operator = BigQueryInsertJobOperatorAsync(
+            task_id="insert_query_job",
+            configuration=configuration,
+            location=TEST_DATASET_LOCATION,
+            job_id=job_id,
+            project_id=TEST_GCP_PROJECT_ID,
+        )
+        with mock.patch.object(operator.log, "info") as mock_log_info:
+            operator.execute_complete(
+                context=create_context(operator),
+                event={"status": "success", "message": "Job completed", "job_id": job_id},
+            )
+        mock_log_info.assert_called_with(
+            "%s completed with response %s ", "insert_query_job", "Job completed"
+        )
 
-    op = BigQueryInsertJobOperatorAsync(
-        task_id="insert_query_job",
-        configuration=configuration,
-        location=TEST_DATASET_LOCATION,
-        job_id=job_id,
-        project_id=TEST_GCP_PROJECT_ID,
-        reattach_states={"PENDING"},
-    )
+    @mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
+    def test_bigquery_insert_job_operator_with_job_id_generate(self, mock_hook):
+        job_id = "123456"
+        hash_ = "hash"
+        real_job_id = f"{job_id}_{hash_}"
 
-    with pytest.raises(TaskDeferred):
-        op.execute(create_context(op))
-
-    mock_hook.return_value.get_job.assert_called_once_with(
-        location=TEST_DATASET_LOCATION,
-        job_id=real_job_id,
-        project_id=TEST_GCP_PROJECT_ID,
-    )
-
-    job._begin.assert_called_once_with()
-
-
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
-def test_execute_force_rerun(mock_hook):
-    job_id = "123456"
-    hash_ = "hash"
-    real_job_id = f"{job_id}_{hash_}"
-    mock_hook.return_value.generate_job_id.return_value = f"{job_id}_{hash_}"
-
-    configuration = {
-        "query": {
-            "query": "SELECT * FROM any",
-            "useLegacySql": False,
+        configuration = {
+            "query": {
+                "query": "SELECT * FROM any",
+                "useLegacySql": False,
+            }
         }
-    }
 
-    mock_hook.return_value.insert_job.side_effect = Conflict("any")
-    job = MagicMock(
-        job_id=real_job_id,
-        error_result=False,
-        state="DONE",
-        done=lambda: False,
+        mock_hook.return_value.insert_job.side_effect = Conflict("any")
+        job = MagicMock(
+            job_id=real_job_id,
+            error_result=False,
+            state="PENDING",
+            done=lambda: False,
+        )
+        mock_hook.return_value.get_job.return_value = job
+
+        op = BigQueryInsertJobOperatorAsync(
+            task_id="insert_query_job",
+            configuration=configuration,
+            location=TEST_DATASET_LOCATION,
+            job_id=job_id,
+            project_id=TEST_GCP_PROJECT_ID,
+            reattach_states={"PENDING"},
+        )
+
+        with pytest.raises(TaskDeferred):
+            op.execute(create_context(op))
+
+        mock_hook.return_value.generate_job_id.assert_called_once_with(
+            job_id=job_id,
+            dag_id="adhoc_airflow",
+            task_id="insert_query_job",
+            logical_date=datetime(2022, 1, 1, 1, 0),
+            configuration=configuration,
+            force_rerun=True,
+        )
+
+    @mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
+    def test_execute_reattach(self, mock_hook):
+        job_id = "123456"
+        hash_ = "hash"
+        real_job_id = f"{job_id}_{hash_}"
+        mock_hook.return_value.generate_job_id.return_value = f"{job_id}_{hash_}"
+
+        configuration = {
+            "query": {
+                "query": "SELECT * FROM any",
+                "useLegacySql": False,
+            }
+        }
+
+        mock_hook.return_value.insert_job.side_effect = Conflict("any")
+        job = MagicMock(
+            job_id=real_job_id,
+            error_result=False,
+            state="PENDING",
+            done=lambda: False,
+        )
+        mock_hook.return_value.get_job.return_value = job
+
+        op = BigQueryInsertJobOperatorAsync(
+            task_id="insert_query_job",
+            configuration=configuration,
+            location=TEST_DATASET_LOCATION,
+            job_id=job_id,
+            project_id=TEST_GCP_PROJECT_ID,
+            reattach_states={"PENDING"},
+        )
+
+        with pytest.raises(TaskDeferred):
+            op.execute(create_context(op))
+
+        mock_hook.return_value.get_job.assert_called_once_with(
+            location=TEST_DATASET_LOCATION,
+            job_id=real_job_id,
+            project_id=TEST_GCP_PROJECT_ID,
+        )
+
+        job._begin.assert_called_once_with()
+
+    @mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
+    def test_execute_force_rerun(self, mock_hook):
+        job_id = "123456"
+        hash_ = "hash"
+        real_job_id = f"{job_id}_{hash_}"
+        mock_hook.return_value.generate_job_id.return_value = f"{job_id}_{hash_}"
+
+        configuration = {
+            "query": {
+                "query": "SELECT * FROM any",
+                "useLegacySql": False,
+            }
+        }
+
+        mock_hook.return_value.insert_job.side_effect = Conflict("any")
+        job = MagicMock(
+            job_id=real_job_id,
+            error_result=False,
+            state="DONE",
+            done=lambda: False,
+        )
+        mock_hook.return_value.get_job.return_value = job
+
+        op = BigQueryInsertJobOperatorAsync(
+            task_id="insert_query_job",
+            configuration=configuration,
+            location=TEST_DATASET_LOCATION,
+            job_id=job_id,
+            project_id=TEST_GCP_PROJECT_ID,
+            reattach_states={"PENDING"},
+        )
+
+        with pytest.raises(AirflowException) as exc:
+            op.execute(create_context(op))
+
+        expected_exception_msg = (
+            f"Job with id: {real_job_id} already exists and is in {job.state} state. "
+            f"If you want to force rerun it consider setting `force_rerun=True`."
+            f"Or, if you want to reattach in this scenario add {job.state} to `reattach_states`"
+        )
+
+        assert str(exc.value) == expected_exception_msg
+
+        mock_hook.return_value.get_job.assert_called_once_with(
+            location=TEST_DATASET_LOCATION,
+            job_id=real_job_id,
+            project_id=TEST_GCP_PROJECT_ID,
+        )
+
+
+class TestBigQueryCheckOperatorAsync:
+    @mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
+    def test_bigquery_check_operator_async(self, mock_hook):
+        """
+        Asserts that a task is deferred and a BigQueryCheckTrigger will be fired
+        when the BigQueryCheckOperatorAsync is executed.
+        """
+        job_id = "123456"
+        hash_ = "hash"
+        real_job_id = f"{job_id}_{hash_}"
+
+        mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
+
+        op = BigQueryCheckOperatorAsync(
+            task_id="bq_check_operator_job",
+            sql="SELECT * FROM any",
+            location=TEST_DATASET_LOCATION,
+        )
+
+        with pytest.raises(TaskDeferred) as exc:
+            op.execute(create_context(op))
+
+        assert isinstance(exc.value.trigger, BigQueryCheckTrigger), "Trigger is not a BigQueryCheckTrigger"
+
+    def test_bigquery_check_operator_execute_failure(self, context):
+        """Tests that an AirflowException is raised in case of error event"""
+
+        operator = BigQueryCheckOperatorAsync(
+            task_id="bq_check_operator_execute_failure",
+            sql="SELECT * FROM any",
+            location=TEST_DATASET_LOCATION,
+        )
+
+        with pytest.raises(AirflowException):
+            operator.execute_complete(
+                context=None, event={"status": "error", "message": "test failure message"}
+            )
+
+    def test_bigquery_check_op_execute_complete_with_no_records(self):
+        """Asserts that exception is raised with correct expected exception message"""
+
+        operator = BigQueryCheckOperatorAsync(
+            task_id="bq_check_operator_execute_complete",
+            sql="SELECT * FROM any",
+            location=TEST_DATASET_LOCATION,
+        )
+
+        with pytest.raises(AirflowException) as exc:
+            operator.execute_complete(context=None, event={"status": "success", "records": None})
+
+        expected_exception_msg = "The query returned None"
+
+        assert str(exc.value) == expected_exception_msg
+
+    def test_bigquery_check_op_execute_complete_with_non_boolean_records(self):
+        """Executing a sql which returns a non-boolean value should raise exception"""
+
+        test_sql = "SELECT * FROM any"
+
+        operator = BigQueryCheckOperatorAsync(
+            task_id="bq_check_operator_execute_complete", sql=test_sql, location=TEST_DATASET_LOCATION
+        )
+
+        expected_exception_msg = f"Test failed.\nQuery:\n{test_sql}\nResults:\n{[20, False]!s}"
+
+        with pytest.raises(AirflowException) as exc:
+            operator.execute_complete(context=None, event={"status": "success", "records": [20, False]})
+
+        assert str(exc.value) == expected_exception_msg
+
+    def test_bigquery_check_operator_execute_complete(self):
+        """Asserts that logging occurs as expected"""
+
+        operator = BigQueryCheckOperatorAsync(
+            task_id="bq_check_operator_execute_complete",
+            sql="SELECT * FROM any",
+            location=TEST_DATASET_LOCATION,
+        )
+
+        with mock.patch.object(operator.log, "info") as mock_log_info:
+            operator.execute_complete(context=None, event={"status": "success", "records": [20]})
+        mock_log_info.assert_called_with("Success.")
+
+
+class TestBigQueryIntervalCheckOperatorAsync:
+    def test_bigquery_interval_check_operator_execute_complete(self):
+        """Asserts that logging occurs as expected"""
+
+        operator = BigQueryIntervalCheckOperatorAsync(
+            task_id="bq_interval_check_operator_execute_complete",
+            table="test_table",
+            metrics_thresholds={"COUNT(*)": 1.5},
+            location=TEST_DATASET_LOCATION,
+        )
+
+        with mock.patch.object(operator.log, "info") as mock_log_info:
+            operator.execute_complete(context=None, event={"status": "success", "message": "Job completed"})
+        mock_log_info.assert_called_with(
+            "%s completed with response %s ", "bq_interval_check_operator_execute_complete", "success"
+        )
+
+    def test_bigquery_interval_check_operator_execute_failure(self, context):
+        """Tests that an AirflowException is raised in case of error event"""
+
+        operator = BigQueryIntervalCheckOperatorAsync(
+            task_id="bq_interval_check_operator_execute_complete",
+            table="test_table",
+            metrics_thresholds={"COUNT(*)": 1.5},
+            location=TEST_DATASET_LOCATION,
+        )
+
+        with pytest.raises(AirflowException):
+            operator.execute_complete(
+                context=None, event={"status": "error", "message": "test failure message"}
+            )
+
+    @mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
+    def test_bigquery_interval_check_operator_async(self, mock_hook):
+        """
+        Asserts that a task is deferred and a BigQueryIntervalCheckTrigger will be fired
+        when the BigQueryIntervalCheckOperatorAsync is executed.
+        """
+        job_id = "123456"
+        hash_ = "hash"
+        real_job_id = f"{job_id}_{hash_}"
+
+        mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
+
+        op = BigQueryIntervalCheckOperatorAsync(
+            task_id="bq_interval_check_operator_execute_complete",
+            table="test_table",
+            metrics_thresholds={"COUNT(*)": 1.5},
+            location=TEST_DATASET_LOCATION,
+        )
+
+        with pytest.raises(TaskDeferred) as exc:
+            op.execute(create_context(op))
+
+        assert isinstance(
+            exc.value.trigger, BigQueryIntervalCheckTrigger
+        ), "Trigger is not a BigQueryIntervalCheckTrigger"
+
+
+class TestBigQueryGetDataOperatorAsync:
+    @mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
+    def test_bigquery_get_data_operator_async_with_selected_fields(self, mock_hook):
+        """
+        Asserts that a task is deferred and a BigQuerygetDataTrigger will be fired
+        when the BigQuerygetDataOperatorAsync is executed.
+        """
+        job_id = "123456"
+        hash_ = "hash"
+        real_job_id = f"{job_id}_{hash_}"
+
+        mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
+
+        op = BigQueryGetDataOperatorAsync(
+            task_id="get_data_from_bq",
+            dataset_id=TEST_DATASET,
+            table_id=TEST_TABLE,
+            max_results=100,
+            selected_fields="value,name",
+        )
+
+        with pytest.raises(TaskDeferred) as exc:
+            op.execute(create_context(op))
+
+        assert isinstance(
+            exc.value.trigger, BigQueryGetDataTrigger
+        ), "Trigger is not a BigQueryGetDataTrigger"
+
+    @mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
+    def test_bigquery_get_data_operator_async_without_selected_fields(self, mock_hook):
+        """
+        Asserts that a task is deferred and a BigQuerygetDataTrigger will be fired
+        when the BigQuerygetDataOperatorAsync is executed.
+        """
+        job_id = "123456"
+        hash_ = "hash"
+        real_job_id = f"{job_id}_{hash_}"
+
+        mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
+
+        op = BigQueryGetDataOperatorAsync(
+            task_id="get_data_from_bq",
+            dataset_id=TEST_DATASET,
+            table_id=TEST_TABLE,
+            max_results=100,
+        )
+
+        with pytest.raises(TaskDeferred) as exc:
+            op.execute(create_context(op))
+
+        assert isinstance(
+            exc.value.trigger, BigQueryGetDataTrigger
+        ), "Trigger is not a BigQueryGetDataTrigger"
+
+    def test_bigquery_get_data_operator_execute_failure(self, context):
+        """Tests that an AirflowException is raised in case of error event"""
+
+        operator = BigQueryGetDataOperatorAsync(
+            task_id="get_data_from_bq",
+            dataset_id=TEST_DATASET,
+            table_id="any",
+            max_results=100,
+        )
+
+        with pytest.raises(AirflowException):
+            operator.execute_complete(
+                context=None, event={"status": "error", "message": "test failure message"}
+            )
+
+    def test_bigquery_get_data_op_execute_complete_with_records(self):
+        """Asserts that exception is raised with correct expected exception message"""
+
+        operator = BigQueryGetDataOperatorAsync(
+            task_id="get_data_from_bq",
+            dataset_id=TEST_DATASET,
+            table_id="any",
+            max_results=100,
+        )
+
+        with mock.patch.object(operator.log, "info") as mock_log_info:
+            operator.execute_complete(context=None, event={"status": "success", "records": [20]})
+        mock_log_info.assert_called_with("Total extracted rows: %s", 1)
+
+
+class TestBigQueryValueCheckOperatorAsync:
+    def _get_value_check_async_operator(self, use_legacy_sql: bool = False):
+        """Helper function to initialise BigQueryValueCheckOperatorAsync operator"""
+        query = "SELECT COUNT(*) FROM Any"
+        pass_val = 2
+
+        return BigQueryValueCheckOperatorAsync(
+            task_id="check_value",
+            sql=query,
+            pass_value=pass_val,
+            use_legacy_sql=use_legacy_sql,
+        )
+
+    @mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
+    def test_bigquery_value_check_async(self, mock_hook):
+        """
+        Asserts that a task is deferred and a BigQueryValueCheckTrigger will be fired
+        when the BigQueryValueCheckOperatorAsync is executed.
+        """
+        operator = self._get_value_check_async_operator(True)
+        job_id = "123456"
+        hash_ = "hash"
+        real_job_id = f"{job_id}_{hash_}"
+        mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute(create_context(operator))
+
+        assert isinstance(
+            exc.value.trigger, BigQueryValueCheckTrigger
+        ), "Trigger is not a BigQueryValueCheckTrigger"
+
+    def test_bigquery_value_check_operator_execute_complete_success(self):
+        """Tests response message in case of success event"""
+        operator = self._get_value_check_async_operator()
+
+        assert (
+            operator.execute_complete(context=None, event={"status": "success", "message": "Job completed!"})
+            is None
+        )
+
+    def test_bigquery_value_check_operator_execute_complete_failure(self):
+        """Tests that an AirflowException is raised in case of error event"""
+        operator = self._get_value_check_async_operator()
+
+        with pytest.raises(AirflowException):
+            operator.execute_complete(
+                context=None, event={"status": "error", "message": "test failure message"}
+            )
+
+    @pytest.mark.parametrize(
+        "kwargs, expected",
+        [
+            ({"sql": "SELECT COUNT(*) from Any"}, "missing keyword argument 'pass_value'"),
+            ({"pass_value": "Any"}, "missing keyword argument 'sql'"),
+        ],
     )
-    mock_hook.return_value.get_job.return_value = job
-
-    op = BigQueryInsertJobOperatorAsync(
-        task_id="insert_query_job",
-        configuration=configuration,
-        location=TEST_DATASET_LOCATION,
-        job_id=job_id,
-        project_id=TEST_GCP_PROJECT_ID,
-        reattach_states={"PENDING"},
-    )
-
-    with pytest.raises(AirflowException) as exc:
-        op.execute(create_context(op))
-
-    expected_exception_msg = (
-        f"Job with id: {real_job_id} already exists and is in {job.state} state. "
-        f"If you want to force rerun it consider setting `force_rerun=True`."
-        f"Or, if you want to reattach in this scenario add {job.state} to `reattach_states`"
-    )
-
-    assert str(exc.value) == expected_exception_msg
-
-    mock_hook.return_value.get_job.assert_called_once_with(
-        location=TEST_DATASET_LOCATION,
-        job_id=real_job_id,
-        project_id=TEST_GCP_PROJECT_ID,
-    )
-
-
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
-def test_bigquery_check_operator_async(mock_hook):
-    """
-    Asserts that a task is deferred and a BigQueryCheckTrigger will be fired
-    when the BigQueryCheckOperatorAsync is executed.
-    """
-    job_id = "123456"
-    hash_ = "hash"
-    real_job_id = f"{job_id}_{hash_}"
-
-    mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
-
-    op = BigQueryCheckOperatorAsync(
-        task_id="bq_check_operator_job",
-        sql="SELECT * FROM any",
-        location=TEST_DATASET_LOCATION,
-    )
-
-    with pytest.raises(TaskDeferred) as exc:
-        op.execute(create_context(op))
-
-    assert isinstance(exc.value.trigger, BigQueryCheckTrigger), "Trigger is not a BigQueryCheckTrigger"
-
-
-def test_bigquery_check_operator_execute_failure(context):
-    """Tests that an AirflowException is raised in case of error event"""
-
-    operator = BigQueryCheckOperatorAsync(
-        task_id="bq_check_operator_execute_failure", sql="SELECT * FROM any", location=TEST_DATASET_LOCATION
-    )
-
-    with pytest.raises(AirflowException):
-        operator.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
-
-
-def test_bigquery_check_op_execute_complete_with_no_records():
-    """Asserts that exception is raised with correct expected exception message"""
-
-    operator = BigQueryCheckOperatorAsync(
-        task_id="bq_check_operator_execute_complete", sql="SELECT * FROM any", location=TEST_DATASET_LOCATION
-    )
-
-    with pytest.raises(AirflowException) as exc:
-        operator.execute_complete(context=None, event={"status": "success", "records": None})
-
-    expected_exception_msg = "The query returned None"
-
-    assert str(exc.value) == expected_exception_msg
-
-
-def test_bigquery_check_op_execute_complete_with_non_boolean_records():
-    """Executing a sql which returns a non-boolean value should raise exception"""
-
-    test_sql = "SELECT * FROM any"
-
-    operator = BigQueryCheckOperatorAsync(
-        task_id="bq_check_operator_execute_complete", sql=test_sql, location=TEST_DATASET_LOCATION
-    )
-
-    expected_exception_msg = f"Test failed.\nQuery:\n{test_sql}\nResults:\n{[20, False]!s}"
-
-    with pytest.raises(AirflowException) as exc:
-        operator.execute_complete(context=None, event={"status": "success", "records": [20, False]})
-
-    assert str(exc.value) == expected_exception_msg
-
-
-def test_bigquery_check_operator_execute_complete():
-    """Asserts that logging occurs as expected"""
-
-    operator = BigQueryCheckOperatorAsync(
-        task_id="bq_check_operator_execute_complete", sql="SELECT * FROM any", location=TEST_DATASET_LOCATION
-    )
-
-    with mock.patch.object(operator.log, "info") as mock_log_info:
-        operator.execute_complete(context=None, event={"status": "success", "records": [20]})
-    mock_log_info.assert_called_with("Success.")
-
-
-def test_bigquery_interval_check_operator_execute_complete():
-    """Asserts that logging occurs as expected"""
-
-    operator = BigQueryIntervalCheckOperatorAsync(
-        task_id="bq_interval_check_operator_execute_complete",
-        table="test_table",
-        metrics_thresholds={"COUNT(*)": 1.5},
-        location=TEST_DATASET_LOCATION,
-    )
-
-    with mock.patch.object(operator.log, "info") as mock_log_info:
-        operator.execute_complete(context=None, event={"status": "success", "message": "Job completed"})
-    mock_log_info.assert_called_with(
-        "%s completed with response %s ", "bq_interval_check_operator_execute_complete", "success"
-    )
-
-
-def test_bigquery_interval_check_operator_execute_failure(context):
-    """Tests that an AirflowException is raised in case of error event"""
-
-    operator = BigQueryIntervalCheckOperatorAsync(
-        task_id="bq_interval_check_operator_execute_complete",
-        table="test_table",
-        metrics_thresholds={"COUNT(*)": 1.5},
-        location=TEST_DATASET_LOCATION,
-    )
-
-    with pytest.raises(AirflowException):
-        operator.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
-
-
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
-def test_bigquery_interval_check_operator_async(mock_hook):
-    """
-    Asserts that a task is deferred and a BigQueryIntervalCheckTrigger will be fired
-    when the BigQueryIntervalCheckOperatorAsync is executed.
-    """
-    job_id = "123456"
-    hash_ = "hash"
-    real_job_id = f"{job_id}_{hash_}"
-
-    mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
-
-    op = BigQueryIntervalCheckOperatorAsync(
-        task_id="bq_interval_check_operator_execute_complete",
-        table="test_table",
-        metrics_thresholds={"COUNT(*)": 1.5},
-        location=TEST_DATASET_LOCATION,
-    )
-
-    with pytest.raises(TaskDeferred) as exc:
-        op.execute(create_context(op))
-
-    assert isinstance(
-        exc.value.trigger, BigQueryIntervalCheckTrigger
-    ), "Trigger is not a BigQueryIntervalCheckTrigger"
-
-
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
-def test_bigquery_get_data_operator_async_with_selected_fields(mock_hook):
-    """
-    Asserts that a task is deferred and a BigQuerygetDataTrigger will be fired
-    when the BigQuerygetDataOperatorAsync is executed.
-    """
-    job_id = "123456"
-    hash_ = "hash"
-    real_job_id = f"{job_id}_{hash_}"
-
-    mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
-
-    op = BigQueryGetDataOperatorAsync(
-        task_id="get_data_from_bq",
-        dataset_id=TEST_DATASET,
-        table_id=TEST_TABLE,
-        max_results=100,
-        selected_fields="value,name",
-    )
-
-    with pytest.raises(TaskDeferred) as exc:
-        op.execute(create_context(op))
-
-    assert isinstance(exc.value.trigger, BigQueryGetDataTrigger), "Trigger is not a BigQueryGetDataTrigger"
-
-
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
-def test_bigquery_get_data_operator_async_without_selected_fields(mock_hook):
-    """
-    Asserts that a task is deferred and a BigQuerygetDataTrigger will be fired
-    when the BigQuerygetDataOperatorAsync is executed.
-    """
-    job_id = "123456"
-    hash_ = "hash"
-    real_job_id = f"{job_id}_{hash_}"
-
-    mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
-
-    op = BigQueryGetDataOperatorAsync(
-        task_id="get_data_from_bq",
-        dataset_id=TEST_DATASET,
-        table_id=TEST_TABLE,
-        max_results=100,
-    )
-
-    with pytest.raises(TaskDeferred) as exc:
-        op.execute(create_context(op))
-
-    assert isinstance(exc.value.trigger, BigQueryGetDataTrigger), "Trigger is not a BigQueryGetDataTrigger"
-
-
-def test_bigquery_get_data_operator_execute_failure(context):
-    """Tests that an AirflowException is raised in case of error event"""
-
-    operator = BigQueryGetDataOperatorAsync(
-        task_id="get_data_from_bq",
-        dataset_id=TEST_DATASET,
-        table_id="any",
-        max_results=100,
-    )
-
-    with pytest.raises(AirflowException):
-        operator.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
-
-
-def test_bigquery_get_data_op_execute_complete_with_records():
-    """Asserts that exception is raised with correct expected exception message"""
-
-    operator = BigQueryGetDataOperatorAsync(
-        task_id="get_data_from_bq",
-        dataset_id=TEST_DATASET,
-        table_id="any",
-        max_results=100,
-    )
-
-    with mock.patch.object(operator.log, "info") as mock_log_info:
-        operator.execute_complete(context=None, event={"status": "success", "records": [20]})
-    mock_log_info.assert_called_with("Total extracted rows: %s", 1)
-
-
-def _get_value_check_async_operator(use_legacy_sql: bool = False):
-    """Helper function to initialise BigQueryValueCheckOperatorAsync operator"""
-    query = "SELECT COUNT(*) FROM Any"
-    pass_val = 2
-
-    return BigQueryValueCheckOperatorAsync(
-        task_id="check_value",
-        sql=query,
-        pass_value=pass_val,
-        use_legacy_sql=use_legacy_sql,
-    )
-
-
-@mock.patch("astronomer.providers.google.cloud.operators.bigquery.BigQueryHook")
-def test_bigquery_value_check_async(mock_hook):
-    """
-    Asserts that a task is deferred and a BigQueryValueCheckTrigger will be fired
-    when the BigQueryValueCheckOperatorAsync is executed.
-    """
-    operator = _get_value_check_async_operator(True)
-    job_id = "123456"
-    hash_ = "hash"
-    real_job_id = f"{job_id}_{hash_}"
-    mock_hook.return_value.insert_job.return_value = MagicMock(job_id=real_job_id, error_result=False)
-    with pytest.raises(TaskDeferred) as exc:
-        operator.execute(create_context(operator))
-
-    assert isinstance(
-        exc.value.trigger, BigQueryValueCheckTrigger
-    ), "Trigger is not a BigQueryValueCheckTrigger"
-
-
-def test_bigquery_value_check_operator_execute_complete_success():
-    """Tests response message in case of success event"""
-    operator = _get_value_check_async_operator()
-
-    assert (
-        operator.execute_complete(context=None, event={"status": "success", "message": "Job completed!"})
-        is None
-    )
-
-
-def test_bigquery_value_check_operator_execute_complete_failure():
-    """Tests that an AirflowException is raised in case of error event"""
-    operator = _get_value_check_async_operator()
-
-    with pytest.raises(AirflowException):
-        operator.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
-
-
-@pytest.mark.parametrize(
-    "kwargs, expected",
-    [
-        ({"sql": "SELECT COUNT(*) from Any"}, "missing keyword argument 'pass_value'"),
-        ({"pass_value": "Any"}, "missing keyword argument 'sql'"),
-    ],
-)
-def test_bigquery_value_check_missing_param(kwargs, expected):
-    """Assert the exception if require param not pass to BigQueryValueCheckOperatorAsync operator"""
-    with pytest.raises(AirflowException) as missing_param:
-        BigQueryValueCheckOperatorAsync(**kwargs)
-    assert missing_param.value.args[0] == expected
-
-
-def test_bigquery_value_check_empty():
-    """Assert the exception if require param not pass to BigQueryValueCheckOperatorAsync operator"""
-    expected, expected1 = (
-        "missing keyword arguments 'sql', 'pass_value'",
-        "missing keyword arguments 'pass_value', 'sql'",
-    )
-    with pytest.raises(AirflowException) as missing_param:
-        BigQueryValueCheckOperatorAsync(kwargs={})
-    assert (missing_param.value.args[0] == expected) or (missing_param.value.args[0] == expected1)
+    def test_bigquery_value_check_missing_param(self, kwargs, expected):
+        """Assert the exception if require param not pass to BigQueryValueCheckOperatorAsync operator"""
+        with pytest.raises(AirflowException) as missing_param:
+            BigQueryValueCheckOperatorAsync(**kwargs)
+        assert missing_param.value.args[0] == expected
+
+    def test_bigquery_value_check_empty(self):
+        """Assert the exception if require param not pass to BigQueryValueCheckOperatorAsync operator"""
+        expected, expected1 = (
+            "missing keyword arguments 'sql', 'pass_value'",
+            "missing keyword arguments 'pass_value', 'sql'",
+        )
+        with pytest.raises(AirflowException) as missing_param:
+            BigQueryValueCheckOperatorAsync(kwargs={})
+        assert (missing_param.value.args[0] == expected) or (missing_param.value.args[0] == expected1)

--- a/tests/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/google/cloud/operators/test_kubernetes_engine.py
@@ -29,32 +29,9 @@ POD_NAME = "astro-k8s-gke-test-pod-25131a0d9cda46419099ac4aa8a4ef8f"
 GCP_CONN_ID = "google_cloud_default"
 
 
-@pytest.fixture()
-def context():
-    """
-    Creates an empty context.
-    """
-    context = {}
-    yield context
-
-
 # TODO: Improve test
-@mock.patch(
-    "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file"
-)
-@mock.patch(
-    "airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.build_pod_request_obj"
-)
-@mock.patch(
-    "airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.get_or_create_pod"
-)
-def test__get_or_create_pod(mock_get_or_create_pod, moc_build_pod_request_obj, mock_tmp):
-    """assert that _get_or_create_pod does not return any value"""
-    my_tmp = mock_tmp.__enter__()
-    my_tmp.return_value = "/tmp/tmps90l"
-    moc_build_pod_request_obj.return_value = {}
-    mock_get_or_create_pod.return_value = k8s.V1Pod(metadata=V1ObjectMeta(name=POD_NAME, namespace=NAMESPACE))
-    operator = GKEStartPodOperatorAsync(
+class TestGKEStartPodOperatorAsync:
+    OPERATOR = GKEStartPodOperatorAsync(
         task_id="start_pod",
         project_id=PROJECT_ID,
         location=LOCATION,
@@ -64,165 +41,7 @@ def test__get_or_create_pod(mock_get_or_create_pod, moc_build_pod_request_obj, m
         image="ubuntu",
         gcp_conn_id=GCP_CONN_ID,
     )
-    assert operator._get_or_create_pod(context=context) is None
-
-
-@mock.patch(
-    "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync._get_or_create_pod"
-)
-def test_execute(mock__get_or_create_pod):
-    """
-    asserts that a task is deferred and a GKEStartPodTrigger will be fired
-    when the GKEStartPodOperatorAsync is executed.
-    """
-    mock__get_or_create_pod.return_value = None
-    operator = GKEStartPodOperatorAsync(
-        task_id="start_pod",
-        project_id=PROJECT_ID,
-        location=LOCATION,
-        cluster_name=GKE_CLUSTER_NAME,
-        name="astro_k8s_gke_test_pod",
-        namespace=NAMESPACE,
-        image="ubuntu",
-        gcp_conn_id=GCP_CONN_ID,
-    )
-    with pytest.raises(TaskDeferred) as exc:
-        operator.execute(context)
-    assert isinstance(exc.value.trigger, GKEStartPodTrigger), "Trigger is not a GKEStartPodTrigger"
-
-
-@mock.patch(
-    "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.trigger_reentry"
-)
-def test_execute_complete_success(mock_trigger_reentry):
-    """assert that execute_complete_success log correct message when a task succeed"""
-    mock_trigger_reentry.return_value = {}
-    operator = GKEStartPodOperatorAsync(
-        task_id="start_pod",
-        project_id=PROJECT_ID,
-        location=LOCATION,
-        cluster_name=GKE_CLUSTER_NAME,
-        name="astro_k8s_gke_test_pod",
-        namespace=NAMESPACE,
-        image="ubuntu",
-        gcp_conn_id=GCP_CONN_ID,
-    )
-    assert operator.execute_complete(context=create_context(operator), event={}) is None
-
-
-def test_execute_complete_fail():
-    operator = GKEStartPodOperatorAsync(
-        task_id="start_pod",
-        project_id=PROJECT_ID,
-        location=LOCATION,
-        cluster_name=GKE_CLUSTER_NAME,
-        name="astro_k8s_gke_test_pod",
-        namespace=NAMESPACE,
-        image="ubuntu",
-        gcp_conn_id=GCP_CONN_ID,
-    )
-    with pytest.raises(AirflowException):
-        """assert that execute_complete_success raise exception when a task fail"""
-        operator.execute_complete(context=context, event={"status": "error", "description": "Pod not found"})
-
-
-def test_raise_for_trigger_status_done():
-    """Assert trigger don't raise exception in case of status is done"""
-    assert (
-        GKEStartPodOperatorAsync(
-            task_id="start_pod",
-            project_id=PROJECT_ID,
-            location=LOCATION,
-            cluster_name=GKE_CLUSTER_NAME,
-            name="astro_k8s_gke_test_pod",
-            namespace=NAMESPACE,
-            image="ubuntu",
-            gcp_conn_id=GCP_CONN_ID,
-        ).raise_for_trigger_status({"status": "done"})
-        is None
-    )
-
-
-@mock.patch("airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.client")
-@mock.patch("astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.cleanup")
-@mock.patch("airflow.kubernetes.kube_client.get_kube_client")
-@mock.patch(
-    "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync"
-    ".raise_for_trigger_status"
-)
-@mock.patch("astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.find_pod")
-@mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
-@mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.fetch_container_logs")
-@mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
-@mock.patch(
-    "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file"
-)
-@mock.patch(
-    "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.extract_xcom"
-)
-def test_get_logs_not_running(
-    mock_extract_xcom,
-    mock_gke_config,
-    mock_get_default_client,
-    fetch_container_logs,
-    await_pod_completion,
-    find_pod,
-    raise_for_trigger_status,
-    get_kube_client,
-    cleanup,
-    mock_client,
-):
-    mock_extract_xcom.return_value = "{}"
-    pod = MagicMock()
-    find_pod.return_value = pod
-    mock_client.return_value = {}
-    op = GKEStartPodOperatorAsync(
-        task_id="start_pod",
-        project_id=PROJECT_ID,
-        location=LOCATION,
-        cluster_name=GKE_CLUSTER_NAME,
-        name="astro_k8s_gke_test_pod",
-        namespace=NAMESPACE,
-        image="ubuntu",
-        gcp_conn_id=GCP_CONN_ID,
-        get_logs=True,
-        do_xcom_push=True,
-    )
-    context = create_context(op)
-    await_pod_completion.return_value = None
-    fetch_container_logs.return_value = PodLoggingStatus(False, None)
-    op.trigger_reentry(context, {"namespace": NAMESPACE})
-    fetch_container_logs.is_called_with(pod, "base")
-
-
-@mock.patch("airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.client")
-@mock.patch("astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.cleanup")
-@mock.patch("airflow.kubernetes.kube_client.get_kube_client")
-@mock.patch(
-    "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync"
-    ".raise_for_trigger_status"
-)
-@mock.patch("astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.find_pod")
-@mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
-@mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.fetch_container_logs")
-@mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
-@mock.patch(
-    "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file"
-)
-def test_no_pod(
-    mock_gke_config,
-    mock_get_default_client,
-    fetch_container_logs,
-    await_pod_completion,
-    find_pod,
-    raise_for_trigger_status,
-    get_kube_client,
-    cleanup,
-    mock_client,
-):
-    """Assert if pod not found then raise exception"""
-    find_pod.return_value = None
-    op = GKEStartPodOperatorAsync(
+    OPERATOR1 = GKEStartPodOperatorAsync(
         task_id="start_pod",
         project_id=PROJECT_ID,
         location=LOCATION,
@@ -233,30 +52,153 @@ def test_no_pod(
         gcp_conn_id=GCP_CONN_ID,
         get_logs=True,
     )
-    context = create_context(op)
-    with pytest.raises(PodNotFoundException):
-        op.trigger_reentry(context, {"namespace": NAMESPACE})
 
-
-def test_trigger_error():
-    """Assert that trigger_reentry raise exception in case of error"""
-    op = GKEStartPodOperatorAsync(
-        task_id="start_pod",
-        project_id=PROJECT_ID,
-        location=LOCATION,
-        cluster_name=GKE_CLUSTER_NAME,
-        name="astro_k8s_gke_test_pod",
-        namespace=NAMESPACE,
-        image="ubuntu",
-        gcp_conn_id=GCP_CONN_ID,
-        get_logs=True,
+    @mock.patch(
+        "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file"
     )
-    with pytest.raises(PodLaunchTimeoutException):
-        op.execute_complete(
-            context,
-            {
-                "status": "error",
-                "error_type": "PodLaunchTimeoutException",
-                "description": "any message",
-            },
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.build_pod_request_obj"
+    )
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.get_or_create_pod"
+    )
+    def test__get_or_create_pod(self, mock_get_or_create_pod, moc_build_pod_request_obj, mock_tmp, context):
+        """assert that _get_or_create_pod does not return any value"""
+        my_tmp = mock_tmp.__enter__()
+        my_tmp.return_value = "/tmp/tmps90l"
+        moc_build_pod_request_obj.return_value = {}
+        mock_get_or_create_pod.return_value = k8s.V1Pod(
+            metadata=V1ObjectMeta(name=POD_NAME, namespace=NAMESPACE)
         )
+
+        assert self.OPERATOR._get_or_create_pod(context=context) is None
+
+    @mock.patch(
+        "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync._get_or_create_pod"
+    )
+    def test_execute(self, mock__get_or_create_pod, context):
+        """
+        asserts that a task is deferred and a GKEStartPodTrigger will be fired
+        when the GKEStartPodOperatorAsync is executed.
+        """
+        mock__get_or_create_pod.return_value = None
+
+        with pytest.raises(TaskDeferred) as exc:
+            self.OPERATOR.execute(context)
+        assert isinstance(exc.value.trigger, GKEStartPodTrigger), "Trigger is not a GKEStartPodTrigger"
+
+    @mock.patch(
+        "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.trigger_reentry"
+    )
+    def test_execute_complete_success(self, mock_trigger_reentry):
+        """assert that execute_complete_success log correct message when a task succeed"""
+        mock_trigger_reentry.return_value = {}
+
+        assert self.OPERATOR.execute_complete(context=create_context(self.OPERATOR), event={}) is None
+
+    def test_execute_complete_fail(self, context):
+
+        with pytest.raises(AirflowException):
+            """assert that execute_complete_success raise exception when a task fail"""
+            self.OPERATOR.execute_complete(
+                context=context, event={"status": "error", "description": "Pod not found"}
+            )
+
+    def test_raise_for_trigger_status_done(self):
+        """Assert trigger don't raise exception in case of status is done"""
+        assert self.OPERATOR.raise_for_trigger_status({"status": "done"}) is None
+
+    @mock.patch("airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.client")
+    @mock.patch(
+        "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.cleanup"
+    )
+    @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
+    @mock.patch(
+        "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync"
+        ".raise_for_trigger_status"
+    )
+    @mock.patch(
+        "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.find_pod"
+    )
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.fetch_container_logs")
+    @mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
+    @mock.patch(
+        "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file"
+    )
+    @mock.patch(
+        "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.extract_xcom"
+    )
+    def test_get_logs_not_running(
+        self,
+        mock_extract_xcom,
+        mock_gke_config,
+        mock_get_default_client,
+        fetch_container_logs,
+        await_pod_completion,
+        find_pod,
+        raise_for_trigger_status,
+        get_kube_client,
+        cleanup,
+        mock_client,
+    ):
+        mock_extract_xcom.return_value = "{}"
+        pod = MagicMock()
+        find_pod.return_value = pod
+        mock_client.return_value = {}
+
+        context = create_context(self.OPERATOR1)
+        await_pod_completion.return_value = None
+        fetch_container_logs.return_value = PodLoggingStatus(False, None)
+        self.OPERATOR1.trigger_reentry(context, {"namespace": NAMESPACE})
+        fetch_container_logs.is_called_with(pod, "base")
+
+    @mock.patch("airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.client")
+    @mock.patch(
+        "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.cleanup"
+    )
+    @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
+    @mock.patch(
+        "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync"
+        ".raise_for_trigger_status"
+    )
+    @mock.patch(
+        "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.find_pod"
+    )
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.fetch_container_logs")
+    @mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
+    @mock.patch(
+        "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file"
+    )
+    def test_no_pod(
+        self,
+        mock_gke_config,
+        mock_get_default_client,
+        fetch_container_logs,
+        await_pod_completion,
+        find_pod,
+        raise_for_trigger_status,
+        get_kube_client,
+        cleanup,
+        mock_client,
+    ):
+        """Assert if pod not found then raise exception"""
+        find_pod.return_value = None
+
+        context = create_context(self.OPERATOR1)
+        with pytest.raises(PodNotFoundException):
+            self.OPERATOR1.trigger_reentry(context, {"namespace": NAMESPACE})
+
+    def test_trigger_error(self, context):
+        """Assert that trigger_reentry raise exception in case of error"""
+
+        with pytest.raises(PodLaunchTimeoutException):
+            self.OPERATOR1.execute_complete(
+                context,
+                {
+                    "status": "error",
+                    "error_type": "PodLaunchTimeoutException",
+                    "description": "any message",
+                },
+            )

--- a/tests/google/cloud/sensors/test_bigquery.py
+++ b/tests/google/cloud/sensors/test_bigquery.py
@@ -15,79 +15,58 @@ DATASET_NAME = "test-astro_dataset"
 TABLE_NAME = "test-partitioned_table"
 
 
-@pytest.fixture()
-def context():
-    """
-    Creates an empty context.
-    """
-    context = {}
-    yield context
-
-
-def test_big_query_table_existence_sensor_async():
-    """
-    Asserts that a task is deferred and a BigQueryTableExistenceTrigger will be fired
-    when the BigQueryTableExistenceSensorAsync is executed.
-    """
-    task = BigQueryTableExistenceSensorAsync(
-        task_id="check_table_exists",
+class TestBigQueryTableExistenceSensorAsync:
+    SENSOR = BigQueryTableExistenceSensorAsync(
+        task_id="bq_check_table",
         project_id=PROJECT_ID,
         dataset_id=DATASET_NAME,
         table_id=TABLE_NAME,
     )
-    with pytest.raises(TaskDeferred) as exc:
-        task.execute(context)
-    assert isinstance(
-        exc.value.trigger, BigQueryTableExistenceTrigger
-    ), "Trigger is not a BigQueryTableExistenceTrigger"
 
+    def test_big_query_table_existence_sensor_async(self, context):
+        """
+        Asserts that a task is deferred and a BigQueryTableExistenceTrigger will be fired
+        when the BigQueryTableExistenceSensorAsync is executed.
+        """
 
-def test_big_query_table_existence_sensor_async_execute_failure(context):
-    """Tests that an AirflowException is raised in case of error event"""
-    task = BigQueryTableExistenceSensorAsync(
-        task_id="task-id",
-        project_id=PROJECT_ID,
-        dataset_id=DATASET_NAME,
-        table_id=TABLE_NAME,
-    )
-    with pytest.raises(AirflowException):
-        task.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
+        with pytest.raises(TaskDeferred) as exc:
+            self.SENSOR.execute(context)
+        assert isinstance(
+            exc.value.trigger, BigQueryTableExistenceTrigger
+        ), "Trigger is not a BigQueryTableExistenceTrigger"
 
+    def test_big_query_table_existence_sensor_async_execute_failure(self, context):
+        """Tests that an AirflowException is raised in case of error event"""
 
-def test_big_query_table_existence_sensor_async_execute_complete():
-    """Asserts that logging occurs as expected"""
-    task = BigQueryTableExistenceSensorAsync(
-        task_id="task-id",
-        project_id=PROJECT_ID,
-        dataset_id=DATASET_NAME,
-        table_id=TABLE_NAME,
-    )
-    table_uri = f"{PROJECT_ID}:{DATASET_NAME}.{TABLE_NAME}"
-    with mock.patch.object(task.log, "info") as mock_log_info:
-        task.execute_complete(context=None, event={"status": "success", "message": "Job completed"})
-    mock_log_info.assert_called_with("Sensor checks existence of table: %s", table_uri)
+        with pytest.raises(AirflowException):
+            self.SENSOR.execute_complete(
+                context=context, event={"status": "error", "message": "test failure message"}
+            )
 
+    def test_big_query_table_existence_sensor_async_execute_complete(self):
+        """Asserts that logging occurs as expected"""
 
-def test_redshift_sensor_async_execute_complete_event_none():
-    """Asserts that logging occurs as expected"""
-    task = BigQueryTableExistenceSensorAsync(
-        task_id="task-id",
-        project_id=PROJECT_ID,
-        dataset_id=DATASET_NAME,
-        table_id=TABLE_NAME,
-    )
-    with pytest.raises(AirflowException):
-        task.execute_complete(context=None, event=None)
+        table_uri = f"{PROJECT_ID}:{DATASET_NAME}.{TABLE_NAME}"
+        with mock.patch.object(self.SENSOR.log, "info") as mock_log_info:
+            self.SENSOR.execute_complete(
+                context=None, event={"status": "success", "message": "Job completed"}
+            )
+        mock_log_info.assert_called_with("Sensor checks existence of table: %s", table_uri)
 
+    def test_redshift_sensor_async_execute_complete_event_none(self):
+        """Asserts that logging occurs as expected"""
 
-def test_poll_interval_deprecation_warning():
-    """Test DeprecationWarning for BigQueryTableExistenceSensorAsync by setting param poll_interval"""
-    # TODO: Remove once deprecated
-    with pytest.warns(expected_warning=DeprecationWarning):
-        BigQueryTableExistenceSensorAsync(
-            task_id="task-id",
-            project_id=PROJECT_ID,
-            dataset_id=DATASET_NAME,
-            table_id=TABLE_NAME,
-            polling_interval=5.0,
-        )
+        with pytest.raises(AirflowException):
+            self.SENSOR.execute_complete(context=None, event=None)
+
+    def test_poll_interval_deprecation_warning(self):
+        """Test DeprecationWarning for BigQueryTableExistenceSensorAsync by setting param poll_interval"""
+        # TODO: Remove once deprecated
+        with pytest.warns(expected_warning=DeprecationWarning):
+            BigQueryTableExistenceSensorAsync(
+                task_id="task-id",
+                project_id=PROJECT_ID,
+                dataset_id=DATASET_NAME,
+                table_id=TABLE_NAME,
+                polling_interval=5.0,
+            )

--- a/tests/google/cloud/sensors/test_gcs.py
+++ b/tests/google/cloud/sensors/test_gcs.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -16,234 +15,201 @@ from astronomer.providers.google.cloud.triggers.gcs import (
     GCSPrefixBlobTrigger,
     GCSUploadSessionTrigger,
 )
+from tests.utils.airflow_util import create_context
 
 TEST_BUCKET = "TEST_BUCKET"
 TEST_OBJECT = "TEST_OBJECT"
 TEST_GCP_CONN_ID = "TEST_GCP_CONN_ID"
-TEST_DAG_ID = "unit_tests_gcs_sensor"
 TEST_INACTIVITY_PERIOD = 5
 TEST_MIN_OBJECTS = 1
 
 
-@pytest.fixture()
-def context():
-    """
-    Creates an empty context.
-    """
-    context = {"data_interval_end": datetime.utcnow()}
-    yield context
-
-
-def test_gcs_object_existence_sensor_async():
-    """
-    Asserts that a task is deferred and a GCSBlobTrigger will be fired
-    when the GCSObjectExistenceSensorAsync is executed.
-    """
-    task = GCSObjectExistenceSensorAsync(
-        task_id="task-id",
+class TestGCSObjectExistenceSensorAsync:
+    OPERATOR = GCSObjectExistenceSensorAsync(
+        task_id="gcs-object",
         bucket=TEST_BUCKET,
         object=TEST_OBJECT,
         google_cloud_conn_id=TEST_GCP_CONN_ID,
     )
-    with pytest.raises(TaskDeferred) as exc:
-        task.execute(context)
-    assert isinstance(exc.value.trigger, GCSBlobTrigger), "Trigger is not a GCSBlobTrigger"
+
+    def test_gcs_object_existence_sensor_async(self, context):
+        """
+        Asserts that a task is deferred and a GCSBlobTrigger will be fired
+        when the GCSObjectExistenceSensorAsync is executed.
+        """
+
+        with pytest.raises(TaskDeferred) as exc:
+            self.OPERATOR.execute(context)
+        assert isinstance(exc.value.trigger, GCSBlobTrigger), "Trigger is not a GCSBlobTrigger"
+
+    def test_gcs_object_existence_sensor_async_execute_failure(self, context):
+        """Tests that an AirflowException is raised in case of error event"""
+
+        with pytest.raises(AirflowException):
+            self.OPERATOR.execute_complete(
+                context=context, event={"status": "error", "message": "test failure message"}
+            )
+
+    def test_gcs_object_existence_sensor_async_execute_complete(self, context):
+        """Asserts that logging occurs as expected"""
+
+        with mock.patch.object(self.OPERATOR.log, "info") as mock_log_info:
+            self.OPERATOR.execute_complete(
+                context=context, event={"status": "success", "message": "Job completed"}
+            )
+        mock_log_info.assert_called_with("File %s was found in bucket %s.", TEST_OBJECT, TEST_BUCKET)
 
 
-def test_gcs_object_existence_sensor_async_execute_failure(context):
-    """Tests that an AirflowException is raised in case of error event"""
-    task = GCSObjectExistenceSensorAsync(
-        task_id="task-id",
-        bucket=TEST_BUCKET,
-        object=TEST_OBJECT,
-        google_cloud_conn_id=TEST_GCP_CONN_ID,
-    )
-    with pytest.raises(AirflowException):
-        task.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
-
-
-def test_gcs_object_existence_sensor_async_execute_complete():
-    """Asserts that logging occurs as expected"""
-    task = GCSObjectExistenceSensorAsync(
-        task_id="task-id",
-        bucket=TEST_BUCKET,
-        object=TEST_OBJECT,
-        google_cloud_conn_id=TEST_GCP_CONN_ID,
-    )
-    with mock.patch.object(task.log, "info") as mock_log_info:
-        task.execute_complete(context=None, event={"status": "success", "message": "Job completed"})
-    mock_log_info.assert_called_with("File %s was found in bucket %s.", TEST_OBJECT, TEST_BUCKET)
-
-
-def test_gcs_object_with_prefix_existence_sensor_async():
-    """
-    Asserts that a task is deferred and a GCSPrefixBlobTrigger will be fired
-    when the GCSObjectsWithPrefixExistenceSensorAsync is executed.
-    """
-    task = GCSObjectsWithPrefixExistenceSensorAsync(
-        task_id="task-id",
+class TestGCSObjectsWithPrefixExistenceSensorAsync:
+    OPERATOR = GCSObjectsWithPrefixExistenceSensorAsync(
+        task_id="gcs-obj-prefix",
         bucket=TEST_BUCKET,
         prefix=TEST_OBJECT,
         google_cloud_conn_id=TEST_GCP_CONN_ID,
     )
-    with pytest.raises(TaskDeferred) as exc:
-        task.execute(context)
-    assert isinstance(exc.value.trigger, GCSPrefixBlobTrigger), "Trigger is not a GCSPrefixBlobTrigger"
 
+    def test_gcs_object_with_prefix_existence_sensor_async(self, context):
+        """
+        Asserts that a task is deferred and a GCSPrefixBlobTrigger will be fired
+        when the GCSObjectsWithPrefixExistenceSensorAsync is executed.
+        """
 
-def test_gcs_object_with_prefix_existence_sensor_async_execute_failure(context):
-    """Tests that an AirflowException is raised in case of error event"""
-    task = GCSObjectsWithPrefixExistenceSensorAsync(
-        task_id="task-id",
-        bucket=TEST_BUCKET,
-        prefix=TEST_OBJECT,
-        google_cloud_conn_id=TEST_GCP_CONN_ID,
-    )
-    with pytest.raises(AirflowException):
-        task.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
+        with pytest.raises(TaskDeferred) as exc:
+            self.OPERATOR.execute(context)
+        assert isinstance(exc.value.trigger, GCSPrefixBlobTrigger), "Trigger is not a GCSPrefixBlobTrigger"
 
+    def test_gcs_object_with_prefix_existence_sensor_async_execute_failure(self, context):
+        """Tests that an AirflowException is raised in case of error event"""
 
-def test_gcs_object_with_prefix_existence_sensor_async_execute_complete():
-    """Asserts that logging occurs as expected"""
-    task = GCSObjectsWithPrefixExistenceSensorAsync(
-        task_id="task-id",
-        bucket=TEST_BUCKET,
-        prefix=TEST_OBJECT,
-        google_cloud_conn_id=TEST_GCP_CONN_ID,
-    )
-    with mock.patch.object(task.log, "info") as mock_log_info:
-        task.execute_complete(
-            context=None, event={"status": "success", "message": "Job completed", "matches": [TEST_OBJECT]}
-        )
-    mock_log_info.assert_called_with("Sensor checks existence of objects: %s, %s", TEST_BUCKET, TEST_OBJECT)
+        with pytest.raises(AirflowException):
+            self.OPERATOR.execute_complete(
+                context=context, event={"status": "error", "message": "test failure message"}
+            )
 
+    def test_gcs_object_with_prefix_existence_sensor_async_execute_complete(self, context):
+        """Asserts that logging occurs as expected"""
 
-def test_poll_interval_deprecation_warning_prefix_existence():
-    """Test DeprecationWarning for GCSObjectsWithPrefixExistenceSensorAsync by setting param poll_interval"""
-    # TODO: Remove once deprecated
-    with pytest.warns(expected_warning=DeprecationWarning):
-        GCSObjectsWithPrefixExistenceSensorAsync(
-            task_id="task-id",
-            bucket=TEST_BUCKET,
-            prefix=TEST_OBJECT,
-            google_cloud_conn_id=TEST_GCP_CONN_ID,
-            polling_interval=5.0,
+        with mock.patch.object(self.OPERATOR.log, "info") as mock_log_info:
+            self.OPERATOR.execute_complete(
+                context=context,
+                event={"status": "success", "message": "Job completed", "matches": [TEST_OBJECT]},
+            )
+        mock_log_info.assert_called_with(
+            "Sensor checks existence of objects: %s, %s", TEST_BUCKET, TEST_OBJECT
         )
 
+    def test_poll_interval_deprecation_warning_prefix_existence(self):
+        """Test DeprecationWarning for GCSObjectsWithPrefixExistenceSensorAsync by setting param poll_interval"""
+        # TODO: Remove once deprecated
+        with pytest.warns(expected_warning=DeprecationWarning):
+            GCSObjectsWithPrefixExistenceSensorAsync(
+                task_id="task-id",
+                bucket=TEST_BUCKET,
+                prefix=TEST_OBJECT,
+                google_cloud_conn_id=TEST_GCP_CONN_ID,
+                polling_interval=5.0,
+            )
 
-def test_gcs_upload_session_complete_sensor_async():
-    """
-    Asserts that a task is deferred and a GCSUploadSessionTrigger will be fired
-    when the GCSUploadSessionCompleteSensorAsync is executed.
-    """
-    task = GCSUploadSessionCompleteSensorAsync(
-        task_id="task-id",
+
+class TestGCSUploadSessionCompleteSensorAsync:
+    OPERATOR = GCSUploadSessionCompleteSensorAsync(
+        task_id="gcs-obj-session",
         bucket=TEST_BUCKET,
         google_cloud_conn_id=TEST_GCP_CONN_ID,
         prefix=TEST_OBJECT,
         inactivity_period=TEST_INACTIVITY_PERIOD,
         min_objects=TEST_MIN_OBJECTS,
     )
-    with pytest.raises(TaskDeferred) as exc:
-        task.execute(context)
-    assert isinstance(exc.value.trigger, GCSUploadSessionTrigger), "Trigger is not a GCSUploadSessionTrigger"
 
+    def test_gcs_upload_session_complete_sensor_async(self, context):
+        """
+        Asserts that a task is deferred and a GCSUploadSessionTrigger will be fired
+        when the GCSUploadSessionCompleteSensorAsync is executed.
+        """
 
-def test_gcs_upload_session_complete_sensor_execute_failure(context):
-    """Tests that an AirflowException is raised in case of error event"""
-    task = GCSUploadSessionCompleteSensorAsync(
-        task_id="task-id",
-        bucket=TEST_BUCKET,
-        google_cloud_conn_id=TEST_GCP_CONN_ID,
-        prefix=TEST_OBJECT,
-        inactivity_period=TEST_INACTIVITY_PERIOD,
-        min_objects=TEST_MIN_OBJECTS,
-    )
-    with pytest.raises(AirflowException):
-        task.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
+        with pytest.raises(TaskDeferred) as exc:
+            self.OPERATOR.execute(context)
+        assert isinstance(
+            exc.value.trigger, GCSUploadSessionTrigger
+        ), "Trigger is not a GCSUploadSessionTrigger"
 
+    def test_gcs_upload_session_complete_sensor_execute_failure(self, context):
+        """Tests that an AirflowException is raised in case of error event"""
 
-def test_gcs_upload_session_complete_sensor_async_execute_complete():
-    """Asserts that execute complete is completed as expected"""
-    task = GCSUploadSessionCompleteSensorAsync(
-        task_id="task-id",
-        bucket=TEST_BUCKET,
-        google_cloud_conn_id=TEST_GCP_CONN_ID,
-        prefix=TEST_OBJECT,
-        inactivity_period=TEST_INACTIVITY_PERIOD,
-        min_objects=TEST_MIN_OBJECTS,
-    )
-    assert task.execute_complete(context=None, event={"status": "success", "message": "success"})
+        with pytest.raises(AirflowException):
+            self.OPERATOR.execute_complete(
+                context=context, event={"status": "error", "message": "test failure message"}
+            )
 
+    def test_gcs_upload_session_complete_sensor_async_execute_complete(self, context):
+        """Asserts that execute complete is completed as expected"""
 
-def test_poll_interval_deprecation_warning_gcs_upload_session():
-    """Test DeprecationWarning for GCSUploadSessionCompleteSensorAsync by setting param poll_interval"""
-    # TODO: Remove once deprecated
-    with pytest.warns(expected_warning=DeprecationWarning):
-        GCSUploadSessionCompleteSensorAsync(
-            task_id="task-id",
-            bucket=TEST_BUCKET,
-            google_cloud_conn_id=TEST_GCP_CONN_ID,
-            prefix=TEST_OBJECT,
-            inactivity_period=TEST_INACTIVITY_PERIOD,
-            min_objects=TEST_MIN_OBJECTS,
-            polling_interval=5.0,
+        assert self.OPERATOR.execute_complete(
+            context=context, event={"status": "success", "message": "success"}
         )
 
+    def test_poll_interval_deprecation_warning_gcs_upload_session(self):
+        """Test DeprecationWarning for GCSUploadSessionCompleteSensorAsync by setting param poll_interval"""
+        # TODO: Remove once deprecated
+        with pytest.warns(expected_warning=DeprecationWarning):
+            GCSUploadSessionCompleteSensorAsync(
+                task_id="task-id",
+                bucket=TEST_BUCKET,
+                google_cloud_conn_id=TEST_GCP_CONN_ID,
+                prefix=TEST_OBJECT,
+                inactivity_period=TEST_INACTIVITY_PERIOD,
+                min_objects=TEST_MIN_OBJECTS,
+                polling_interval=5.0,
+            )
 
-def test_gcs_object_update_sensor_async(context):
-    """
-    Asserts that a task is deferred and a GCSBlobTrigger will be fired
-    when the GCSObjectUpdateSensorAsync is executed.
-    """
-    task = GCSObjectUpdateSensorAsync(
-        task_id="task-id",
+
+class TestGCSObjectUpdateSensorAsync:
+    OPERATOR = GCSObjectUpdateSensorAsync(
+        task_id="gcs-obj-update",
         bucket=TEST_BUCKET,
         object=TEST_OBJECT,
         google_cloud_conn_id=TEST_GCP_CONN_ID,
     )
-    with pytest.raises(TaskDeferred) as exc:
-        task.execute(context)
-    assert isinstance(
-        exc.value.trigger, GCSCheckBlobUpdateTimeTrigger
-    ), "Trigger is not a GCSCheckBlobUpdateTimeTrigger"
 
+    def test_gcs_object_update_sensor_async(self, context):
+        """
+        Asserts that a task is deferred and a GCSBlobTrigger will be fired
+        when the GCSObjectUpdateSensorAsync is executed.
+        """
 
-def test_gcs_object_update_sensor_async_execute_failure(context):
-    """Tests that an AirflowException is raised in case of error event"""
-    task = GCSObjectUpdateSensorAsync(
-        task_id="task-id",
-        bucket=TEST_BUCKET,
-        object=TEST_OBJECT,
-        google_cloud_conn_id=TEST_GCP_CONN_ID,
-    )
-    with pytest.raises(AirflowException):
-        task.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
+        with pytest.raises(TaskDeferred) as exc:
+            self.OPERATOR.execute(create_context(self.OPERATOR))
+        assert isinstance(
+            exc.value.trigger, GCSCheckBlobUpdateTimeTrigger
+        ), "Trigger is not a GCSCheckBlobUpdateTimeTrigger"
 
+    def test_gcs_object_update_sensor_async_execute_failure(self, context):
+        """Tests that an AirflowException is raised in case of error event"""
 
-def test_gcs_object_update_sensor_async_execute_complete():
-    """Asserts that logging occurs as expected"""
-    task = GCSObjectUpdateSensorAsync(
-        task_id="task-id",
-        bucket=TEST_BUCKET,
-        object=TEST_OBJECT,
-        google_cloud_conn_id=TEST_GCP_CONN_ID,
-    )
-    with mock.patch.object(task.log, "info") as mock_log_info:
-        task.execute_complete(context=None, event={"status": "success", "message": "Job completed"})
-    mock_log_info.assert_called_with(
-        "Sensor checks update time for object %s in bucket : %s", TEST_OBJECT, TEST_BUCKET
-    )
+        with pytest.raises(AirflowException):
+            self.OPERATOR.execute_complete(
+                context=context, event={"status": "error", "message": "test failure message"}
+            )
 
+    def test_gcs_object_update_sensor_async_execute_complete(self, context):
+        """Asserts that logging occurs as expected"""
 
-def test_poll_interval_deprecation_warning():
-    """Test DeprecationWarning for GCSObjectUpdateSensorAsync by setting param poll_interval"""
-    # TODO: Remove once deprecated
-    with pytest.warns(expected_warning=DeprecationWarning):
-        GCSObjectUpdateSensorAsync(
-            task_id="task-id",
-            bucket=TEST_BUCKET,
-            object=TEST_OBJECT,
-            google_cloud_conn_id=TEST_GCP_CONN_ID,
-            polling_interval=5.0,
+        with mock.patch.object(self.OPERATOR.log, "info") as mock_log_info:
+            self.OPERATOR.execute_complete(
+                context=context, event={"status": "success", "message": "Job completed"}
+            )
+        mock_log_info.assert_called_with(
+            "Sensor checks update time for object %s in bucket : %s", TEST_OBJECT, TEST_BUCKET
         )
+
+    def test_poll_interval_deprecation_warning(self):
+        """Test DeprecationWarning for GCSObjectUpdateSensorAsync by setting param poll_interval"""
+        # TODO: Remove once deprecated
+        with pytest.warns(expected_warning=DeprecationWarning):
+            GCSObjectUpdateSensorAsync(
+                task_id="task-id",
+                bucket=TEST_BUCKET,
+                object=TEST_OBJECT,
+                google_cloud_conn_id=TEST_GCP_CONN_ID,
+                polling_interval=5.0,
+            )

--- a/tests/google/cloud/triggers/test_bigquery.py
+++ b/tests/google/cloud/triggers/test_bigquery.py
@@ -21,9 +21,6 @@ from astronomer.providers.google.cloud.triggers.bigquery import (
 
 TEST_CONN_ID = "bq_default"
 TEST_JOB_ID = "1234"
-RUN_ID = "1"
-RETRY_LIMIT = 2
-RETRY_DELAY = 1.0
 TEST_GCP_PROJECT_ID = "test-project"
 TEST_DATASET_ID = "bq_dataset"
 TEST_TABLE_ID = "bq_table"
@@ -44,107 +41,8 @@ TEST_DELEGATE_TO = None
 TEST_IMPERSONATION_CHAIN = None
 
 
-def test_bigquery_insert_job_op_trigger_serialization():
-    """
-    Asserts that the BigQueryInsertJobTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = BigQueryInsertJobTrigger(
-        TEST_CONN_ID,
-        TEST_JOB_ID,
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_DELEGATE_TO,
-        TEST_IMPERSONATION_CHAIN,
-        POLLING_PERIOD_SECONDS,
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryInsertJobTrigger"
-    assert kwargs == {
-        "conn_id": TEST_CONN_ID,
-        "job_id": TEST_JOB_ID,
-        "project_id": TEST_GCP_PROJECT_ID,
-        "dataset_id": TEST_DATASET_ID,
-        "table_id": TEST_TABLE_ID,
-        "delegate_to": TEST_DELEGATE_TO,
-        "impersonation_chain": TEST_IMPERSONATION_CHAIN,
-        "poll_interval": POLLING_PERIOD_SECONDS,
-    }
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_insert_job_op_trigger_success(mock_job_status):
-    """
-    Tests the BigQueryInsertJobTrigger only fires once the query execution reaches a successful state.
-    """
-    mock_job_status.return_value = "success"
-
-    trigger = BigQueryInsertJobTrigger(
-        TEST_CONN_ID,
-        TEST_JOB_ID,
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        POLLING_PERIOD_SECONDS,
-    )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent({"status": "success", "message": "Job completed", "job_id": TEST_JOB_ID}) == actual
-
-
-@pytest.mark.parametrize(
-    "trigger_class",
-    [BigQueryInsertJobTrigger, BigQueryGetDataTrigger, BigQueryCheckTrigger],
-)
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_op_trigger_running(mock_job_status, caplog, trigger_class):
-    """
-    Test that BigQuery Triggers do not fire while a query is still running.
-    """
-    mock_job_status.return_value = "pending"
-    caplog.set_level(logging.INFO)
-
-    trigger = trigger_class(
-        conn_id=TEST_CONN_ID,
-        job_id=TEST_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-        dataset_id=TEST_DATASET_ID,
-        table_id=TEST_TABLE_ID,
-        poll_interval=POLLING_PERIOD_SECONDS,
-    )
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-
-    assert f"Using the connection  {TEST_CONN_ID} ." in caplog.text
-
-    assert "Query is still running..." in caplog.text
-    assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
-
-    # Prevents error when task is destroyed while in "pending" state
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.parametrize(
-    "trigger_class",
-    [BigQueryInsertJobTrigger, BigQueryGetDataTrigger, BigQueryCheckTrigger],
-)
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_op_trigger_terminated(mock_job_status, trigger_class):
-    """
-    Test that BigQuery Triggers fire the correct event in case of an error.
-    """
-    # Set the status to a value other than success or pending
-    mock_job_status.return_value = "error"
-
-    trigger = trigger_class(
+class TestBigQueryInsertJobTrigger:
+    TRIGGER = BigQueryInsertJobTrigger(
         conn_id=TEST_CONN_ID,
         job_id=TEST_JOB_ID,
         project_id=TEST_GCP_PROJECT_ID,
@@ -153,470 +51,447 @@ async def test_bigquery_op_trigger_terminated(mock_job_status, trigger_class):
         poll_interval=POLLING_PERIOD_SECONDS,
     )
 
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent({"status": "error", "message": "error"}) == actual
+    def test_bigquery_insert_job_op_trigger_serialization(self):
+        """Asserts that the BigQueryInsertJobTrigger correctly serializes its arguments and classpath."""
 
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryInsertJobTrigger"
+        assert kwargs == {
+            "conn_id": TEST_CONN_ID,
+            "job_id": TEST_JOB_ID,
+            "project_id": TEST_GCP_PROJECT_ID,
+            "dataset_id": TEST_DATASET_ID,
+            "table_id": TEST_TABLE_ID,
+            "delegate_to": TEST_DELEGATE_TO,
+            "impersonation_chain": TEST_IMPERSONATION_CHAIN,
+            "poll_interval": POLLING_PERIOD_SECONDS,
+        }
 
-@pytest.mark.parametrize(
-    "trigger_class",
-    [BigQueryInsertJobTrigger, BigQueryGetDataTrigger, BigQueryCheckTrigger],
-)
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_op_trigger_exception(mock_job_status, caplog, trigger_class):
-    """
-    Test that BigQuery Triggers fire the correct event in case of an error.
-    """
-    mock_job_status.side_effect = Exception("Test exception")
-    caplog.set_level(logging.DEBUG)
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_insert_job_op_trigger_success(self, mock_job_status):
+        """
+        Tests the BigQueryInsertJobTrigger only fires once the query execution reaches a successful state.
+        """
+        mock_job_status.return_value = "success"
 
-    trigger = trigger_class(
-        conn_id=TEST_CONN_ID,
-        job_id=TEST_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-        dataset_id=TEST_DATASET_ID,
-        table_id=TEST_TABLE_ID,
-        poll_interval=POLLING_PERIOD_SECONDS,
-    )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) == actual
-
-
-def test_bigquery_check_op_trigger_serialization():
-    """
-    Asserts that the BigQueryCheckTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = BigQueryCheckTrigger(
-        conn_id=TEST_CONN_ID,
-        job_id=TEST_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-        dataset_id=TEST_DATASET_ID,
-        table_id=TEST_TABLE_ID,
-        impersonation_chain=TEST_IMPERSONATION_CHAIN,
-        poll_interval=POLLING_PERIOD_SECONDS,
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryCheckTrigger"
-    assert kwargs == {
-        "conn_id": TEST_CONN_ID,
-        "job_id": TEST_JOB_ID,
-        "dataset_id": TEST_DATASET_ID,
-        "project_id": TEST_GCP_PROJECT_ID,
-        "table_id": TEST_TABLE_ID,
-        "impersonation_chain": TEST_IMPERSONATION_CHAIN,
-        "poll_interval": POLLING_PERIOD_SECONDS,
-    }
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_output")
-async def test_bigquery_check_op_trigger_success_with_data(mock_job_output, mock_job_status):
-    """
-    Test the BigQueryCheckTrigger only fires once the query execution reaches a successful state.
-    """
-    mock_job_status.return_value = "success"
-    mock_job_output.return_value = {
-        "kind": "bigquery#getQueryResultsResponse",
-        "etag": "test_etag",
-        "schema": {"fields": [{"name": "f0_", "type": "INTEGER", "mode": "NULLABLE"}]},
-        "jobReference": {
-            "projectId": "test_astronomer-airflow-providers",
-            "jobId": "test_jobid",
-            "location": "US",
-        },
-        "totalRows": "1",
-        "rows": [{"f": [{"v": "22"}]}],
-        "totalBytesProcessed": "0",
-        "jobComplete": True,
-        "cacheHit": False,
-    }
-
-    trigger = BigQueryCheckTrigger(
-        TEST_CONN_ID,
-        TEST_JOB_ID,
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        POLLING_PERIOD_SECONDS,
-    )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-
-    assert TriggerEvent({"status": "success", "records": [22]}) == actual
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_output")
-async def test_bigquery_check_op_trigger_success_without_data(mock_job_output, mock_job_status):
-    """
-    Tests that BigQueryCheckTrigger sends TriggerEvent as  { "status": "success", "records": None}
-    when no rows are available in the query result.
-    """
-    mock_job_status.return_value = "success"
-    mock_job_output.return_value = {
-        "kind": "bigquery#getQueryResultsResponse",
-        "etag": "test_etag",
-        "schema": {
-            "fields": [
-                {"name": "value", "type": "INTEGER", "mode": "NULLABLE"},
-                {"name": "name", "type": "STRING", "mode": "NULLABLE"},
-                {"name": "ds", "type": "DATE", "mode": "NULLABLE"},
-            ]
-        },
-        "jobReference": {
-            "projectId": "test_astronomer-airflow-providers",
-            "jobId": "test_jobid",
-            "location": "US",
-        },
-        "totalRows": "0",
-        "totalBytesProcessed": "0",
-        "jobComplete": True,
-        "cacheHit": False,
-    }
-
-    trigger = BigQueryCheckTrigger(
-        TEST_CONN_ID,
-        TEST_JOB_ID,
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        POLLING_PERIOD_SECONDS,
-    )
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent({"status": "success", "records": None}) == actual
-
-
-def test_bigquery_get_data_trigger_serialization():
-    """
-    Asserts that the BigQueryGetDataTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = BigQueryGetDataTrigger(
-        conn_id=TEST_CONN_ID,
-        job_id=TEST_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-        dataset_id=TEST_DATASET_ID,
-        table_id=TEST_TABLE_ID,
-        delegate_to=TEST_DELEGATE_TO,
-        impersonation_chain=TEST_IMPERSONATION_CHAIN,
-        poll_interval=POLLING_PERIOD_SECONDS,
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryGetDataTrigger"
-    assert kwargs == {
-        "conn_id": TEST_CONN_ID,
-        "job_id": TEST_JOB_ID,
-        "dataset_id": TEST_DATASET_ID,
-        "project_id": TEST_GCP_PROJECT_ID,
-        "table_id": TEST_TABLE_ID,
-        "delegate_to": TEST_DELEGATE_TO,
-        "impersonation_chain": TEST_IMPERSONATION_CHAIN,
-        "poll_interval": POLLING_PERIOD_SECONDS,
-    }
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_output")
-async def test_bigquery_get_data_trigger_success_with_data(mock_job_output, mock_job_status):
-    """
-    Tests that BigQueryGetDataTrigger only fires once the query execution reaches a successful state.
-    """
-    mock_job_status.return_value = "success"
-    mock_job_output.return_value = {
-        "kind": "bigquery#tableDataList",
-        "etag": "test_etag",
-        "schema": {
-            "fields": [
-                {"name": "f0_", "type": "INTEGER", "mode": "NULLABLE"},
-                {"name": "f1_", "type": "STRING", "mode": "NULLABLE"},
-            ]
-        },
-        "jobReference": {
-            "projectId": "test-airflow-providers",
-            "jobId": "test_jobid",
-            "location": "US",
-        },
-        "totalRows": "10",
-        "rows": [{"f": [{"v": "42"}, {"v": "monthy python"}]}, {"f": [{"v": "42"}, {"v": "fishy fish"}]}],
-        "totalBytesProcessed": "0",
-        "jobComplete": True,
-        "cacheHit": False,
-    }
-
-    trigger = BigQueryGetDataTrigger(
-        TEST_CONN_ID,
-        TEST_JOB_ID,
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        POLLING_PERIOD_SECONDS,
-    )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    # # The extracted row will be parsed and formatted to retrieve the value from the
-    # # structure - 'rows":[{"f":[{"v":"42"},{"v":"monthy python"}]},{"f":[{"v":"42"},{"v":"fishy fish"}]}]
-
-    assert (
-        TriggerEvent(
-            {
-                "status": "success",
-                "message": "success",
-                "records": [[42, "monthy python"], [42, "fishy fish"]],
-            }
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert (
+            TriggerEvent({"status": "success", "message": "Job completed", "job_id": TEST_JOB_ID}) == actual
         )
-        == actual
-    )
-    # Prevents error when task is destroyed while in "pending" state
-    asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_op_trigger_terminated(self, mock_job_status):
+        """Test that BigQuery Triggers fire the correct event in case of an error."""
+        # Set the status to a value other than success or pending
+        mock_job_status.return_value = "error"
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "error", "message": "error"}) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_op_trigger_exception(self, mock_job_status, caplog):
+        """Test that BigQuery Triggers fire the correct event in case of an error."""
+        mock_job_status.side_effect = Exception("Test exception")
+        caplog.set_level(logging.DEBUG)
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_op_trigger_running(self, mock_job_status, caplog):
+        """Test that BigQuery Triggers do not fire while a query is still running."""
+        mock_job_status.return_value = "pending"
+        caplog.set_level(logging.INFO)
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+
+        assert "Query is still running..." in caplog.text
+        assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
+
+        # Prevents error when task is destroyed while in "pending" state
+        asyncio.get_event_loop().stop()
 
 
-def test_bigquery_interval_check_trigger_serialization():
-    """
-    Asserts that the BigQueryIntervalCheckTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = BigQueryIntervalCheckTrigger(
-        TEST_CONN_ID,
-        TEST_FIRST_JOB_ID,
-        TEST_SECOND_JOB_ID,
-        TEST_GCP_PROJECT_ID,
-        TEST_TABLE_ID,
-        TEST_METRIC_THRESHOLDS,
-        TEST_DATE_FILTER_COLUMN,
-        TEST_DAYS_BACK,
-        TEST_RATIO_FORMULA,
-        TEST_IGNORE_ZERO,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_IMPERSONATION_CHAIN,
-        POLLING_PERIOD_SECONDS,
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryIntervalCheckTrigger"
-    assert kwargs == {
-        "conn_id": TEST_CONN_ID,
-        "first_job_id": TEST_FIRST_JOB_ID,
-        "second_job_id": TEST_SECOND_JOB_ID,
-        "project_id": TEST_GCP_PROJECT_ID,
-        "table": TEST_TABLE_ID,
-        "metrics_thresholds": TEST_METRIC_THRESHOLDS,
-        "date_filter_column": TEST_DATE_FILTER_COLUMN,
-        "days_back": TEST_DAYS_BACK,
-        "ratio_formula": TEST_RATIO_FORMULA,
-        "ignore_zero": TEST_IGNORE_ZERO,
-    }
-
-
-@pytest.mark.parametrize(
-    "get_output_value",
-    ["0", "1"],
-)
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_output")
-async def test_bigquery_interval_check_trigger_success(
-    mock_get_job_output, mock_job_status, get_output_value
-):
-    """
-    Tests the BigQueryIntervalCheckTrigger only fires once the query execution reaches a successful state.
-    """
-    mock_job_status.return_value = "success"
-    mock_get_job_output.return_value = get_output_value
-
-    trigger = BigQueryIntervalCheckTrigger(
+class TestBigQueryCheckTrigger:
+    TRIGGER = BigQueryCheckTrigger(
         conn_id=TEST_CONN_ID,
-        first_job_id=TEST_FIRST_JOB_ID,
-        second_job_id=TEST_SECOND_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-        table=TEST_TABLE_ID,
-        metrics_thresholds=TEST_METRIC_THRESHOLDS,
-        date_filter_column=TEST_DATE_FILTER_COLUMN,
-        days_back=TEST_DAYS_BACK,
-        ratio_formula=TEST_RATIO_FORMULA,
-        ignore_zero=TEST_IGNORE_ZERO,
-        dataset_id=TEST_DATASET_ID,
-        table_id=TEST_TABLE_ID,
-        poll_interval=POLLING_PERIOD_SECONDS,
-    )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert actual == TriggerEvent({"status": "error", "message": "The second SQL query returned None"})
-
-
-@pytest.mark.parametrize(
-    "trigger_class",
-    [BigQueryIntervalCheckTrigger],
-)
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_interval_check_trigger_pending(mock_job_status, caplog, trigger_class):
-    """
-    Tests that the BigQueryIntervalCheckTrigger do not fire while a query is still running.
-    """
-    mock_job_status.return_value = "pending"
-    caplog.set_level(logging.INFO)
-
-    trigger = trigger_class(
-        conn_id=TEST_CONN_ID,
-        first_job_id=TEST_FIRST_JOB_ID,
-        second_job_id=TEST_SECOND_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-        table=TEST_TABLE_ID,
-        metrics_thresholds=TEST_METRIC_THRESHOLDS,
-        date_filter_column=TEST_DATE_FILTER_COLUMN,
-        days_back=TEST_DAYS_BACK,
-        ratio_formula=TEST_RATIO_FORMULA,
-        ignore_zero=TEST_IGNORE_ZERO,
-        dataset_id=TEST_DATASET_ID,
-        table_id=TEST_TABLE_ID,
-        poll_interval=POLLING_PERIOD_SECONDS,
-    )
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-
-    assert f"Using the connection  {TEST_CONN_ID} ." in caplog.text
-
-    assert "Query is still running..." in caplog.text
-    assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
-
-    # Prevents error when task is destroyed while in "pending" state
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.parametrize(
-    "trigger_class",
-    [BigQueryIntervalCheckTrigger],
-)
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_interval_check_trigger_terminated(mock_job_status, trigger_class):
-    """
-    Tests the BigQueryIntervalCheckTrigger fires the correct event in case of an error.
-    """
-    # Set the status to a value other than success or pending
-    mock_job_status.return_value = "error"
-    trigger = trigger_class(
-        conn_id=TEST_CONN_ID,
-        first_job_id=TEST_FIRST_JOB_ID,
-        second_job_id=TEST_SECOND_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-        table=TEST_TABLE_ID,
-        metrics_thresholds=TEST_METRIC_THRESHOLDS,
-        date_filter_column=TEST_DATE_FILTER_COLUMN,
-        days_back=TEST_DAYS_BACK,
-        ratio_formula=TEST_RATIO_FORMULA,
-        ignore_zero=TEST_IGNORE_ZERO,
-        dataset_id=TEST_DATASET_ID,
-        table_id=TEST_TABLE_ID,
-        poll_interval=POLLING_PERIOD_SECONDS,
-    )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-
-    assert TriggerEvent({"status": "error", "message": "error", "data": None}) == actual
-
-
-@pytest.mark.parametrize(
-    "trigger_class",
-    [BigQueryIntervalCheckTrigger],
-)
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_interval_check_trigger_exception(mock_job_status, caplog, trigger_class):
-    """
-    Tests that the BigQueryIntervalCheckTrigger fires the correct event in case of an error.
-    """
-    mock_job_status.side_effect = Exception("Test exception")
-    caplog.set_level(logging.DEBUG)
-
-    trigger = trigger_class(
-        conn_id=TEST_CONN_ID,
-        first_job_id=TEST_FIRST_JOB_ID,
-        second_job_id=TEST_SECOND_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-        table=TEST_TABLE_ID,
-        metrics_thresholds=TEST_METRIC_THRESHOLDS,
-        date_filter_column=TEST_DATE_FILTER_COLUMN,
-        days_back=TEST_DAYS_BACK,
-        ratio_formula=TEST_RATIO_FORMULA,
-        ignore_zero=TEST_IGNORE_ZERO,
-        dataset_id=TEST_DATASET_ID,
-        table_id=TEST_TABLE_ID,
-        poll_interval=POLLING_PERIOD_SECONDS,
-    )
-
-    # trigger event is yielded so it creates a generator object
-    # so i have used async for to get all the values and added it to task
-    task = [i async for i in trigger.run()]
-    # since we use return as soon as we yield the trigger event
-    # at any given point there should be one trigger event returned to the task
-    # so we validate for length of task to be 1
-
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
-
-
-def test_bigquery_value_check_op_trigger_serialization():
-    """
-    Asserts that the BigQueryValueCheckTrigger correctly serializes its arguments
-    and classpath.
-    """
-
-    trigger = BigQueryValueCheckTrigger(
-        conn_id=TEST_CONN_ID,
-        pass_value=TEST_PASS_VALUE,
         job_id=TEST_JOB_ID,
-        dataset_id=TEST_DATASET_ID,
         project_id=TEST_GCP_PROJECT_ID,
-        sql=TEST_SQL_QUERY,
+        dataset_id=TEST_DATASET_ID,
         table_id=TEST_TABLE_ID,
-        tolerance=TEST_TOLERANCE,
         poll_interval=POLLING_PERIOD_SECONDS,
     )
-    classpath, kwargs = trigger.serialize()
 
-    assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryValueCheckTrigger"
-    assert kwargs == {
-        "conn_id": TEST_CONN_ID,
-        "pass_value": TEST_PASS_VALUE,
-        "job_id": TEST_JOB_ID,
-        "dataset_id": TEST_DATASET_ID,
-        "project_id": TEST_GCP_PROJECT_ID,
-        "sql": TEST_SQL_QUERY,
-        "table_id": TEST_TABLE_ID,
-        "tolerance": TEST_TOLERANCE,
-        "poll_interval": POLLING_PERIOD_SECONDS,
-    }
+    def test_bigquery_check_op_trigger_serialization(self):
+        """
+        Asserts that the BigQueryCheckTrigger correctly serializes its arguments and classpath.
+        """
+
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryCheckTrigger"
+        assert kwargs == {
+            "conn_id": TEST_CONN_ID,
+            "job_id": TEST_JOB_ID,
+            "dataset_id": TEST_DATASET_ID,
+            "project_id": TEST_GCP_PROJECT_ID,
+            "table_id": TEST_TABLE_ID,
+            "impersonation_chain": TEST_IMPERSONATION_CHAIN,
+            "poll_interval": POLLING_PERIOD_SECONDS,
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_output")
+    async def test_bigquery_check_op_trigger_success_with_data(self, mock_job_output, mock_job_status):
+        """
+        Test the BigQueryCheckTrigger only fires once the query execution reaches a successful state.
+        """
+        mock_job_status.return_value = "success"
+        mock_job_output.return_value = {
+            "kind": "bigquery#getQueryResultsResponse",
+            "etag": "test_etag",
+            "schema": {"fields": [{"name": "f0_", "type": "INTEGER", "mode": "NULLABLE"}]},
+            "jobReference": {
+                "projectId": "test_astronomer-airflow-providers",
+                "jobId": "test_jobid",
+                "location": "US",
+            },
+            "totalRows": "1",
+            "rows": [{"f": [{"v": "22"}]}],
+            "totalBytesProcessed": "0",
+            "jobComplete": True,
+            "cacheHit": False,
+        }
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+
+        assert TriggerEvent({"status": "success", "records": [22]}) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_output")
+    async def test_bigquery_check_op_trigger_success_without_data(self, mock_job_output, mock_job_status):
+        """
+        Tests that BigQueryCheckTrigger sends TriggerEvent as  { "status": "success", "records": None}
+        when no rows are available in the query result.
+        """
+        mock_job_status.return_value = "success"
+        mock_job_output.return_value = {
+            "kind": "bigquery#getQueryResultsResponse",
+            "etag": "test_etag",
+            "schema": {
+                "fields": [
+                    {"name": "value", "type": "INTEGER", "mode": "NULLABLE"},
+                    {"name": "name", "type": "STRING", "mode": "NULLABLE"},
+                    {"name": "ds", "type": "DATE", "mode": "NULLABLE"},
+                ]
+            },
+            "jobReference": {
+                "projectId": "test_astronomer-airflow-providers",
+                "jobId": "test_jobid",
+                "location": "US",
+            },
+            "totalRows": "0",
+            "totalBytesProcessed": "0",
+            "jobComplete": True,
+            "cacheHit": False,
+        }
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "success", "records": None}) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_op_trigger_terminated(self, mock_job_status):
+        """Test that BigQuery Triggers fire the correct event in case of an error."""
+        # Set the status to a value other than success or pending
+        mock_job_status.return_value = "error"
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "error", "message": "error"}) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_op_trigger_exception(self, mock_job_status, caplog):
+        """Test that BigQuery Triggers fire the correct event in case of an error."""
+        mock_job_status.side_effect = Exception("Test exception")
+        caplog.set_level(logging.DEBUG)
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_op_trigger_running(self, mock_job_status, caplog):
+        """Test that BigQuery Triggers do not fire while a query is still running."""
+        mock_job_status.return_value = "pending"
+        caplog.set_level(logging.INFO)
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+
+        assert "Query is still running..." in caplog.text
+        assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
+
+        # Prevents error when task is destroyed while in "pending" state
+        asyncio.get_event_loop().stop()
 
 
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_records")
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_output")
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_value_check_op_trigger_success(mock_job_status, get_job_output, get_records):
-    """
-    Tests that the BigQueryValueCheckTrigger only fires once the query execution reaches a successful state.
-    """
-    mock_job_status.return_value = "success"
-    get_job_output.return_value = {}
-    get_records.return_value = [[2], [4]]
+class TestBigQueryGetDataTrigger:
+    TRIGGER = BigQueryGetDataTrigger(
+        conn_id=TEST_CONN_ID,
+        job_id=TEST_JOB_ID,
+        project_id=TEST_GCP_PROJECT_ID,
+        dataset_id=TEST_DATASET_ID,
+        table_id=TEST_TABLE_ID,
+        poll_interval=POLLING_PERIOD_SECONDS,
+    )
 
-    trigger = BigQueryValueCheckTrigger(
+    def test_bigquery_get_data_trigger_serialization(self):
+        """
+        Asserts that the BigQueryGetDataTrigger correctly serializes its arguments and classpath.
+        """
+
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryGetDataTrigger"
+        assert kwargs == {
+            "conn_id": TEST_CONN_ID,
+            "job_id": TEST_JOB_ID,
+            "dataset_id": TEST_DATASET_ID,
+            "project_id": TEST_GCP_PROJECT_ID,
+            "table_id": TEST_TABLE_ID,
+            "delegate_to": TEST_DELEGATE_TO,
+            "impersonation_chain": TEST_IMPERSONATION_CHAIN,
+            "poll_interval": POLLING_PERIOD_SECONDS,
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_output")
+    async def test_bigquery_get_data_trigger_success_with_data(self, mock_job_output, mock_job_status):
+        """
+        Tests that BigQueryGetDataTrigger only fires once the query execution reaches a successful state.
+        """
+        mock_job_status.return_value = "success"
+        mock_job_output.return_value = {
+            "kind": "bigquery#tableDataList",
+            "etag": "test_etag",
+            "schema": {
+                "fields": [
+                    {"name": "f0_", "type": "INTEGER", "mode": "NULLABLE"},
+                    {"name": "f1_", "type": "STRING", "mode": "NULLABLE"},
+                ]
+            },
+            "jobReference": {
+                "projectId": "test-airflow-providers",
+                "jobId": "test_jobid",
+                "location": "US",
+            },
+            "totalRows": "10",
+            "rows": [{"f": [{"v": "42"}, {"v": "monthy python"}]}, {"f": [{"v": "42"}, {"v": "fishy fish"}]}],
+            "totalBytesProcessed": "0",
+            "jobComplete": True,
+            "cacheHit": False,
+        }
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        # # The extracted row will be parsed and formatted to retrieve the value from the
+        # # structure - 'rows":[{"f":[{"v":"42"},{"v":"monthy python"}]},{"f":[{"v":"42"},{"v":"fishy fish"}]}]
+
+        assert (
+            TriggerEvent(
+                {
+                    "status": "success",
+                    "message": "success",
+                    "records": [[42, "monthy python"], [42, "fishy fish"]],
+                }
+            )
+            == actual
+        )
+        # Prevents error when task is destroyed while in "pending" state
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_op_trigger_terminated(self, mock_job_status):
+        """
+        Test that BigQuery Triggers fire the correct event in case of an error.
+        """
+        # Set the status to a value other than success or pending
+        mock_job_status.return_value = "error"
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "error", "message": "error"}) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_op_trigger_exception(self, mock_job_status, caplog):
+        """
+        Test that BigQuery Triggers fire the correct event in case of an error.
+        """
+        mock_job_status.side_effect = Exception("Test exception")
+        caplog.set_level(logging.DEBUG)
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_op_trigger_running(self, mock_job_status, caplog):
+        """
+        Test that BigQuery Triggers do not fire while a query is still running.
+        """
+        mock_job_status.return_value = "pending"
+        caplog.set_level(logging.INFO)
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+
+        assert "Query is still running..." in caplog.text
+        assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
+
+        # Prevents error when task is destroyed while in "pending" state
+        asyncio.get_event_loop().stop()
+
+
+class TestBigQueryIntervalCheckTrigger:
+    TRIGGER = BigQueryIntervalCheckTrigger(
+        conn_id=TEST_CONN_ID,
+        first_job_id=TEST_FIRST_JOB_ID,
+        second_job_id=TEST_SECOND_JOB_ID,
+        project_id=TEST_GCP_PROJECT_ID,
+        table=TEST_TABLE_ID,
+        metrics_thresholds=TEST_METRIC_THRESHOLDS,
+        date_filter_column=TEST_DATE_FILTER_COLUMN,
+        days_back=TEST_DAYS_BACK,
+        ratio_formula=TEST_RATIO_FORMULA,
+        ignore_zero=TEST_IGNORE_ZERO,
+        dataset_id=TEST_DATASET_ID,
+        table_id=TEST_TABLE_ID,
+        poll_interval=POLLING_PERIOD_SECONDS,
+    )
+
+    def test_bigquery_interval_check_trigger_serialization(self):
+        """
+        Asserts that the BigQueryIntervalCheckTrigger correctly serializes its arguments and classpath.
+        """
+
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryIntervalCheckTrigger"
+        assert kwargs == {
+            "conn_id": TEST_CONN_ID,
+            "first_job_id": TEST_FIRST_JOB_ID,
+            "second_job_id": TEST_SECOND_JOB_ID,
+            "project_id": TEST_GCP_PROJECT_ID,
+            "table": TEST_TABLE_ID,
+            "metrics_thresholds": TEST_METRIC_THRESHOLDS,
+            "date_filter_column": TEST_DATE_FILTER_COLUMN,
+            "days_back": TEST_DAYS_BACK,
+            "ratio_formula": TEST_RATIO_FORMULA,
+            "ignore_zero": TEST_IGNORE_ZERO,
+        }
+
+    @pytest.mark.parametrize(
+        "get_output_value",
+        ["0", "1"],
+    )
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_output")
+    async def test_bigquery_interval_check_trigger_success(
+        self, mock_get_job_output, mock_job_status, get_output_value
+    ):
+        """
+        Tests the BigQueryIntervalCheckTrigger only fires once the query execution reaches a successful state.
+        """
+        mock_job_status.return_value = "success"
+        mock_get_job_output.return_value = get_output_value
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert actual == TriggerEvent({"status": "error", "message": "The second SQL query returned None"})
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_interval_check_trigger_pending(self, mock_job_status, caplog):
+        """
+        Tests that the BigQueryIntervalCheckTrigger do not fire while a query is still running.
+        """
+        mock_job_status.return_value = "pending"
+        caplog.set_level(logging.INFO)
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+
+        assert "Query is still running..." in caplog.text
+        assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
+
+        # Prevents error when task is destroyed while in "pending" state
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_interval_check_trigger_terminated(self, mock_job_status):
+        """
+        Tests the BigQueryIntervalCheckTrigger fires the correct event in case of an error.
+        """
+        # Set the status to a value other than success or pending
+        mock_job_status.return_value = "error"
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+
+        assert TriggerEvent({"status": "error", "message": "error", "data": None}) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_interval_check_trigger_exception(self, mock_job_status, caplog):
+        """
+        Tests that the BigQueryIntervalCheckTrigger fires the correct event in case of an error.
+        """
+        mock_job_status.side_effect = Exception("Test exception")
+        caplog.set_level(logging.DEBUG)
+
+        # trigger event is yielded so it creates a generator object
+        # so i have used async for to get all the values and added it to task
+        task = [i async for i in self.TRIGGER.run()]
+        # since we use return as soon as we yield the trigger event
+        # at any given point there should be one trigger event returned to the task
+        # so we validate for length of task to be 1
+
+        assert len(task) == 1
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+
+
+class TestBigQueryValueCheckTrigger:
+    TRIGGER = BigQueryValueCheckTrigger(
         conn_id=TEST_CONN_ID,
         pass_value=TEST_PASS_VALUE,
         job_id=TEST_JOB_ID,
@@ -628,273 +503,222 @@ async def test_bigquery_value_check_op_trigger_success(mock_job_status, get_job_
         poll_interval=POLLING_PERIOD_SECONDS,
     )
 
-    asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
+    def test_bigquery_value_check_op_trigger_serialization(self):
+        """
+        Asserts that the BigQueryValueCheckTrigger correctly serializes its arguments and classpath.
+        """
 
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert actual == TriggerEvent({"status": "success", "message": "Job completed", "records": [4]})
+        classpath, kwargs = self.TRIGGER.serialize()
 
+        assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryValueCheckTrigger"
+        assert kwargs == {
+            "conn_id": TEST_CONN_ID,
+            "pass_value": TEST_PASS_VALUE,
+            "job_id": TEST_JOB_ID,
+            "dataset_id": TEST_DATASET_ID,
+            "project_id": TEST_GCP_PROJECT_ID,
+            "sql": TEST_SQL_QUERY,
+            "table_id": TEST_TABLE_ID,
+            "tolerance": TEST_TOLERANCE,
+            "poll_interval": POLLING_PERIOD_SECONDS,
+        }
 
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_value_check_op_trigger_pending(mock_job_status, caplog):
-    """
-    Tests that the BigQueryValueCheckTrigger only fires once the query execution reaches a successful state.
-    """
-    mock_job_status.return_value = "pending"
-    caplog.set_level(logging.INFO)
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_records")
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_output")
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_value_check_op_trigger_success(
+        self, mock_job_status, get_job_output, get_records
+    ):
+        """
+        Tests that the BigQueryValueCheckTrigger only fires once the query execution reaches a successful state.
+        """
+        mock_job_status.return_value = "success"
+        get_job_output.return_value = {}
+        get_records.return_value = [[2], [4]]
 
-    trigger = BigQueryValueCheckTrigger(
-        TEST_CONN_ID,
-        TEST_PASS_VALUE,
-        TEST_JOB_ID,
-        TEST_DATASET_ID,
-        TEST_GCP_PROJECT_ID,
-        TEST_SQL_QUERY,
-        TEST_TABLE_ID,
-        TEST_TOLERANCE,
-        POLLING_PERIOD_SECONDS,
-    )
+        asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
 
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert actual == TriggerEvent({"status": "success", "message": "Job completed", "records": [4]})
 
-    # TriggerEvent was returned
-    assert task.done() is False
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_value_check_op_trigger_pending(self, mock_job_status, caplog):
+        """
+        Tests that the BigQueryValueCheckTrigger only fires once the query execution reaches a successful state.
+        """
+        mock_job_status.return_value = "pending"
+        caplog.set_level(logging.INFO)
 
-    assert "Query is still running..." in caplog.text
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
 
-    assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
+        # TriggerEvent was returned
+        assert task.done() is False
 
-    # Prevents error when task is destroyed while in "pending" state
-    asyncio.get_event_loop().stop()
+        assert "Query is still running..." in caplog.text
+        assert f"Sleeping for {POLLING_PERIOD_SECONDS} seconds." in caplog.text
 
+        # Prevents error when task is destroyed while in "pending" state
+        asyncio.get_event_loop().stop()
 
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_value_check_op_trigger_fail(mock_job_status):
-    """
-    Tests that the BigQueryValueCheckTrigger only fires once the query execution reaches a successful state.
-    """
-    mock_job_status.return_value = "dummy"
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_value_check_op_trigger_fail(self, mock_job_status):
+        """
+        Tests that the BigQueryValueCheckTrigger only fires once the query execution reaches a successful state.
+        """
+        mock_job_status.return_value = "dummy"
 
-    trigger = BigQueryValueCheckTrigger(
-        TEST_CONN_ID,
-        TEST_PASS_VALUE,
-        TEST_JOB_ID,
-        TEST_DATASET_ID,
-        TEST_GCP_PROJECT_ID,
-        TEST_SQL_QUERY,
-        TEST_TABLE_ID,
-        TEST_TOLERANCE,
-        POLLING_PERIOD_SECONDS,
-    )
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "error", "message": "dummy", "records": None}) == actual
 
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent({"status": "error", "message": "dummy", "records": None}) == actual
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
+    async def test_bigquery_value_check_trigger_exception(self, mock_job_status):
+        """Tests the BigQueryValueCheckTrigger does not fire if there is an exception."""
+        mock_job_status.side_effect = Exception("Test exception")
 
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryHookAsync.get_job_status")
-async def test_bigquery_value_check_trigger_exception(mock_job_status):
-    """
-    Tests the BigQueryValueCheckTrigger does not fire if there is an exception.
-    """
-    mock_job_status.side_effect = Exception("Test exception")
-
-    trigger = BigQueryValueCheckTrigger(
-        conn_id=TEST_CONN_ID,
-        sql=TEST_SQL_QUERY,
-        pass_value=TEST_PASS_VALUE,
-        tolerance=1,
-        job_id=TEST_JOB_ID,
-        project_id=TEST_GCP_PROJECT_ID,
-    )
-
-    # trigger event is yielded so it creates a generator object
-    # so i have used async for to get all the values and added it to task
-    task = [i async for i in trigger.run()]
-    # since we use return as soon as we yield the trigger event
-    # at any given point there should be one trigger event returned to the task
-    # so we validate for length of task to be 1
-
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
-
-
-def test_big_query_table_existence_trigger_serialization():
-    """
-    Asserts that the BigQueryTableExistenceTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = BigQueryTableExistenceTrigger(
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        POLLING_PERIOD_SECONDS,
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger"
-    assert kwargs == {
-        "dataset_id": TEST_DATASET_ID,
-        "project_id": TEST_GCP_PROJECT_ID,
-        "table_id": TEST_TABLE_ID,
-        "gcp_conn_id": TEST_GCP_CONN_ID,
-        "poke_interval": POLLING_PERIOD_SECONDS,
-        "hook_params": TEST_HOOK_PARAMS,
-    }
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists")
-async def test_big_query_table_existence_trigger_success(mock_table_exists):
-    """
-    Tests success case BigQueryTableExistenceTrigger
-    """
-    mock_table_exists.return_value = True
-
-    trigger = BigQueryTableExistenceTrigger(
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        POLLING_PERIOD_SECONDS,
-    )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent({"status": "success", "message": "success"}) == actual
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists")
-async def test_big_query_table_existence_trigger_pending(mock_table_exists):
-    """
-    Test that BigQueryTableExistenceTrigger is in loop till the table exist.
-    """
-    mock_table_exists.return_value = False
-
-    trigger = BigQueryTableExistenceTrigger(
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        POLLING_PERIOD_SECONDS,
-    )
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists")
-async def test_big_query_table_existence_trigger_exception(mock_table_exists):
-    """
-    Test BigQueryTableExistenceTrigger throws exception if any error.
-    """
-    mock_table_exists.side_effect = mock.AsyncMock(side_effect=Exception("Test exception"))
-
-    trigger = BigQueryTableExistenceTrigger(
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        POLLING_PERIOD_SECONDS,
-    )
-    task = [i async for i in trigger.run()]
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "mock_get_table_client_value, expected_value",
-    [
-        (
-            Table,
-            True,
+        trigger = BigQueryValueCheckTrigger(
+            conn_id=TEST_CONN_ID,
+            sql=TEST_SQL_QUERY,
+            pass_value=TEST_PASS_VALUE,
+            tolerance=1,
+            job_id=TEST_JOB_ID,
+            project_id=TEST_GCP_PROJECT_ID,
         )
-    ],
-)
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryTableHookAsync.get_table_client")
-async def test_table_exists(mock_get_table_client, mock_get_table_client_value, expected_value):
-    """Test BigQueryTableExistenceTrigger._table_exists async function with mocked value and mocked return value"""
-    hook = mock.AsyncMock(BigQueryTableHookAsync)
-    mock_get_table_client.return_value = mock_get_table_client_value
-    trigger = BigQueryTableExistenceTrigger(
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        POLLING_PERIOD_SECONDS,
-    )
-    res = await trigger._table_exists(hook, TEST_DATASET_ID, TEST_TABLE_ID, TEST_GCP_PROJECT_ID)
-    assert res == expected_value
+
+        # trigger event is yielded so it creates a generator object
+        # so i have used async for to get all the values and added it to task
+        task = [i async for i in trigger.run()]
+        # since we use return as soon as we yield the trigger event
+        # at any given point there should be one trigger event returned to the task
+        # so we validate for length of task to be 1
+
+        assert len(task) == 1
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
 
 
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryTableHookAsync.get_table_client")
-async def test_table_exists_exception(mock_get_table_client):
-    """Test BigQueryTableExistenceTrigger._table_exists async function with exception and return False"""
-    hook = BigQueryTableHookAsync()
-    mock_get_table_client.side_effect = ClientResponseError(
-        history=(),
-        request_info=RequestInfo(
-            headers=CIMultiDict(),
-            real_url=URL("https://example.com"),
-            method="GET",
-            url=URL("https://example.com"),
-        ),
-        status=404,
-        message="Not Found",
+class TestBigQueryTableExistenceTrigger:
+    TRIGGER = BigQueryTableExistenceTrigger(
+        project_id=TEST_GCP_PROJECT_ID,
+        dataset_id=TEST_DATASET_ID,
+        table_id=TEST_TABLE_ID,
+        gcp_conn_id=TEST_GCP_CONN_ID,
+        hook_params=TEST_HOOK_PARAMS,
+        poke_interval=POLLING_PERIOD_SECONDS,
     )
-    trigger = BigQueryTableExistenceTrigger(
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        POLLING_PERIOD_SECONDS,
-    )
-    res = await trigger._table_exists(hook, TEST_DATASET_ID, TEST_TABLE_ID, TEST_GCP_PROJECT_ID)
-    expected_response = False
-    assert res == expected_response
 
+    def test_big_query_table_existence_trigger_serialization(self):
+        """Asserts that the BigQueryTableExistenceTrigger correctly serializes its arguments and classpath."""
 
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryTableHookAsync.get_table_client")
-async def test_table_exists_raise_exception(mock_get_table_client):
-    """Test BigQueryTableExistenceTrigger._table_exists async function with raise exception"""
-    hook = BigQueryTableHookAsync()
-    mock_get_table_client.side_effect = ClientResponseError(
-        history=(),
-        request_info=RequestInfo(
-            headers=CIMultiDict(),
-            real_url=URL("https://example.com"),
-            method="GET",
-            url=URL("https://example.com"),
-        ),
-        status=400,
-        message="Not Found",
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert (
+            classpath == "astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger"
+        )
+        assert kwargs == {
+            "dataset_id": TEST_DATASET_ID,
+            "project_id": TEST_GCP_PROJECT_ID,
+            "table_id": TEST_TABLE_ID,
+            "gcp_conn_id": TEST_GCP_CONN_ID,
+            "poke_interval": POLLING_PERIOD_SECONDS,
+            "hook_params": TEST_HOOK_PARAMS,
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists"
     )
-    trigger = BigQueryTableExistenceTrigger(
-        TEST_GCP_PROJECT_ID,
-        TEST_DATASET_ID,
-        TEST_TABLE_ID,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        POLLING_PERIOD_SECONDS,
+    async def test_big_query_table_existence_trigger_success(self, mock_table_exists):
+        """Tests success case BigQueryTableExistenceTrigger"""
+        mock_table_exists.return_value = True
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "success", "message": "success"}) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists"
     )
-    with pytest.raises(ClientResponseError):
-        await trigger._table_exists(hook, TEST_DATASET_ID, TEST_TABLE_ID, TEST_GCP_PROJECT_ID)
+    async def test_big_query_table_existence_trigger_pending(self, mock_table_exists):
+        """Test that BigQueryTableExistenceTrigger is in loop till the table exist."""
+        mock_table_exists.return_value = False
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists"
+    )
+    async def test_big_query_table_existence_trigger_exception(self, mock_table_exists):
+        """Test BigQueryTableExistenceTrigger throws exception if any error."""
+        mock_table_exists.side_effect = mock.AsyncMock(side_effect=Exception("Test exception"))
+
+        task = [i async for i in self.TRIGGER.run()]
+        assert len(task) == 1
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_get_table_client_value, expected_value",
+        [(Table, True)],
+    )
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryTableHookAsync.get_table_client")
+    async def test_table_exists(self, mock_get_table_client, mock_get_table_client_value, expected_value):
+        """Test BigQueryTableExistenceTrigger._table_exists async function with mocked value and mocked return value"""
+        hook = mock.AsyncMock(BigQueryTableHookAsync)
+        mock_get_table_client.return_value = mock_get_table_client_value
+
+        res = await self.TRIGGER._table_exists(hook, TEST_DATASET_ID, TEST_TABLE_ID, TEST_GCP_PROJECT_ID)
+        assert res == expected_value
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryTableHookAsync.get_table_client")
+    async def test_table_exists_exception(self, mock_get_table_client):
+        """Test BigQueryTableExistenceTrigger._table_exists async function with exception and return False"""
+        hook = BigQueryTableHookAsync()
+        mock_get_table_client.side_effect = ClientResponseError(
+            history=(),
+            request_info=RequestInfo(
+                headers=CIMultiDict(),
+                real_url=URL("https://example.com"),
+                method="GET",
+                url=URL("https://example.com"),
+            ),
+            status=404,
+            message="Not Found",
+        )
+
+        res = await self.TRIGGER._table_exists(hook, TEST_DATASET_ID, TEST_TABLE_ID, TEST_GCP_PROJECT_ID)
+        expected_response = False
+        assert res == expected_response
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.bigquery.BigQueryTableHookAsync.get_table_client")
+    async def test_table_exists_raise_exception(self, mock_get_table_client):
+        """Test BigQueryTableExistenceTrigger._table_exists async function with raise exception"""
+        hook = BigQueryTableHookAsync()
+        mock_get_table_client.side_effect = ClientResponseError(
+            history=(),
+            request_info=RequestInfo(
+                headers=CIMultiDict(),
+                real_url=URL("https://example.com"),
+                method="GET",
+                url=URL("https://example.com"),
+            ),
+            status=400,
+            message="Not Found",
+        )
+
+        with pytest.raises(ClientResponseError):
+            await self.TRIGGER._table_exists(hook, TEST_DATASET_ID, TEST_TABLE_ID, TEST_GCP_PROJECT_ID)

--- a/tests/google/cloud/triggers/test_dataproc.py
+++ b/tests/google/cloud/triggers/test_dataproc.py
@@ -21,586 +21,548 @@ TEST_PROJECT_ID = "test_project_id"
 TEST_GCP_CONN_ID = "TEST_GCP_CONN_ID"
 TEST_CLUSTER_NAME = "test_ccluster"
 TEST_REGION = "us-central1"
-TEST_ZONE = "us-central1-a"
 TEST_JOB_ID = "test-job"
 TEST_POLLING_INTERVAL = 3.0
 TEST_IMPERSONATION_CHAIN = None
 
 
-def test_dataproc_submit_trigger_serialization():
-    """
-    Asserts that the DataProcSubmitTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = DataProcSubmitTrigger(
-        gcp_conn_id=TEST_GCP_CONN_ID,
-        dataproc_job_id=TEST_JOB_ID,
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        impersonation_chain=TEST_IMPERSONATION_CHAIN,
-        polling_interval=TEST_POLLING_INTERVAL,
+class TestDataprocCreateClusterTrigger:
+    def test_dataproc_create_cluster_trigger_serialization(self):
+        """
+        asserts that the DataprocCreateClusterTrigger correctly serializes its arguments and classpath.
+        """
+        trigger = DataprocCreateClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=100,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
+        classpath, kwargs = trigger.serialize()
+        assert classpath == "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger"
+        assert kwargs == {
+            "project_id": TEST_PROJECT_ID,
+            "region": TEST_REGION,
+            "cluster_name": "test_cluster",
+            "gcp_conn_id": TEST_GCP_CONN_ID,
+            "polling_interval": TEST_POLLING_INTERVAL,
+            "impersonation_chain": TEST_IMPERSONATION_CHAIN,
+            "delete_on_error": True,
+            "labels": None,
+            "cluster_config": None,
+            "end_time": 100,
+            "metadata": (),
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
+    async def test_run_running(self, mock_get_cluster):
+        """assert that run method yield correctly when cluster is running"""
+        cluster = Cluster(
+            cluster_name="test_cluster",
+            status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.RUNNING),
+        )
+        mock_get_cluster.return_value = cluster
+
+        trigger = DataprocCreateClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() + 100,
+        )
+
+        generator = trigger.run()
+        actual = await generator.asend(None)
+        assert actual == TriggerEvent(
+            {"status": "success", "data": Cluster.to_dict(cluster), "cluster_name": "test_cluster"}
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
+    async def test_run_pending(self, mock_get_cluster):
+        """assert that run method wait when cluster being is creating"""
+        mock_get_cluster.return_value = Cluster(
+            cluster_name="test_cluster",
+            status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.CREATING),
+        )
+
+        trigger = DataprocCreateClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() + 100,
+        )
+
+        task = asyncio.create_task(trigger.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
+    async def test_run_exception(self, mock_get_cluster):
+        """assert that run method raise exception when get_cluster call fail"""
+        mock_get_cluster.side_effect = Exception("Fail to fetch cluster")
+        trigger = DataprocCreateClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() + 100,
+        )
+
+        generator = trigger.run()
+        actual = await generator.asend(None)
+        assert actual == TriggerEvent({"status": "error", "message": "Fail to fetch cluster"})
+
+    @pytest.mark.asyncio
+    async def test_run_timeout(self):
+        """assert that run method timeout when end_time > start time"""
+        trigger = DataprocCreateClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() - 100,
+        )
+
+        generator = trigger.run()
+        actual = await generator.asend(None)
+        assert actual == TriggerEvent({"status": "error", "message": "Timeout"})
+
+    @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocHook.create_cluster")
+    def test__create_cluster(self, mock_create_cluster):
+        trigger = DataprocCreateClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name=TEST_CLUSTER_NAME,
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() - 100,
+        )
+        trigger._create_cluster()
+
+        mock_create_cluster.assert_called_once_with(
+            region=TEST_REGION,
+            project_id=TEST_PROJECT_ID,
+            cluster_name=TEST_CLUSTER_NAME,
+            cluster_config=None,
+            labels=None,
+            metadata=(),
+        )
+
+    @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocHook.diagnose_cluster")
+    def test__diagnose_cluster(self, mock_diagnose_cluster):
+        """Assert diagnose_cluster call with correct param"""
+        trigger = DataprocCreateClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name=TEST_CLUSTER_NAME,
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() - 100,
+        )
+        trigger._diagnose_cluster()
+
+        mock_diagnose_cluster.assert_called_once_with(
+            region=TEST_REGION, project_id=TEST_PROJECT_ID, cluster_name=TEST_CLUSTER_NAME, metadata=()
+        )
+
+    @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocHook.delete_cluster")
+    def test__delete_cluster(self, mock_delete_cluster):
+        """Assert delete_cluster call with correct param"""
+        trigger = DataprocCreateClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name=TEST_CLUSTER_NAME,
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() - 100,
+        )
+        trigger._delete_cluster()
+
+        mock_delete_cluster.assert_called_once_with(
+            region=TEST_REGION, project_id=TEST_PROJECT_ID, cluster_name=TEST_CLUSTER_NAME, metadata=()
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._get_cluster"
     )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.dataproc.DataProcSubmitTrigger"
-    assert kwargs == {
-        "project_id": TEST_PROJECT_ID,
-        "dataproc_job_id": TEST_JOB_ID,
-        "region": TEST_REGION,
-        "polling_interval": TEST_POLLING_INTERVAL,
-        "gcp_conn_id": TEST_GCP_CONN_ID,
-        "impersonation_chain": TEST_IMPERSONATION_CHAIN,
-    }
+    async def test__wait_for_deleting(self, mock_get_cluster):
+        """Assert that _wait_for_deleting wait if cluster status is deleting"""
+        mock_get_cluster.return_value = Cluster(
+            cluster_name="test_cluster",
+            status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.DELETING),
+        )
 
+        trigger = DataprocCreateClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() + 100,
+        )
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "status",
-    [
-        ({"status": "success", "message": "Job completed successfully"}),
-        ({"status": "error", "message": "Job Failed"}),
-    ],
-)
-@mock.patch("astronomer.providers.google.cloud.triggers.dataproc.DataProcSubmitTrigger._get_job_status")
-async def test_dataproc_submit_return_success_and_failure(mock_get_job_status, status):
-    """Tests that the DataProcSubmitTrigger is success case and also error case"""
-    mock_get_job_status.return_value = status
+        task = asyncio.create_task(trigger._wait_for_deleting())
+        await asyncio.sleep(0.5)
 
-    trigger = DataProcSubmitTrigger(
-        dataproc_job_id=TEST_JOB_ID,
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        impersonation_chain=TEST_IMPERSONATION_CHAIN,
-        polling_interval=TEST_POLLING_INTERVAL,
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._get_cluster"
     )
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent(status) == actual
+    async def test_wait_for_deleting_success(self, mock__get_cluster):
+        """Assert that _wait_for_deleting return success if cluster not found exception raise by get_cluster"""
+        mock__get_cluster.side_effect = NotFound("Cluster deleted")
+        trigger = DataprocCreateClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() + 100,
+        )
+        assert await trigger._wait_for_deleting() is None
 
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.dataproc.DataProcSubmitTrigger._get_job_status")
-async def test_dataproc_submit_return_pending(mock_get_job_status):
-    """Tests that the DataProcSubmitTrigger is in pending state"""
-    mock_get_job_status.return_value = {"status": "pending"}
-
-    trigger = DataProcSubmitTrigger(
-        dataproc_job_id=TEST_JOB_ID,
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        polling_interval=TEST_POLLING_INTERVAL,
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._get_cluster"
     )
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
+    async def test_wait_for_deleting_exception(self, mock__get_cluster):
+        """Assert that _wait_for_deleting return raise exception when get_cluster raise exception"""
+        mock__get_cluster.side_effect = Exception("Error occur while deleting")
+        trigger = DataprocCreateClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() + 100,
+        )
+        with pytest.raises(Exception):
+            await trigger._wait_for_deleting()
 
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.dataproc.DataProcSubmitTrigger._get_job_status")
-async def test_dataproc_submit_return_exception(mock_get_job_status):
-    """Tests that the DataProcSubmitTrigger throws an exception"""
-    mock_get_job_status.side_effect = Exception("Test exception")
-
-    trigger = DataProcSubmitTrigger(
-        dataproc_job_id=TEST_JOB_ID,
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        polling_interval=TEST_POLLING_INTERVAL,
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "delete_on_error",
+        [True, False],
     )
-    task = [i async for i in trigger.run()]
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "state, response",
-    [
-        (
-            JobStatus.State.DONE,
-            {"status": "success", "message": "Job completed successfully", "job_id": TEST_JOB_ID},
-        ),
-        (JobStatus.State.ERROR, {"status": "error", "message": "Job Failed", "job_id": TEST_JOB_ID}),
-        (
-            JobStatus.State.CANCELLED,
-            {"status": "error", "message": "Job got cancelled", "job_id": TEST_JOB_ID},
-        ),
-        (
-            JobStatus.State.ATTEMPT_FAILURE,
-            {"status": "pending", "message": "Job is in pending state", "job_id": TEST_JOB_ID},
-        ),
-        (
-            JobStatus.State.SETUP_DONE,
-            {"status": "pending", "message": "Job is in pending state", "job_id": TEST_JOB_ID},
-        ),
-    ],
-)
-async def test_dataproc_get_job_status(state, response):
-    """Tests that the get job status gives appropriate status for the job"""
-    hook = mock.AsyncMock(DataprocHookAsync)
-    get_job_instance = mock.AsyncMock(Job)
-    hook.get_job = get_job_instance
-    hook.get_job.return_value.status.state = state
-    trigger = DataProcSubmitTrigger(
-        dataproc_job_id=TEST_JOB_ID,
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        polling_interval=TEST_POLLING_INTERVAL,
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._delete_cluster"
     )
-    res = await trigger._get_job_status(hook)
-    assert res == response
-
-
-def test_dataproc_create_cluster_trigger_serialization():
-    """
-    asserts that the DataprocCreateClusterTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = DataprocCreateClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        gcp_conn_id=TEST_GCP_CONN_ID,
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=100,
-        metadata=(),
-        impersonation_chain=TEST_IMPERSONATION_CHAIN,
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._wait_for_deleting"
     )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger"
-    assert kwargs == {
-        "project_id": TEST_PROJECT_ID,
-        "region": TEST_REGION,
-        "cluster_name": "test_cluster",
-        "gcp_conn_id": TEST_GCP_CONN_ID,
-        "polling_interval": TEST_POLLING_INTERVAL,
-        "impersonation_chain": TEST_IMPERSONATION_CHAIN,
-        "delete_on_error": True,
-        "labels": None,
-        "cluster_config": None,
-        "end_time": 100,
-        "metadata": (),
-    }
+    @mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocHook.diagnose_cluster")
+    async def test__handle_error(
+        self, mock_diagnose_cluster, mock_wait_for_deleting, mock_delete_cluster, delete_on_error
+    ):
+        """Assert that _handle_error raise exception correctly in case of error"""
+        mock_diagnose_cluster.return_value = {}
+        mock_delete_cluster.return_value = {}
+        mock_wait_for_deleting.return_value = {}
+        cluster = Cluster(
+            cluster_name="test_cluster",
+            status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.ERROR),
+        )
 
+        trigger = DataprocCreateClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() + 100,
+            delete_on_error=delete_on_error,
+        )
+        with pytest.raises(AirflowException):
+            await trigger._handle_error(cluster=cluster)
 
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
-async def test_run_running(mock_get_cluster):
-    """assert that run method yield correctly when cluster is running"""
-    cluster = Cluster(
-        cluster_name="test_cluster", status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.RUNNING)
+    @pytest.mark.asyncio
+    async def test__handle_error_with_no_error(self):
+        """Assert that _handle_error return success when no error"""
+        cluster = Cluster(
+            cluster_name="test_cluster",
+            status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.DELETING),
+        )
+
+        trigger = DataprocCreateClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() + 100,
+        )
+
+        assert await trigger._handle_error(cluster=cluster) is None
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._handle_error"
     )
-    mock_get_cluster.return_value = cluster
-
-    trigger = DataprocCreateClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() + 100,
-        metadata=(),
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._create_cluster"
     )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert actual == TriggerEvent(
-        {"status": "success", "data": Cluster.to_dict(cluster), "cluster_name": "test_cluster"}
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._wait_for_deleting"
     )
+    @mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
+    async def test_run_deleting(
+        self, mock_get_cluster, mock_wait_for_deleting, mock_create_cluster, mock_handle_error
+    ):
+        """
+        assert that run method call
+        1. _wait_for_deleting correctly
+        2. _create_cluster
+        3. _handle_error
+        methods correctly when cluster status is deleting
+        """
+        cluster = Cluster(
+            cluster_name="test_cluster",
+            status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.DELETING),
+        )
+        mock_get_cluster.return_value = cluster
+
+        trigger = DataprocCreateClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() + 100,
+        )
+        asyncio.create_task(trigger.run().__anext__())
+        await asyncio.sleep(0.5)
+        mock_wait_for_deleting.assert_called_once_with()
+        mock_create_cluster.assert_called_once_with()
+        mock_handle_error.assert_called_once_with(cluster)
+        asyncio.get_event_loop().stop()
 
 
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
-async def test_run_pending(mock_get_cluster):
-    """assert that run method wait when cluster being is creating"""
-    mock_get_cluster.return_value = Cluster(
-        cluster_name="test_cluster",
-        status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.CREATING),
+class TestDataProcSubmitTrigger:
+    def test_dataproc_submit_trigger_serialization(self):
+        """
+        Asserts that the DataProcSubmitTrigger correctly serializes its arguments and classpath.
+        """
+        trigger = DataProcSubmitTrigger(
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            dataproc_job_id=TEST_JOB_ID,
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+            polling_interval=TEST_POLLING_INTERVAL,
+        )
+        classpath, kwargs = trigger.serialize()
+        assert classpath == "astronomer.providers.google.cloud.triggers.dataproc.DataProcSubmitTrigger"
+        assert kwargs == {
+            "project_id": TEST_PROJECT_ID,
+            "dataproc_job_id": TEST_JOB_ID,
+            "region": TEST_REGION,
+            "polling_interval": TEST_POLLING_INTERVAL,
+            "gcp_conn_id": TEST_GCP_CONN_ID,
+            "impersonation_chain": TEST_IMPERSONATION_CHAIN,
+        }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status",
+        [
+            ({"status": "success", "message": "Job completed successfully"}),
+            ({"status": "error", "message": "Job Failed"}),
+        ],
     )
+    @mock.patch("astronomer.providers.google.cloud.triggers.dataproc.DataProcSubmitTrigger._get_job_status")
+    async def test_dataproc_submit_return_success_and_failure(self, mock_get_job_status, status):
+        """Tests that the DataProcSubmitTrigger is success case and also error case"""
+        mock_get_job_status.return_value = status
 
-    trigger = DataprocCreateClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() + 100,
-        metadata=(),
+        trigger = DataProcSubmitTrigger(
+            dataproc_job_id=TEST_JOB_ID,
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+            polling_interval=TEST_POLLING_INTERVAL,
+        )
+        generator = trigger.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent(status) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.triggers.dataproc.DataProcSubmitTrigger._get_job_status")
+    async def test_dataproc_submit_return_pending(self, mock_get_job_status):
+        """Tests that the DataProcSubmitTrigger is in pending state"""
+        mock_get_job_status.return_value = {"status": "pending"}
+
+        trigger = DataProcSubmitTrigger(
+            dataproc_job_id=TEST_JOB_ID,
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            polling_interval=TEST_POLLING_INTERVAL,
+        )
+        task = asyncio.create_task(trigger.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.triggers.dataproc.DataProcSubmitTrigger._get_job_status")
+    async def test_dataproc_submit_return_exception(self, mock_get_job_status):
+        """Tests that the DataProcSubmitTrigger throws an exception"""
+        mock_get_job_status.side_effect = Exception("Test exception")
+
+        trigger = DataProcSubmitTrigger(
+            dataproc_job_id=TEST_JOB_ID,
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            polling_interval=TEST_POLLING_INTERVAL,
+        )
+        task = [i async for i in trigger.run()]
+        assert len(task) == 1
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "state, response",
+        [
+            (
+                JobStatus.State.DONE,
+                {"status": "success", "message": "Job completed successfully", "job_id": TEST_JOB_ID},
+            ),
+            (JobStatus.State.ERROR, {"status": "error", "message": "Job Failed", "job_id": TEST_JOB_ID}),
+            (
+                JobStatus.State.CANCELLED,
+                {"status": "error", "message": "Job got cancelled", "job_id": TEST_JOB_ID},
+            ),
+            (
+                JobStatus.State.ATTEMPT_FAILURE,
+                {"status": "pending", "message": "Job is in pending state", "job_id": TEST_JOB_ID},
+            ),
+            (
+                JobStatus.State.SETUP_DONE,
+                {"status": "pending", "message": "Job is in pending state", "job_id": TEST_JOB_ID},
+            ),
+        ],
     )
-
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
-async def test_run_exception(mock_get_cluster):
-    """assert that run method raise exception when get_cluster call fail"""
-    mock_get_cluster.side_effect = Exception("Fail to fetch cluster")
-    trigger = DataprocCreateClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() + 100,
-        metadata=(),
-    )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert actual == TriggerEvent({"status": "error", "message": "Fail to fetch cluster"})
+    async def test_dataproc_get_job_status(self, state, response):
+        """Tests that the get job status gives appropriate status for the job"""
+        hook = mock.AsyncMock(DataprocHookAsync)
+        get_job_instance = mock.AsyncMock(Job)
+        hook.get_job = get_job_instance
+        hook.get_job.return_value.status.state = state
+        trigger = DataProcSubmitTrigger(
+            dataproc_job_id=TEST_JOB_ID,
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            polling_interval=TEST_POLLING_INTERVAL,
+        )
+        res = await trigger._get_job_status(hook)
+        assert res == response
 
 
-@pytest.mark.asyncio
-async def test_run_timeout():
-    """assert that run method timeout when end_time > start time"""
-    trigger = DataprocCreateClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() - 100,
-        metadata=(),
-    )
+class TestDataprocDeleteClusterTrigger:
+    def test_dataproc_delete_cluster_trigger_serialization(self):
+        """
+        asserts that the DataprocDeleteClusterTrigger correctly serializes its arguments
+        and classpath.
+        """
+        trigger = DataprocDeleteClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            polling_interval=TEST_POLLING_INTERVAL,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+            end_time=100,
+        )
+        classpath, kwargs = trigger.serialize()
+        assert classpath == "astronomer.providers.google.cloud.triggers.dataproc.DataprocDeleteClusterTrigger"
+        assert kwargs == {
+            "project_id": TEST_PROJECT_ID,
+            "region": TEST_REGION,
+            "cluster_name": "test_cluster",
+            "gcp_conn_id": TEST_GCP_CONN_ID,
+            "polling_interval": TEST_POLLING_INTERVAL,
+            "impersonation_chain": TEST_IMPERSONATION_CHAIN,
+            "end_time": 100,
+            "metadata": (),
+        }
 
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert actual == TriggerEvent({"status": "error", "message": "Timeout"})
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
+    async def test_delete_cluster_run_pending(self, mock_get_cluster):
+        """assert that run method wait when cluster being is deleting"""
+        mock_get_cluster.return_value = Cluster(
+            cluster_name="test_cluster",
+            status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.DELETING),
+        )
 
+        trigger = DataprocDeleteClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() + 100,
+        )
 
-@mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocHook.create_cluster")
-def test__create_cluster(mock_create_cluster):
-    trigger = DataprocCreateClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name=TEST_CLUSTER_NAME,
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() - 100,
-        metadata=(),
-    )
-    trigger._create_cluster()
+        task = asyncio.create_task(trigger.run().__anext__())
+        await asyncio.sleep(0.5)
 
-    mock_create_cluster.assert_called_once_with(
-        region=TEST_REGION,
-        project_id=TEST_PROJECT_ID,
-        cluster_name=TEST_CLUSTER_NAME,
-        cluster_config=None,
-        labels=None,
-        metadata=(),
-    )
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
 
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
+    async def test_delete_run_success(self, mock_get_cluster):
+        """assert that run method yield correctly when cluster is deleted"""
+        mock_get_cluster.side_effect = NotFound("Cluster deleted")
 
-@mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocHook.diagnose_cluster")
-def test__diagnose_cluster(mock_diagnose_cluster):
-    """Assert diagnose_cluster call with correct param"""
-    trigger = DataprocCreateClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name=TEST_CLUSTER_NAME,
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() - 100,
-        metadata=(),
-    )
-    trigger._diagnose_cluster()
+        trigger = DataprocDeleteClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() + 100,
+        )
+        generator = trigger.run()
+        actual = await generator.asend(None)
+        assert actual == TriggerEvent({"status": "success", "message": ""})
 
-    mock_diagnose_cluster.assert_called_once_with(
-        region=TEST_REGION,
-        project_id=TEST_PROJECT_ID,
-        cluster_name=TEST_CLUSTER_NAME,
-        metadata=(),
-    )
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
+    async def test_delete_run_exception(self, mock_get_cluster):
+        """assert that run method raise exception when get_cluster call fail"""
+        mock_get_cluster.side_effect = Exception("Cluster deletion fail")
 
+        trigger = DataprocDeleteClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() + 100,
+        )
+        generator = trigger.run()
+        actual = await generator.asend(None)
+        assert actual == TriggerEvent({"status": "error", "message": "Cluster deletion fail"})
 
-@mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocHook.delete_cluster")
-def test__delete_cluster(mock_delete_cluster):
-    """Assert delete_cluster call with correct param"""
-    trigger = DataprocCreateClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name=TEST_CLUSTER_NAME,
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() - 100,
-        metadata=(),
-    )
-    trigger._delete_cluster()
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
+    async def test_delete_run_timeout(self, mock_get_cluster):
+        """assert that run method timeout when end_time > start time"""
+        mock_get_cluster.side_effect = Exception("Cluster deletion fail")
 
-    mock_delete_cluster.assert_called_once_with(
-        region=TEST_REGION,
-        project_id=TEST_PROJECT_ID,
-        cluster_name=TEST_CLUSTER_NAME,
-        metadata=(),
-    )
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._get_cluster")
-async def test__wait_for_deleting(mock_get_cluster):
-    """Assert that _wait_for_deleting wait if cluster status is deleting"""
-    mock_get_cluster.return_value = Cluster(
-        cluster_name="test_cluster",
-        status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.DELETING),
-    )
-
-    trigger = DataprocCreateClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() + 100,
-        metadata=(),
-    )
-
-    task = asyncio.create_task(trigger._wait_for_deleting())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._get_cluster")
-async def test_wait_for_deleting_success(mock__get_cluster):
-    """Assert that _wait_for_deleting return success if cluster not found exception raise by get_cluster"""
-    mock__get_cluster.side_effect = NotFound("Cluster deleted")
-    trigger = DataprocCreateClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() + 100,
-        metadata=(),
-    )
-    assert await trigger._wait_for_deleting() is None
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._get_cluster")
-async def test_wait_for_deleting_exception(mock__get_cluster):
-    """Assert that _wait_for_deleting return raise exception when get_cluster raise exception"""
-    mock__get_cluster.side_effect = Exception("Error occur while deleting")
-    trigger = DataprocCreateClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() + 100,
-        metadata=(),
-    )
-    with pytest.raises(Exception):
-        await trigger._wait_for_deleting()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "delete_on_error",
-    [
-        True,
-        False,
-    ],
-)
-@mock.patch(
-    "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._delete_cluster"
-)
-@mock.patch(
-    "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._wait_for_deleting"
-)
-@mock.patch("airflow.providers.google.cloud.hooks.dataproc.DataprocHook.diagnose_cluster")
-async def test__handle_error(
-    mock_diagnose_cluster, mock_wait_for_deleting, mock_delete_cluster, delete_on_error
-):
-    """Assert that _handle_error raise exception correctly in case of error"""
-    mock_diagnose_cluster.return_value = {}
-    mock_delete_cluster.return_value = {}
-    mock_wait_for_deleting.return_value = {}
-    cluster = Cluster(
-        cluster_name="test_cluster",
-        status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.ERROR),
-    )
-
-    trigger = DataprocCreateClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() + 100,
-        metadata=(),
-        delete_on_error=delete_on_error,
-    )
-    with pytest.raises(AirflowException):
-        await trigger._handle_error(cluster=cluster)
-
-
-@pytest.mark.asyncio
-async def test__handle_error_with_no_error():
-    """Assert that _handle_error return success when no error"""
-    cluster = Cluster(
-        cluster_name="test_cluster",
-        status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.DELETING),
-    )
-
-    trigger = DataprocCreateClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() + 100,
-        metadata=(),
-    )
-
-    assert await trigger._handle_error(cluster=cluster) is None
-
-
-def test_dataproc_delete_cluster_trigger_serialization():
-    """
-    asserts that the DataprocDeleteClusterTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = DataprocDeleteClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        gcp_conn_id=TEST_GCP_CONN_ID,
-        polling_interval=TEST_POLLING_INTERVAL,
-        impersonation_chain=TEST_IMPERSONATION_CHAIN,
-        end_time=100,
-        metadata=(),
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.dataproc.DataprocDeleteClusterTrigger"
-    assert kwargs == {
-        "project_id": TEST_PROJECT_ID,
-        "region": TEST_REGION,
-        "cluster_name": "test_cluster",
-        "gcp_conn_id": TEST_GCP_CONN_ID,
-        "polling_interval": TEST_POLLING_INTERVAL,
-        "impersonation_chain": TEST_IMPERSONATION_CHAIN,
-        "end_time": 100,
-        "metadata": (),
-    }
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
-async def test_delete_cluster_run_pending(mock_get_cluster):
-    """assert that run method wait when cluster being is deleting"""
-    mock_get_cluster.return_value = Cluster(
-        cluster_name="test_cluster",
-        status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.DELETING),
-    )
-
-    trigger = DataprocDeleteClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() + 100,
-        metadata=(),
-    )
-
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
-async def test_delete_run_success(mock_get_cluster):
-    """assert that run method yield correctly when cluster is deleted"""
-    mock_get_cluster.side_effect = NotFound("Cluster deleted")
-
-    trigger = DataprocDeleteClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() + 100,
-        metadata=(),
-    )
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert actual == TriggerEvent({"status": "success", "message": ""})
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
-async def test_delete_run_exception(mock_get_cluster):
-    """assert that run method raise exception when get_cluster call fail"""
-    mock_get_cluster.side_effect = Exception("Cluster deletion fail")
-
-    trigger = DataprocDeleteClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() + 100,
-        metadata=(),
-    )
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert actual == TriggerEvent({"status": "error", "message": "Cluster deletion fail"})
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._handle_error")
-@mock.patch(
-    "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._create_cluster"
-)
-@mock.patch(
-    "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger._wait_for_deleting"
-)
-@mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
-async def test_run_deleting(mock_get_cluster, mock_wait_for_deleting, mock_create_cluster, mock_handle_error):
-    """
-    assert that run method call
-    1. _wait_for_deleting correctly
-    2. _create_cluster
-    3. _handle_error
-    methods correctly when cluster status is deleting
-    """
-    cluster = Cluster(
-        cluster_name="test_cluster",
-        status=dataproc.ClusterStatus(state=dataproc.ClusterStatus.State.DELETING),
-    )
-    mock_get_cluster.return_value = cluster
-
-    trigger = DataprocCreateClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() + 100,
-        metadata=(),
-    )
-    asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-    mock_wait_for_deleting.assert_called_once_with()
-    mock_create_cluster.assert_called_once_with()
-    mock_handle_error.assert_called_once_with(cluster)
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.hooks.dataproc.DataprocHookAsync.get_cluster")
-async def test_delete_run_timeout(mock_get_cluster):
-    """assert that run method timeout when end_time > start time"""
-    mock_get_cluster.side_effect = Exception("Cluster deletion fail")
-
-    trigger = DataprocDeleteClusterTrigger(
-        project_id=TEST_PROJECT_ID,
-        region=TEST_REGION,
-        cluster_name="test_cluster",
-        polling_interval=TEST_POLLING_INTERVAL,
-        end_time=time.time() - 100,
-        metadata=(),
-    )
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert actual == TriggerEvent({"status": "error", "message": "Timeout"})
+        trigger = DataprocDeleteClusterTrigger(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            cluster_name="test_cluster",
+            polling_interval=TEST_POLLING_INTERVAL,
+            end_time=time.time() - 100,
+        )
+        generator = trigger.run()
+        actual = await generator.asend(None)
+        assert actual == TriggerEvent({"status": "error", "message": "Timeout"})

--- a/tests/google/cloud/triggers/test_gcs.py
+++ b/tests/google/cloud/triggers/test_gcs.py
@@ -28,604 +28,362 @@ TEST_PREVIOUS_OBJECTS = {"a", "ab"}
 TEST_TS_OBJECT = datetime.utcnow()
 
 
-def test_gcs_blob_trigger_serialization():
-    """
-    Asserts that the GCSBlobTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = GCSBlobTrigger(
-        TEST_BUCKET,
-        TEST_OBJECT,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.gcs.GCSBlobTrigger"
-    assert kwargs == {
-        "bucket": TEST_BUCKET,
-        "object_name": TEST_OBJECT,
-        "poke_interval": TEST_POLLING_INTERVAL,
-        "google_cloud_conn_id": TEST_GCP_CONN_ID,
-        "hook_params": TEST_HOOK_PARAMS,
-    }
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSBlobTrigger._object_exists")
-async def test_gcs_blob_trigger_success(mock_object_exists):
-    """
-    Tests that the GCSBlobTrigger is success case
-    """
-    mock_object_exists.return_value = "success"
-
-    trigger = GCSBlobTrigger(
-        TEST_BUCKET,
-        TEST_OBJECT,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-    )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent({"status": "success", "message": "success"}) == actual
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSBlobTrigger._object_exists")
-async def test_gcs_blob_trigger_pending(mock_object_exists):
-    """
-    Test that GCSBlobTrigger is in loop if file isn't found.
-    """
-    mock_object_exists.return_value = "pending"
-
-    trigger = GCSBlobTrigger(
-        TEST_BUCKET,
-        TEST_OBJECT,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-    )
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSBlobTrigger._object_exists")
-async def test_gcs_blob_trigger_exception(mock_object_exists):
-    """
-    Tests the GCSBlobTrigger does fire if there is an exception.
-    """
-    mock_object_exists.side_effect = mock.AsyncMock(side_effect=Exception("Test exception"))
-    trigger = GCSBlobTrigger(
+class TestGCSBlobTrigger:
+    TRIGGER = GCSBlobTrigger(
         bucket=TEST_BUCKET,
         object_name=TEST_OBJECT,
         poke_interval=TEST_POLLING_INTERVAL,
         google_cloud_conn_id=TEST_GCP_CONN_ID,
         hook_params=TEST_HOOK_PARAMS,
     )
-    task = [i async for i in trigger.run()]
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
 
+    def test_gcs_blob_trigger_serialization(self):
+        """Asserts that the GCSBlobTrigger correctly serializes its arguments and classpath."""
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "exists,response",
-    [
-        (True, "success"),
-        (False, "pending"),
-    ],
-)
-async def test_object_exists(exists, response):
-    """
-    Tests to check if a particular object in Google Cloud Storage
-    is found or not
-    """
-    hook = mock.AsyncMock(GCSHookAsync)
-    storage = mock.AsyncMock(Storage)
-    hook.get_storage_client.return_value = storage
-    bucket = mock.AsyncMock(Bucket)
-    storage.get_bucket.return_value = bucket
-    bucket.blob_exists.return_value = exists
-    trigger = GCSBlobTrigger(
-        bucket=TEST_BUCKET,
-        object_name=TEST_OBJECT,
-        poke_interval=TEST_POLLING_INTERVAL,
-        google_cloud_conn_id=TEST_GCP_CONN_ID,
-        hook_params=TEST_HOOK_PARAMS,
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == "astronomer.providers.google.cloud.triggers.gcs.GCSBlobTrigger"
+        assert kwargs == {
+            "bucket": TEST_BUCKET,
+            "object_name": TEST_OBJECT,
+            "poke_interval": TEST_POLLING_INTERVAL,
+            "google_cloud_conn_id": TEST_GCP_CONN_ID,
+            "hook_params": TEST_HOOK_PARAMS,
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSBlobTrigger._object_exists")
+    async def test_gcs_blob_trigger_success(self, mock_object_exists):
+        """
+        Tests that the GCSBlobTrigger is success case
+        """
+        mock_object_exists.return_value = "success"
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "success", "message": "success"}) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSBlobTrigger._object_exists")
+    async def test_gcs_blob_trigger_pending(self, mock_object_exists):
+        """
+        Test that GCSBlobTrigger is in loop if file isn't found.
+        """
+        mock_object_exists.return_value = "pending"
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSBlobTrigger._object_exists")
+    async def test_gcs_blob_trigger_exception(self, mock_object_exists):
+        """
+        Tests the GCSBlobTrigger does fire if there is an exception.
+        """
+        mock_object_exists.side_effect = mock.AsyncMock(side_effect=Exception("Test exception"))
+
+        task = [i async for i in self.TRIGGER.run()]
+        assert len(task) == 1
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "exists,response",
+        [
+            (True, "success"),
+            (False, "pending"),
+        ],
     )
-    res = await trigger._object_exists(hook, TEST_BUCKET, TEST_OBJECT)
-    assert res == response
-    bucket.blob_exists.assert_called_once_with(blob_name=TEST_OBJECT)
+    async def test_object_exists(self, exists, response):
+        """
+        Tests to check if a particular object in Google Cloud Storage
+        is found or not
+        """
+        hook = mock.AsyncMock(GCSHookAsync)
+        storage = mock.AsyncMock(Storage)
+        hook.get_storage_client.return_value = storage
+        bucket = mock.AsyncMock(Bucket)
+        storage.get_bucket.return_value = bucket
+        bucket.blob_exists.return_value = exists
+
+        res = await self.TRIGGER._object_exists(hook, TEST_BUCKET, TEST_OBJECT)
+        assert res == response
+        bucket.blob_exists.assert_called_once_with(blob_name=TEST_OBJECT)
 
 
-def test_gcs_prefix_blob_trigger_serialization():
-    """
-    Asserts that the GCSPrefixBlobTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = GCSPrefixBlobTrigger(
-        TEST_BUCKET,
-        TEST_PREFIX,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.gcs.GCSPrefixBlobTrigger"
-    assert kwargs == {
-        "bucket": TEST_BUCKET,
-        "prefix": TEST_PREFIX,
-        "poke_interval": TEST_POLLING_INTERVAL,
-        "google_cloud_conn_id": TEST_GCP_CONN_ID,
-        "hook_params": TEST_HOOK_PARAMS,
-    }
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSPrefixBlobTrigger._list_blobs_with_prefix")
-async def test_gcs_prefix_blob_trigger_success(mock_list_blobs_with_prefixs):
-    """
-    Tests that the GCSPrefixBlobTrigger is success case
-    """
-    mock_list_blobs_with_prefixs.return_value = ["success"]
-
-    trigger = GCSPrefixBlobTrigger(
-        TEST_BUCKET,
-        TEST_PREFIX,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-    )
-
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert (
-        TriggerEvent({"status": "success", "message": "Successfully completed", "matches": ["success"]})
-        == actual
-    )
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSPrefixBlobTrigger._list_blobs_with_prefix")
-async def test_gcs_prefix_blob_trigger_exception(mock_list_blobs_with_prefixs):
-    """
-    Tests the GCSPrefixBlobTrigger does fire if there is an exception.
-    """
-    mock_list_blobs_with_prefixs.side_effect = mock.AsyncMock(side_effect=Exception("Test exception"))
-    trigger = GCSPrefixBlobTrigger(
+class TestGCSPrefixBlobTrigger:
+    TRIGGER = GCSPrefixBlobTrigger(
         bucket=TEST_BUCKET,
         prefix=TEST_PREFIX,
         poke_interval=TEST_POLLING_INTERVAL,
         google_cloud_conn_id=TEST_GCP_CONN_ID,
         hook_params=TEST_HOOK_PARAMS,
     )
-    task = [i async for i in trigger.run()]
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+
+    def test_gcs_prefix_blob_trigger_serialization(self):
+        """
+        Asserts that the GCSPrefixBlobTrigger correctly serializes its arguments
+        and classpath.
+        """
+
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == "astronomer.providers.google.cloud.triggers.gcs.GCSPrefixBlobTrigger"
+        assert kwargs == {
+            "bucket": TEST_BUCKET,
+            "prefix": TEST_PREFIX,
+            "poke_interval": TEST_POLLING_INTERVAL,
+            "google_cloud_conn_id": TEST_GCP_CONN_ID,
+            "hook_params": TEST_HOOK_PARAMS,
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSPrefixBlobTrigger._list_blobs_with_prefix")
+    async def test_gcs_prefix_blob_trigger_success(self, mock_list_blobs_with_prefixs):
+        """
+        Tests that the GCSPrefixBlobTrigger is success case
+        """
+        mock_list_blobs_with_prefixs.return_value = ["success"]
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert (
+            TriggerEvent({"status": "success", "message": "Successfully completed", "matches": ["success"]})
+            == actual
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSPrefixBlobTrigger._list_blobs_with_prefix")
+    async def test_gcs_prefix_blob_trigger_exception(self, mock_list_blobs_with_prefixs):
+        """
+        Tests the GCSPrefixBlobTrigger does fire if there is an exception.
+        """
+        mock_list_blobs_with_prefixs.side_effect = mock.AsyncMock(side_effect=Exception("Test exception"))
+
+        task = [i async for i in self.TRIGGER.run()]
+        assert len(task) == 1
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSPrefixBlobTrigger._list_blobs_with_prefix")
+    async def test_gcs_prefix_blob_trigger_pending(self, mock_list_blobs_with_prefixs):
+        """
+        Test that GCSPrefixBlobTrigger is in loop if file isn't found.
+        """
+        mock_list_blobs_with_prefixs.return_value = []
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    async def test_list_blobs_with_prefix(self):
+        """
+        Tests to check if a particular object in Google Cloud Storage
+        is found or not
+        """
+        hook = mock.AsyncMock(GCSHookAsync)
+        storage = mock.AsyncMock(Storage)
+        hook.get_storage_client.return_value = storage
+        bucket = mock.AsyncMock(Bucket)
+        storage.get_bucket.return_value = bucket
+        bucket.list_blobs.return_value = ["test_string"]
+
+        res = await self.TRIGGER._list_blobs_with_prefix(hook, TEST_BUCKET, TEST_PREFIX)
+        assert res == ["test_string"]
+        bucket.list_blobs.assert_called_once_with(prefix=TEST_PREFIX)
 
 
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSPrefixBlobTrigger._list_blobs_with_prefix")
-async def test_gcs_prefix_blob_trigger_pending(mock_list_blobs_with_prefixs):
-    """
-    Test that GCSPrefixBlobTrigger is in loop if file isn't found.
-    """
-    mock_list_blobs_with_prefixs.return_value = []
-
-    trigger = GCSPrefixBlobTrigger(
-        TEST_BUCKET,
-        TEST_PREFIX,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-    )
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-async def test_list_blobs_with_prefix():
-    """
-    Tests to check if a particular object in Google Cloud Storage
-    is found or not
-    """
-    hook = mock.AsyncMock(GCSHookAsync)
-    storage = mock.AsyncMock(Storage)
-    hook.get_storage_client.return_value = storage
-    bucket = mock.AsyncMock(Bucket)
-    storage.get_bucket.return_value = bucket
-    bucket.list_blobs.return_value = ["test_string"]
-    trigger = GCSPrefixBlobTrigger(
+class TestGCSUploadSessionTrigger:
+    TRIGGER = GCSUploadSessionTrigger(
         bucket=TEST_BUCKET,
         prefix=TEST_PREFIX,
         poke_interval=TEST_POLLING_INTERVAL,
         google_cloud_conn_id=TEST_GCP_CONN_ID,
         hook_params=TEST_HOOK_PARAMS,
-    )
-    res = await trigger._list_blobs_with_prefix(hook, TEST_BUCKET, TEST_PREFIX)
-    assert res == ["test_string"]
-    bucket.list_blobs.assert_called_once_with(prefix=TEST_PREFIX)
-
-
-def test_gcs_upload_session_trigger_serialization():
-    """
-    Asserts that the GCSUploadSessionTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = GCSUploadSessionTrigger(
-        TEST_BUCKET,
-        TEST_PREFIX,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        TEST_INACTIVITY_PERIOD,
-        TEST_MIN_OBJECTS,
-        TEST_PREVIOUS_OBJECTS,
-        TEST_ALLOW_DELETE,
-    )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.gcs.GCSUploadSessionTrigger"
-    assert kwargs == {
-        "bucket": TEST_BUCKET,
-        "prefix": TEST_PREFIX,
-        "poke_interval": TEST_POLLING_INTERVAL,
-        "google_cloud_conn_id": TEST_GCP_CONN_ID,
-        "hook_params": TEST_HOOK_PARAMS,
-        "inactivity_period": TEST_INACTIVITY_PERIOD,
-        "min_objects": TEST_MIN_OBJECTS,
-        "previous_objects": TEST_PREVIOUS_OBJECTS,
-        "allow_delete": TEST_ALLOW_DELETE,
-    }
-
-
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSUploadSessionTrigger._list_blobs_with_prefix")
-@mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSUploadSessionTrigger._is_bucket_updated")
-async def test_gcs_upload_session_trigger_pending(mock_is_bucket_updated, mock_list_blobs):
-    """
-    Test that GCSUploadSessionTrigger is in loop if Upload is still in progress till inactivity period.
-    """
-    mock_is_bucket_updated.return_value = {"status": "pending"}
-    mock_list_blobs.return_value = TEST_PREVIOUS_OBJECTS
-
-    trigger = GCSUploadSessionTrigger(
-        TEST_BUCKET,
-        TEST_PREFIX,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        TEST_INACTIVITY_PERIOD,
-        TEST_MIN_OBJECTS,
-        TEST_PREVIOUS_OBJECTS,
-        TEST_ALLOW_DELETE,
-    )
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "is_bucket_return_value",
-    [
-        ({"status": "success", "message": "Successfully completed"}),
-        ({"status": "error", "message": "Error occurred"}),
-    ],
-)
-@mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSUploadSessionTrigger._list_blobs_with_prefix")
-@mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSUploadSessionTrigger._is_bucket_updated")
-async def test_gcs_upload_session_trigger_success(
-    mock_is_bucket_updated, mock_list_blobs, is_bucket_return_value
-):
-    """
-    Tests that the GCSUploadSessionTrigger is success case
-    """
-    mock_is_bucket_updated.return_value = is_bucket_return_value
-    mock_list_blobs.return_value = TEST_PREVIOUS_OBJECTS
-
-    trigger = GCSUploadSessionTrigger(
-        TEST_BUCKET,
-        TEST_PREFIX,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        TEST_INACTIVITY_PERIOD,
-        TEST_MIN_OBJECTS,
-        TEST_PREVIOUS_OBJECTS,
-        TEST_ALLOW_DELETE,
+        inactivity_period=TEST_INACTIVITY_PERIOD,
+        min_objects=TEST_MIN_OBJECTS,
+        previous_objects=TEST_PREVIOUS_OBJECTS,
+        allow_delete=TEST_ALLOW_DELETE,
     )
 
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent(is_bucket_return_value) == actual
+    def test_gcs_upload_session_trigger_serialization(self):
+        """
+        Asserts that the GCSUploadSessionTrigger correctly serializes its arguments
+        and classpath.
+        """
 
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == "astronomer.providers.google.cloud.triggers.gcs.GCSUploadSessionTrigger"
+        assert kwargs == {
+            "bucket": TEST_BUCKET,
+            "prefix": TEST_PREFIX,
+            "poke_interval": TEST_POLLING_INTERVAL,
+            "google_cloud_conn_id": TEST_GCP_CONN_ID,
+            "hook_params": TEST_HOOK_PARAMS,
+            "inactivity_period": TEST_INACTIVITY_PERIOD,
+            "min_objects": TEST_MIN_OBJECTS,
+            "previous_objects": TEST_PREVIOUS_OBJECTS,
+            "allow_delete": TEST_ALLOW_DELETE,
+        }
 
-@pytest.mark.asyncio
-@mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSUploadSessionTrigger._list_blobs_with_prefix")
-async def test_gcs_upload_session_trigger_exception(mock_list_blobs):
-    """
-    Tests the GCSUploadSessionTrigger does fire if there is an exception.
-    """
-    mock_list_blobs.side_effect = mock.AsyncMock(side_effect=Exception("Test exception"))
-    trigger = GCSUploadSessionTrigger(
-        TEST_BUCKET,
-        TEST_PREFIX,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        TEST_INACTIVITY_PERIOD,
-        TEST_MIN_OBJECTS,
-        TEST_PREVIOUS_OBJECTS,
-        TEST_ALLOW_DELETE,
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.gcs.GCSUploadSessionTrigger._list_blobs_with_prefix"
     )
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) == actual
+    @mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSUploadSessionTrigger._is_bucket_updated")
+    async def test_gcs_upload_session_trigger_pending(self, mock_is_bucket_updated, mock_list_blobs):
+        """
+        Test that GCSUploadSessionTrigger is in loop if Upload is still in progress till inactivity period.
+        """
+        mock_is_bucket_updated.return_value = {"status": "pending"}
+        mock_list_blobs.return_value = TEST_PREVIOUS_OBJECTS
 
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "allow_delete, current_objects, response",
-    [
-        (True, {"a", "aa", "ab"}, {"status": "pending"}),
-        (True, {"a"}, {"status": "pending"}),
-        (
-            False,
-            {"a"},
-            {
-                "status": "error",
-                "message": "Illegal behavior: objects were deleted in between check intervals",
-            },
-        ),
-    ],
-)
-async def test_is_bucket_updated_pending_status(allow_delete, current_objects, response):
-    """
-    Tests to check if there is less items or more items than expected and reset the inactivity period
-    along with the proper status
-    """
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
 
-    trigger = GCSUploadSessionTrigger(
-        TEST_BUCKET,
-        TEST_PREFIX,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        TEST_INACTIVITY_PERIOD,
-        TEST_MIN_OBJECTS,
-        TEST_PREVIOUS_OBJECTS,
-        allow_delete,
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "is_bucket_return_value",
+        [
+            ({"status": "success", "message": "Successfully completed"}),
+            ({"status": "error", "message": "Error occurred"}),
+        ],
     )
-    res = trigger._is_bucket_updated(current_objects=current_objects)
-    assert res == response
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "last_activity_time , min_objects, response",
-    [
-        (
-            datetime.now() - timedelta(hours=0, minutes=50),
-            10,
-            {
-                "status": "error",
-                "message": (
-                    "FAILURE: Inactivity Period passed, not enough objects found in TEST_BUCKET/TEST_PREFIX"
-                ),
-            },
-        ),
-        (None, 10, {"status": "pending"}),
-        (
-            datetime.now() - timedelta(hours=0, minutes=50),
-            1,
-            {
-                "status": "success",
-                "message": (
-                    "SUCCESS: Sensor found 2 objects at TEST_BUCKET/TEST_PREFIX. "
-                    "Waited at least 5.0 seconds, with no new objects dropped."
-                ),
-            },
-        ),
-    ],
-)
-@mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSUploadSessionTrigger._get_time")
-async def test_is_bucket_updated_success_failure_status(mock_time, last_activity_time, min_objects, response):
-    """
-    Tests to check if inactivity period is finished and found min objects or not and return status
-    based on that.
-    """
-    mock_time.return_value = (
-        last_activity_time + timedelta(seconds=5) if last_activity_time else datetime.now()
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.gcs.GCSUploadSessionTrigger._list_blobs_with_prefix"
     )
+    @mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSUploadSessionTrigger._is_bucket_updated")
+    async def test_gcs_upload_session_trigger_success(
+        self, mock_is_bucket_updated, mock_list_blobs, is_bucket_return_value
+    ):
+        """
+        Tests that the GCSUploadSessionTrigger is success case
+        """
+        mock_is_bucket_updated.return_value = is_bucket_return_value
+        mock_list_blobs.return_value = TEST_PREVIOUS_OBJECTS
 
-    trigger = GCSUploadSessionTrigger(
-        TEST_BUCKET,
-        TEST_PREFIX,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-        TEST_INACTIVITY_PERIOD,
-        min_objects,
-        TEST_PREVIOUS_OBJECTS,
-        TEST_ALLOW_DELETE,
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent(is_bucket_return_value) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.gcs.GCSUploadSessionTrigger._list_blobs_with_prefix"
     )
-    trigger.last_activity_time = last_activity_time
-    res = trigger._is_bucket_updated(current_objects=TEST_PREVIOUS_OBJECTS)
-    assert res == response
+    async def test_gcs_upload_session_trigger_exception(self, mock_list_blobs):
+        """
+        Tests the GCSUploadSessionTrigger does fire if there is an exception.
+        """
+        mock_list_blobs.side_effect = mock.AsyncMock(side_effect=Exception("Test exception"))
 
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) == actual
 
-def test_gcs_blob_update_trigger_serialization():
-    """
-    Asserts that the GCSCheckBlobUpdateTimeTrigger correctly serializes its arguments
-    and classpath.
-    """
-    trigger = GCSCheckBlobUpdateTimeTrigger(
-        TEST_BUCKET,
-        TEST_OBJECT,
-        TEST_TS_OBJECT,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "allow_delete, current_objects, response",
+        [
+            (True, {"a", "aa", "ab"}, {"status": "pending"}),
+            (True, {"a"}, {"status": "pending"}),
+            (
+                False,
+                {"a"},
+                {
+                    "status": "error",
+                    "message": "Illegal behavior: objects were deleted in between check intervals",
+                },
+            ),
+        ],
     )
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.gcs.GCSCheckBlobUpdateTimeTrigger"
-    assert kwargs == {
-        "bucket": TEST_BUCKET,
-        "object_name": TEST_OBJECT,
-        "ts": TEST_TS_OBJECT,
-        "poke_interval": TEST_POLLING_INTERVAL,
-        "google_cloud_conn_id": TEST_GCP_CONN_ID,
-        "hook_params": TEST_HOOK_PARAMS,
-    }
+    async def test_is_bucket_updated_pending_status(self, allow_delete, current_objects, response):
+        """
+        Tests to check if there is less items or more items than expected and reset the inactivity period
+        along with the proper status
+        """
 
+        trigger = GCSUploadSessionTrigger(
+            TEST_BUCKET,
+            TEST_PREFIX,
+            TEST_POLLING_INTERVAL,
+            TEST_GCP_CONN_ID,
+            TEST_HOOK_PARAMS,
+            TEST_INACTIVITY_PERIOD,
+            TEST_MIN_OBJECTS,
+            TEST_PREVIOUS_OBJECTS,
+            allow_delete,
+        )
+        res = trigger._is_bucket_updated(current_objects=current_objects)
+        assert res == response
 
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.google.cloud.triggers.gcs.GCSCheckBlobUpdateTimeTrigger._is_blob_updated_after"
-)
-async def test_gcs_blob_update_trigger_success(mock_blob_updated):
-    """
-    Tests success case GCSCheckBlobUpdateTimeTrigger
-    """
-    mock_blob_updated.return_value = True, {"status": "success", "message": "success"}
-
-    trigger = GCSCheckBlobUpdateTimeTrigger(
-        TEST_BUCKET,
-        TEST_OBJECT,
-        TEST_TS_OBJECT,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "last_activity_time , min_objects, response",
+        [
+            (
+                datetime.now() - timedelta(hours=0, minutes=50),
+                10,
+                {
+                    "status": "error",
+                    "message": (
+                        "FAILURE: Inactivity Period passed, not enough objects found in TEST_BUCKET/TEST_PREFIX"
+                    ),
+                },
+            ),
+            (None, 10, {"status": "pending"}),
+            (
+                datetime.now() - timedelta(hours=0, minutes=50),
+                1,
+                {
+                    "status": "success",
+                    "message": (
+                        "SUCCESS: Sensor found 2 objects at TEST_BUCKET/TEST_PREFIX. "
+                        "Waited at least 5.0 seconds, with no new objects dropped."
+                    ),
+                },
+            ),
+        ],
     )
+    @mock.patch("astronomer.providers.google.cloud.triggers.gcs.GCSUploadSessionTrigger._get_time")
+    async def test_is_bucket_updated_success_failure_status(
+        self, mock_time, last_activity_time, min_objects, response
+    ):
+        """
+        Tests to check if inactivity period is finished and found min objects or not and return status
+        based on that.
+        """
+        mock_time.return_value = (
+            last_activity_time + timedelta(seconds=5) if last_activity_time else datetime.now()
+        )
 
-    generator = trigger.run()
-    actual = await generator.asend(None)
-    assert TriggerEvent({"status": "success", "message": "success"}) == actual
-
-
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.google.cloud.triggers.gcs.GCSCheckBlobUpdateTimeTrigger._is_blob_updated_after"
-)
-async def test_gcs_blob_update_trigger_pending(mock_blob_updated):
-    """
-    Test that GCSCheckBlobUpdateTimeTrigger is in loop till file isn't updated.
-    """
-    mock_blob_updated.return_value = False, {"status": "pending", "message": "pending"}
-
-    trigger = GCSCheckBlobUpdateTimeTrigger(
-        TEST_BUCKET,
-        TEST_OBJECT,
-        TEST_TS_OBJECT,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-    )
-    task = asyncio.create_task(trigger.run().__anext__())
-    await asyncio.sleep(0.5)
-
-    # TriggerEvent was not returned
-    assert task.done() is False
-    asyncio.get_event_loop().stop()
+        trigger = GCSUploadSessionTrigger(
+            TEST_BUCKET,
+            TEST_PREFIX,
+            TEST_POLLING_INTERVAL,
+            TEST_GCP_CONN_ID,
+            TEST_HOOK_PARAMS,
+            TEST_INACTIVITY_PERIOD,
+            min_objects,
+            TEST_PREVIOUS_OBJECTS,
+            TEST_ALLOW_DELETE,
+        )
+        trigger.last_activity_time = last_activity_time
+        res = trigger._is_bucket_updated(current_objects=TEST_PREVIOUS_OBJECTS)
+        assert res == response
 
 
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.google.cloud.triggers.gcs.GCSCheckBlobUpdateTimeTrigger._is_blob_updated_after"
-)
-async def test_gcs_blob_update_trigger_exception(mock_object_exists):
-    """
-    Tests the GCSCheckBlobUpdateTimeTrigger does fire if there is an exception.
-    """
-    mock_object_exists.side_effect = mock.AsyncMock(side_effect=Exception("Test exception"))
-    trigger = GCSCheckBlobUpdateTimeTrigger(
-        TEST_BUCKET,
-        TEST_OBJECT,
-        TEST_TS_OBJECT,
-        TEST_POLLING_INTERVAL,
-        TEST_GCP_CONN_ID,
-        TEST_HOOK_PARAMS,
-    )
-    task = [i async for i in trigger.run()]
-    assert len(task) == 1
-    assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "blob_object_update_datetime, ts_object, expected_response",
-    [
-        (
-            "2022-03-07T10:05:43.535Z",
-            datetime(2022, 1, 1, 1, 1, 1),
-            (True, {"status": "success", "message": "success"}),
-        ),
-        (
-            "2022-03-07T10:05:43.535Z",
-            datetime(2022, 3, 8, 1, 1, 1),
-            (False, {"status": "pending", "message": "pending"}),
-        ),
-    ],
-)
-async def test_is_blob_updated_after(blob_object_update_datetime, ts_object, expected_response):
-    """
-    Tests to check if a particular object in Google Cloud Storage
-    is found or not
-    """
-    hook = mock.AsyncMock(GCSHookAsync)
-    storage = mock.AsyncMock(Storage)
-    hook.get_storage_client.return_value = storage
-    bucket = mock.AsyncMock(Bucket)
-    storage.get_bucket.return_value = bucket
-    bucket.get_blob.return_value.updated = blob_object_update_datetime
-    trigger = GCSCheckBlobUpdateTimeTrigger(
-        bucket=TEST_BUCKET,
-        object_name=TEST_OBJECT,
-        ts=ts_object,
-        poke_interval=TEST_POLLING_INTERVAL,
-        google_cloud_conn_id=TEST_GCP_CONN_ID,
-        hook_params=TEST_HOOK_PARAMS,
-    )
-    res = await trigger._is_blob_updated_after(hook, TEST_BUCKET, TEST_OBJECT, ts_object)
-    assert res == expected_response
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "blob_object, expected_response",
-    [
-        (
-            None,
-            (True, {"status": "error", "message": "Object (TEST_OBJECT) not found in Bucket (TEST_BUCKET)"}),
-        ),
-    ],
-)
-async def test_is_blob_updated_after_with_none(blob_object, expected_response):
-    """
-    Tests to check if a particular object in Google Cloud Storage
-    is found or not
-    """
-    hook = mock.AsyncMock(GCSHookAsync)
-    storage = mock.AsyncMock(Storage)
-    hook.get_storage_client.return_value = storage
-    bucket = mock.AsyncMock(Bucket)
-    storage.get_bucket.return_value = bucket
-    bucket.get_blob.return_value = blob_object
-    trigger = GCSCheckBlobUpdateTimeTrigger(
+class TestGCSCheckBlobUpdateTimeTrigger:
+    TRIGGER = GCSCheckBlobUpdateTimeTrigger(
         bucket=TEST_BUCKET,
         object_name=TEST_OBJECT,
         ts=TEST_TS_OBJECT,
@@ -633,5 +391,131 @@ async def test_is_blob_updated_after_with_none(blob_object, expected_response):
         google_cloud_conn_id=TEST_GCP_CONN_ID,
         hook_params=TEST_HOOK_PARAMS,
     )
-    res = await trigger._is_blob_updated_after(hook, TEST_BUCKET, TEST_OBJECT, TEST_TS_OBJECT)
-    assert res == expected_response
+
+    def test_gcs_blob_update_trigger_serialization(self):
+        """
+        Asserts that the GCSCheckBlobUpdateTimeTrigger correctly serializes its arguments
+        and classpath.
+        """
+
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == "astronomer.providers.google.cloud.triggers.gcs.GCSCheckBlobUpdateTimeTrigger"
+        assert kwargs == {
+            "bucket": TEST_BUCKET,
+            "object_name": TEST_OBJECT,
+            "ts": TEST_TS_OBJECT,
+            "poke_interval": TEST_POLLING_INTERVAL,
+            "google_cloud_conn_id": TEST_GCP_CONN_ID,
+            "hook_params": TEST_HOOK_PARAMS,
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.gcs.GCSCheckBlobUpdateTimeTrigger._is_blob_updated_after"
+    )
+    async def test_gcs_blob_update_trigger_success(self, mock_blob_updated):
+        """
+        Tests success case GCSCheckBlobUpdateTimeTrigger
+        """
+        mock_blob_updated.return_value = True, {"status": "success", "message": "success"}
+
+        generator = self.TRIGGER.run()
+        actual = await generator.asend(None)
+        assert TriggerEvent({"status": "success", "message": "success"}) == actual
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.gcs.GCSCheckBlobUpdateTimeTrigger._is_blob_updated_after"
+    )
+    async def test_gcs_blob_update_trigger_pending(self, mock_blob_updated):
+        """
+        Test that GCSCheckBlobUpdateTimeTrigger is in loop till file isn't updated.
+        """
+        mock_blob_updated.return_value = False, {"status": "pending", "message": "pending"}
+
+        task = asyncio.create_task(self.TRIGGER.run().__anext__())
+        await asyncio.sleep(0.5)
+
+        # TriggerEvent was not returned
+        assert task.done() is False
+        asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        "astronomer.providers.google.cloud.triggers.gcs.GCSCheckBlobUpdateTimeTrigger._is_blob_updated_after"
+    )
+    async def test_gcs_blob_update_trigger_exception(self, mock_object_exists):
+        """
+        Tests the GCSCheckBlobUpdateTimeTrigger does fire if there is an exception.
+        """
+        mock_object_exists.side_effect = mock.AsyncMock(side_effect=Exception("Test exception"))
+
+        task = [i async for i in self.TRIGGER.run()]
+        assert len(task) == 1
+        assert TriggerEvent({"status": "error", "message": "Test exception"}) in task
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "blob_object_update_datetime, ts_object, expected_response",
+        [
+            (
+                "2022-03-07T10:05:43.535Z",
+                datetime(2022, 1, 1, 1, 1, 1),
+                (True, {"status": "success", "message": "success"}),
+            ),
+            (
+                "2022-03-07T10:05:43.535Z",
+                datetime(2022, 3, 8, 1, 1, 1),
+                (False, {"status": "pending", "message": "pending"}),
+            ),
+        ],
+    )
+    async def test_is_blob_updated_after(self, blob_object_update_datetime, ts_object, expected_response):
+        """
+        Tests to check if a particular object in Google Cloud Storage
+        is found or not
+        """
+        hook = mock.AsyncMock(GCSHookAsync)
+        storage = mock.AsyncMock(Storage)
+        hook.get_storage_client.return_value = storage
+        bucket = mock.AsyncMock(Bucket)
+        storage.get_bucket.return_value = bucket
+        bucket.get_blob.return_value.updated = blob_object_update_datetime
+        trigger = GCSCheckBlobUpdateTimeTrigger(
+            bucket=TEST_BUCKET,
+            object_name=TEST_OBJECT,
+            ts=ts_object,
+            poke_interval=TEST_POLLING_INTERVAL,
+            google_cloud_conn_id=TEST_GCP_CONN_ID,
+            hook_params=TEST_HOOK_PARAMS,
+        )
+        res = await trigger._is_blob_updated_after(hook, TEST_BUCKET, TEST_OBJECT, ts_object)
+        assert res == expected_response
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "blob_object, expected_response",
+        [
+            (
+                None,
+                (
+                    True,
+                    {"status": "error", "message": "Object (TEST_OBJECT) not found in Bucket (TEST_BUCKET)"},
+                ),
+            ),
+        ],
+    )
+    async def test_is_blob_updated_after_with_none(self, blob_object, expected_response):
+        """
+        Tests to check if a particular object in Google Cloud Storage
+        is found or not
+        """
+        hook = mock.AsyncMock(GCSHookAsync)
+        storage = mock.AsyncMock(Storage)
+        hook.get_storage_client.return_value = storage
+        bucket = mock.AsyncMock(Bucket)
+        storage.get_bucket.return_value = bucket
+        bucket.get_blob.return_value = blob_object
+
+        res = await self.TRIGGER._is_blob_updated_after(hook, TEST_BUCKET, TEST_OBJECT, TEST_TS_OBJECT)
+        assert res == expected_response

--- a/tests/google/cloud/triggers/test_kubernetes_engine.py
+++ b/tests/google/cloud/triggers/test_kubernetes_engine.py
@@ -4,21 +4,19 @@ import pytest
 from airflow.triggers.base import TriggerEvent
 from kubernetes_asyncio import client
 
-from astronomer.providers.google.cloud.triggers.kubernetes_engine import (
-    GKEStartPodTrigger,
-)
+from astronomer.providers.google.cloud.triggers.kubernetes_engine import GKEStartPodTrigger
 
 PROJECT_ID = "astronomer-***-providers"
 LOCATION = "us-west1"
-GKE_CLUSTER_NAME = "provider-***-gke-cluster"
 NAMESPACE = "default"
 GCP_CONN_ID = "google_cloud_default"
 POD_NAME = "astro-k8s-gke-test-pod-25131a0d9cda46419099ac4aa8a4ef8f"
+MODULE_GOOGLE = "airflow.providers.google.cloud"
+MODULE_CNCF = "astronomer.providers.cncf"
 
 
-def test_serialization():
-    """asserts that the GKEStartPodTrigger correctly serializes its argument and classpath."""
-    trigger = GKEStartPodTrigger(
+class TestGKEStartPodTrigger:
+    TRIGGER = GKEStartPodTrigger(
         namespace=NAMESPACE,
         name=POD_NAME,
         in_cluster=False,
@@ -35,138 +33,89 @@ def test_serialization():
         logging_interval=None,
     )
 
-    classpath, kwargs = trigger.serialize()
-    assert classpath == "astronomer.providers.google.cloud.triggers.kubernetes_engine.GKEStartPodTrigger"
-    assert kwargs == {
-        "location": LOCATION,
-        "cluster_name": "base",
-        "regional": False,
-        "use_internal_ip": False,
-        "project_id": PROJECT_ID,
-        "gcp_conn_id": GCP_CONN_ID,
-        "impersonation_chain": None,
-        "cluster_context": None,
-        "in_cluster": False,
-        "namespace": NAMESPACE,
-        "name": POD_NAME,
-        "poll_interval": 5,
-        "pending_phase_timeout": 120,
-        "logging_interval": None,
-    }
+    def test_serialization(self):
+        """asserts that the GKEStartPodTrigger correctly serializes its argument and classpath."""
 
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "mock_state, expected_value",
-    [
-        ("Succeeded", {"status": "done", "namespace": NAMESPACE, "pod_name": POD_NAME}),
-        (
-            "Failed",
-            {
-                "status": "failed",
-                "namespace": NAMESPACE,
-                "pod_name": POD_NAME,
-                "description": "Failed to start pod operator",
-            },
-        ),
-    ],
-)
-@mock.patch(
-    "astronomer.providers.cncf.kubernetes.triggers.wait_container.WaitContainerTrigger.wait_for_pod_start"
-)
-@mock.patch("astronomer.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHookAsync.get_api_client_async")
-@mock.patch(
-    "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file"
-)
-async def test_run(mock_tmp, get_api_client_async, wait_for_pod_start, mock_state, expected_value):
-    """assert that when wait_for_pod_start succeeded run method yield correct event"""
-    my_tmp = mock_tmp.__enter__()
-    my_tmp.return_value = "/tmp/tmps90l"
-    get_api_client_async.return_value = client.ApiClient()
-    wait_for_pod_start.return_value = mock_state
-    trigger = GKEStartPodTrigger(
-        namespace=NAMESPACE,
-        name=POD_NAME,
-        in_cluster=False,
-        cluster_context=None,
-        location=LOCATION,
-        cluster_name="base",
-        use_internal_ip=False,
-        project_id=PROJECT_ID,
-        gcp_conn_id=GCP_CONN_ID,
-        impersonation_chain=None,
-        regional=False,
-        poll_interval=5,
-        pending_phase_timeout=120,
-        logging_interval=None,
-    )
-    assert await trigger.run().__anext__() == TriggerEvent(expected_value)
-
-
-@pytest.mark.asyncio
-@mock.patch(
-    "astronomer.providers.cncf.kubernetes.triggers.wait_container.WaitContainerTrigger.wait_for_container_completion"
-)
-@mock.patch(
-    "astronomer.providers.cncf.kubernetes.triggers.wait_container.WaitContainerTrigger.wait_for_pod_start"
-)
-@mock.patch("astronomer.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHookAsync.get_api_client_async")
-@mock.patch(
-    "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file"
-)
-async def test_run_pending(mock_tmp, get_api_client_async, wait_for_pod_start, wait_for_container_completion):
-    """assert that when wait_for_pod_start Pending run method yield wait_for_container_completion response"""
-    my_tmp = mock_tmp.__enter__()
-    my_tmp.return_value = "/tmp/tmps90l"
-    get_api_client_async.return_value = client.ApiClient()
-    wait_for_pod_start.return_value = "Pending"
-    wait_for_container_completion.return_value = TriggerEvent({"status": "done"})
-    trigger = GKEStartPodTrigger(
-        namespace=NAMESPACE,
-        name=POD_NAME,
-        in_cluster=False,
-        cluster_context=None,
-        location=LOCATION,
-        cluster_name="base",
-        use_internal_ip=False,
-        project_id=PROJECT_ID,
-        gcp_conn_id=GCP_CONN_ID,
-        impersonation_chain=None,
-        regional=False,
-        poll_interval=5,
-        pending_phase_timeout=120,
-        logging_interval=None,
-    )
-    assert await trigger.run().__anext__() == TriggerEvent({"status": "done"})
-
-
-@pytest.mark.asyncio
-@mock.patch(
-    "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file"
-)
-async def test_run_exception(mock_tmp):
-    """assert that run raise exception when fail to fetch GKE kube config file"""
-    my_tmp = mock_tmp.__enter__()
-    my_tmp.return_value = None
-    trigger = GKEStartPodTrigger(
-        namespace=NAMESPACE,
-        name=POD_NAME,
-        in_cluster=False,
-        cluster_context=None,
-        location=LOCATION,
-        cluster_name="base",
-        use_internal_ip=False,
-        project_id=PROJECT_ID,
-        gcp_conn_id=GCP_CONN_ID,
-        impersonation_chain=None,
-        regional=False,
-        poll_interval=5,
-        pending_phase_timeout=120,
-        logging_interval=None,
-    )
-    assert await trigger.run().__anext__() == TriggerEvent(
-        {
-            "status": "error",
-            "message": "Invalid kube-config file. Expected key current-context in kube-config",
+        classpath, kwargs = self.TRIGGER.serialize()
+        assert classpath == "astronomer.providers.google.cloud.triggers.kubernetes_engine.GKEStartPodTrigger"
+        assert kwargs == {
+            "location": LOCATION,
+            "cluster_name": "base",
+            "regional": False,
+            "use_internal_ip": False,
+            "project_id": PROJECT_ID,
+            "gcp_conn_id": GCP_CONN_ID,
+            "impersonation_chain": None,
+            "cluster_context": None,
+            "in_cluster": False,
+            "namespace": NAMESPACE,
+            "name": POD_NAME,
+            "poll_interval": 5,
+            "pending_phase_timeout": 120,
+            "logging_interval": None,
         }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mock_state, expected_value",
+        [
+            ("Succeeded", {"status": "done", "namespace": NAMESPACE, "pod_name": POD_NAME}),
+            (
+                "Failed",
+                {
+                    "status": "failed",
+                    "namespace": NAMESPACE,
+                    "pod_name": POD_NAME,
+                    "description": "Failed to start pod operator",
+                },
+            ),
+        ],
     )
+    @mock.patch(f"{MODULE_CNCF}.kubernetes.triggers.wait_container.WaitContainerTrigger.wait_for_pod_start")
+    @mock.patch(
+        "astronomer.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHookAsync.get_api_client_async"
+    )
+    @mock.patch(f"{MODULE_GOOGLE}.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file")
+    async def test_run(self, mock_tmp, get_api_client_async, wait_for_pod_start, mock_state, expected_value):
+        """assert that when wait_for_pod_start succeeded run method yield correct event"""
+        my_tmp = mock_tmp.__enter__()
+        my_tmp.return_value = "/tmp/tmps90l"
+        get_api_client_async.return_value = client.ApiClient()
+        wait_for_pod_start.return_value = mock_state
+
+        assert await self.TRIGGER.run().__anext__() == TriggerEvent(expected_value)
+
+    @pytest.mark.asyncio
+    @mock.patch(
+        f"{MODULE_CNCF}.kubernetes.triggers.wait_container.WaitContainerTrigger.wait_for_container_completion"
+    )
+    @mock.patch(f"{MODULE_CNCF}.kubernetes.triggers.wait_container.WaitContainerTrigger.wait_for_pod_start")
+    @mock.patch(
+        "astronomer.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHookAsync.get_api_client_async"
+    )
+    @mock.patch(f"{MODULE_GOOGLE}.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file")
+    async def test_run_pending(
+        self, mock_tmp, get_api_client_async, wait_for_pod_start, wait_for_container_completion
+    ):
+        """assert that when wait_for_pod_start Pending run method yield wait_for_container_completion response"""
+        my_tmp = mock_tmp.__enter__()
+        my_tmp.return_value = "/tmp/tmps90l"
+        get_api_client_async.return_value = client.ApiClient()
+        wait_for_pod_start.return_value = "Pending"
+        wait_for_container_completion.return_value = TriggerEvent({"status": "done"})
+
+        assert await self.TRIGGER.run().__anext__() == TriggerEvent({"status": "done"})
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE_GOOGLE}.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file")
+    async def test_run_exception(self, mock_tmp):
+        """assert that run raise exception when fail to fetch GKE kube config file"""
+        my_tmp = mock_tmp.__enter__()
+        my_tmp.return_value = None
+
+        assert await self.TRIGGER.run().__anext__() == TriggerEvent(
+            {
+                "status": "error",
+                "message": "Invalid kube-config file. Expected key current-context in kube-config",
+            }
+        )

--- a/tests/google/cloud/xcom_backends/test_gcs.py
+++ b/tests/google/cloud/xcom_backends/test_gcs.py
@@ -55,179 +55,144 @@ def conf_vars(overrides):
         settings.configure_vars()
 
 
-@mock.patch("astronomer.providers.google.cloud.xcom_backends.gcs._GCSXComBackend.write_and_upload_value")
-def test_custom_xcom_gcs_serialize(mock_write):
-    """
-    Asserts that custom xcom is serialize or not
-    """
-    real_job_id = "12345_hash"
-    mock_write.return_value = real_job_id
-    result = GCSXComBackend.serialize_value(real_job_id)
-    assert result == json.dumps(real_job_id).encode("UTF-8")
+class TestGCSXComBackend:
+    @mock.patch("astronomer.providers.google.cloud.xcom_backends.gcs._GCSXComBackend.write_and_upload_value")
+    def test_custom_xcom_gcs_serialize(self, mock_write):
+        """Asserts that custom xcom is serialize or not"""
+        real_job_id = "12345_hash"
+        mock_write.return_value = real_job_id
+        result = GCSXComBackend.serialize_value(real_job_id)
+        assert result == json.dumps(real_job_id).encode("UTF-8")
 
-
-@pytest.mark.parametrize(
-    "job_id",
-    ["1234567890", {"a": "b"}, ["123"]],
-)
-@mock.patch("uuid.uuid4")
-@mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.upload")
-def test_custom_xcom_gcs_write_and_upload(mock_upload, mock_uuid, job_id):
-    """
-    Asserts that custom xcom is upload and returns key
-    """
-    mock_uuid.return_value = "12345667890"
-    result = _GCSXComBackend().write_and_upload_value(job_id)
-    assert result == "gcs_xcom_" + "12345667890"
-
-
-@conf_vars({("core", "enable_xcom_pickling"): "True"})
-@pytest.mark.parametrize(
-    "job_id",
-    ["1234567890", {"a": "b"}, ["123"]],
-)
-@mock.patch("uuid.uuid4")
-@mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.upload")
-def test_custom_xcom_gcs_write_and_upload_pickle(mock_upload, mock_uuid, job_id):
-    """
-    Asserts that custom xcom is upload and returns key
-    """
-    mock_uuid.return_value = "12345667890"
-    result = _GCSXComBackend().write_and_upload_value(job_id)
-    assert result == "gcs_xcom_" + "12345667890"
-
-
-@mock.patch("uuid.uuid4")
-@mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.upload")
-def test_custom_xcom_gcs_write_and_upload_pandas(mock_upload, mock_uuid):
-    """
-    Asserts that custom xcom is upload and returns key
-    """
-    mock_uuid.return_value = "12345667890"
-    result = _GCSXComBackend().write_and_upload_value(pd.DataFrame({"numbers": [1], "colors": ["red"]}))
-    assert result == "gcs_xcom_" + "12345667890" + "_dataframe"
-
-
-@mock.patch("uuid.uuid4")
-@mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.upload")
-def test_custom_xcom_gcs_write_and_upload_datetime(mock_upload, mock_uuid):
-    """
-    Asserts that custom xcom is upload and returns key
-    """
-    mock_uuid.return_value = "12345667890"
-    result = _GCSXComBackend().write_and_upload_value(datetime.now())
-    assert result == "gcs_xcom_" + "12345667890" + "_datetime"
-
-
-@pytest.mark.parametrize(
-    "job_id",
-    ["1234567890", {"a": "b"}, ["123"]],
-)
-@mock.patch("uuid.uuid4")
-@mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.upload")
-def test_custom_xcom_gcs_write_and_upload_as_gzip(mock_upload, mock_uuid, job_id):
-    """
-    Asserts that custom xcom is upload and returns key
-    """
-    mock_uuid.return_value = "12345667890"
-    _GCSXComBackend.UPLOAD_CONTENT_AS_GZIP = mock.patch.dict(
-        os.environ, {"XCOM_BACKEND_UPLOAD_CONTENT_AS_GZIP": True}, clear=True
+    @pytest.mark.parametrize(
+        "job_id",
+        ["1234567890", {"a": "b"}, ["123"]],
     )
-    result = _GCSXComBackend().write_and_upload_value(job_id)
-    assert result == "gcs_xcom_" + "12345667890.gz"
+    @mock.patch("uuid.uuid4")
+    @mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.upload")
+    def test_custom_xcom_gcs_write_and_upload(self, mock_upload, mock_uuid, job_id):
+        """Asserts that custom xcom is upload and returns key"""
+        mock_uuid.return_value = "12345667890"
+        result = _GCSXComBackend().write_and_upload_value(job_id)
+        assert result == "gcs_xcom_" + "12345667890"
 
+    @conf_vars({("core", "enable_xcom_pickling"): "True"})
+    @pytest.mark.parametrize(
+        "job_id",
+        ["1234567890", {"a": "b"}, ["123"]],
+    )
+    @mock.patch("uuid.uuid4")
+    @mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.upload")
+    def test_custom_xcom_gcs_write_and_upload_pickle(self, mock_upload, mock_uuid, job_id):
+        """Asserts that custom xcom is upload and returns key"""
+        mock_uuid.return_value = "12345667890"
+        result = _GCSXComBackend().write_and_upload_value(job_id)
+        assert result == "gcs_xcom_" + "12345667890"
 
-@pytest.mark.parametrize(
-    "job_id",
-    ["gcs_xcom_1234"],
-)
-@mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.download")
-def test_custom_xcom_gcs_deserialize(mock_download, job_id):
-    """
-    Asserts that custom xcom is deserialized and check for data
-    """
-    mock_download.return_value = json.dumps(job_id).encode("UTF-8")
-    real_job_id = BaseXCom(value=json.dumps(job_id).encode("UTF-8"))
-    result = GCSXComBackend.deserialize_value(real_job_id)
-    assert result == job_id
+    @mock.patch("uuid.uuid4")
+    @mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.upload")
+    def test_custom_xcom_gcs_write_and_upload_pandas(self, mock_upload, mock_uuid):
+        """Asserts that custom xcom is upload and returns key"""
+        mock_uuid.return_value = "12345667890"
+        result = _GCSXComBackend().write_and_upload_value(pd.DataFrame({"numbers": [1], "colors": ["red"]}))
+        assert result == "gcs_xcom_" + "12345667890" + "_dataframe"
 
+    @mock.patch("uuid.uuid4")
+    @mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.upload")
+    def test_custom_xcom_gcs_write_and_upload_datetime(self, mock_upload, mock_uuid):
+        """Asserts that custom xcom is upload and returns key"""
+        mock_uuid.return_value = "12345667890"
+        result = _GCSXComBackend().write_and_upload_value(datetime.now())
+        assert result == "gcs_xcom_" + "12345667890" + "_datetime"
 
-@pytest.mark.parametrize(
-    "job_id",
-    ["gcs_xcom_1234_dataframe"],
-)
-@mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.download")
-def test_custom_xcom_gcs_deserialize_pandas(mock_read_value, job_id):
-    """
-    Asserts that custom xcom is deserialized and check for data
-    """
-    mock_read_value.return_value = pd.DataFrame({"numbers": [1], "colors": ["red"]}).to_json()
-    result = _GCSXComBackend.download_and_read_value(job_id)
-    assert_frame_equal(result, pd.DataFrame({"numbers": [1], "colors": ["red"]}))
+    @pytest.mark.parametrize(
+        "job_id",
+        ["1234567890", {"a": "b"}, ["123"]],
+    )
+    @mock.patch("uuid.uuid4")
+    @mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.upload")
+    def test_custom_xcom_gcs_write_and_upload_as_gzip(self, mock_upload, mock_uuid, job_id):
+        """Asserts that custom xcom is upload and returns key"""
+        mock_uuid.return_value = "12345667890"
+        _GCSXComBackend.UPLOAD_CONTENT_AS_GZIP = mock.patch.dict(
+            os.environ, {"XCOM_BACKEND_UPLOAD_CONTENT_AS_GZIP": True}, clear=True
+        )
+        result = _GCSXComBackend().write_and_upload_value(job_id)
+        assert result == "gcs_xcom_" + "12345667890.gz"
 
+    @pytest.mark.parametrize(
+        "job_id",
+        ["gcs_xcom_1234"],
+    )
+    @mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.download")
+    def test_custom_xcom_gcs_deserialize(self, mock_download, job_id):
+        """Asserts that custom xcom is deserialized and check for data"""
+        mock_download.return_value = json.dumps(job_id).encode("UTF-8")
+        real_job_id = BaseXCom(value=json.dumps(job_id).encode("UTF-8"))
+        result = GCSXComBackend.deserialize_value(real_job_id)
+        assert result == job_id
 
-@pytest.mark.parametrize(
-    "job_id",
-    ["gcs_xcom_1234_datetime"],
-)
-@mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.download")
-def test_custom_xcom_gcs_deserialize_datetime(mock_read_value, job_id):
-    """
-    Asserts that custom xcom is deserialized and check for data
-    """
-    time = datetime.now()
-    mock_read_value.return_value = time.isoformat()
-    result = _GCSXComBackend.download_and_read_value(job_id)
-    assert result == time
+    @pytest.mark.parametrize(
+        "job_id",
+        ["gcs_xcom_1234_dataframe"],
+    )
+    @mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.download")
+    def test_custom_xcom_gcs_deserialize_pandas(self, mock_read_value, job_id):
+        """Asserts that custom xcom is deserialized and check for data"""
+        mock_read_value.return_value = pd.DataFrame({"numbers": [1], "colors": ["red"]}).to_json()
+        result = _GCSXComBackend.download_and_read_value(job_id)
+        assert_frame_equal(result, pd.DataFrame({"numbers": [1], "colors": ["red"]}))
 
+    @pytest.mark.parametrize(
+        "job_id",
+        ["gcs_xcom_1234_datetime"],
+    )
+    @mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.download")
+    def test_custom_xcom_gcs_deserialize_datetime(self, mock_read_value, job_id):
+        """Asserts that custom xcom is deserialized and check for data"""
+        time = datetime.now()
+        mock_read_value.return_value = time.isoformat()
+        result = _GCSXComBackend.download_and_read_value(job_id)
+        assert result == time
 
-@conf_vars({("core", "enable_xcom_pickling"): "True"})
-@pytest.mark.parametrize(
-    "job_id",
-    ["gcs_xcom_1234"],
-)
-@mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.download")
-def test_custom_xcom_gcs_deserialize_pickle(mock_download, job_id):
-    """
-    Asserts that custom xcom is deserialized and check for data
-    """
-    mock_download.return_value = pickle.dumps(job_id)
-    result = _GCSXComBackend.download_and_read_value(job_id)
-    assert result == job_id
+    @conf_vars({("core", "enable_xcom_pickling"): "True"})
+    @pytest.mark.parametrize(
+        "job_id",
+        ["gcs_xcom_1234"],
+    )
+    @mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.download")
+    def test_custom_xcom_gcs_deserialize_pickle(self, mock_download, job_id):
+        """Asserts that custom xcom is deserialized and check for data"""
+        mock_download.return_value = pickle.dumps(job_id)
+        result = _GCSXComBackend.download_and_read_value(job_id)
+        assert result == job_id
 
+    @pytest.mark.parametrize(
+        "job_id",
+        ["gcs_xcom_1234"],
+    )
+    @mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.download")
+    def test_custom_xcom_gcs_deserialize_bytes(self, mock_download, job_id):
+        """Asserts that custom xcom is deserialized and check for data"""
+        mock_download.return_value = b'{ "Class": "Email addresses"}'
+        result = _GCSXComBackend.download_and_read_value(job_id)
+        assert result == {"Class": "Email addresses"}
 
-@pytest.mark.parametrize(
-    "job_id",
-    ["gcs_xcom_1234"],
-)
-@mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.download")
-def test_custom_xcom_gcs_deserialize_bytes(mock_download, job_id):
-    """
-    Asserts that custom xcom is deserialized and check for data
-    """
-    mock_download.return_value = b'{ "Class": "Email addresses"}'
-    result = _GCSXComBackend.download_and_read_value(job_id)
-    assert result == {"Class": "Email addresses"}
+    @pytest.mark.parametrize(
+        "job_id",
+        ["gcs_xcom_1234.gz"],
+    )
+    @mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.download")
+    def test_custom_xcom_gcs_deserialize_gzip(self, mock_download, job_id):
+        """Asserts that custom xcom is deserialized and check for data"""
+        mock_download.return_value = gzip.compress(b'{"Class": "Email addresses"}')
+        result = _GCSXComBackend.download_and_read_value(job_id)
+        assert result == {"Class": "Email addresses"}
 
-
-@pytest.mark.parametrize(
-    "job_id",
-    ["gcs_xcom_1234.gz"],
-)
-@mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.download")
-def test_custom_xcom_gcs_deserialize_gzip(mock_download, job_id):
-    """
-    Asserts that custom xcom is deserialized and check for data
-    """
-    mock_download.return_value = gzip.compress(b'{"Class": "Email addresses"}')
-    result = _GCSXComBackend.download_and_read_value(job_id)
-    assert result == {"Class": "Email addresses"}
-
-
-def test_custom_xcom_gcs_orm_deserialize_value():
-    """
-    Asserts that custom xcom has called the orm deserialized
-    value method and check for data.
-    """
-    result = GCSXComBackend().orm_deserialize_value()
-    assert result == "XCOM is uploaded into GCS bucket: airflow_xcom_backend_default_bucket"
+    def test_custom_xcom_gcs_orm_deserialize_value(self):
+        """
+        Asserts that custom xcom has called the orm deserialized
+        value method and check for data.
+        """
+        result = GCSXComBackend().orm_deserialize_value()
+        assert result == "XCOM is uploaded into GCS bucket: airflow_xcom_backend_default_bucket"

--- a/tests/utils/airflow_util.py
+++ b/tests/utils/airflow_util.py
@@ -30,13 +30,14 @@ def get_conn() -> Connection:
 def create_context(task, dag=None):
     if dag is None:
         dag = DAG(dag_id="dag")
-    tzinfo = pendulum.timezone("Europe/Amsterdam")
-    execution_date = timezone.datetime(2016, 1, 1, 1, 0, 0, tzinfo=tzinfo)
+    tzinfo = pendulum.timezone("UTC")
+    execution_date = timezone.datetime(2022, 1, 1, 1, 0, 0, tzinfo=tzinfo)
     dag_run = DagRun(
         dag_id=dag.dag_id,
         execution_date=execution_date,
         run_id=DagRun.generate_run_id(DagRunType.MANUAL, execution_date),
     )
+
     task_instance = TaskInstance(task=task)
     task_instance.dag_run = dag_run
     task_instance.xcom_push = mock.Mock()
@@ -48,4 +49,7 @@ def create_context(task, dag=None):
         "task_instance": task_instance,
         "run_id": dag_run.run_id,
         "dag_run": dag_run,
+        "execution_date": execution_date,
+        "data_interval_end": execution_date,
+        "logical_date": execution_date,
     }


### PR DESCRIPTION
google class-based tests

closes: https://github.com/astronomer/astronomer-providers/issues/694
related-to: https://github.com/astronomer/astronomer-providers/issues/568

- convert the function-based test to a class-based
- remove context fixture definition from operator/sensor/extractor and reuse from conftest
- remove function create_context from a couple of test files and reuse it from the util
- remove duplicate code for initializing op/senor/trigger/hook at possible places