### PR TITLE
Use  `timeout` instead of `execution_timeout` with `ExternalTaskSensor` when sensing task_id

### DIFF
--- a/astronomer/providers/core/sensors/external_task.py
+++ b/astronomer/providers/core/sensors/external_task.py
@@ -50,7 +50,7 @@ class ExternalTaskSensorAsync(ExternalTaskSensor):  # noqa: D101
             )
         else:
             self.defer(
-                timeout=self.execution_timeout,
+                timeout=datetime.timedelta(seconds=self.timeout),
                 trigger=TaskStateTrigger(
                     dag_id=self.external_dag_id,
                     task_id=self.external_task_id,


### PR DESCRIPTION
When an external task id is given `ExternalTaskSensor` is using `execution_timeout`  instead of `timeout` from `BaseSensorOperator`.

closes #857 