### PR TITLE
pin mypy version <1.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,9 @@ tests =
     pytest-cov
     pre-commit
 mypy =
-    mypy>=0.950
+    # mypy-1.0 crashing https://github.com/python/mypy/issues/14631
+    # TODO: unpin the version once above issue resolved
+    mypy>=0.950, <1.0.0
     types-aiofiles
     types-boto
     types-certifi


### PR DESCRIPTION
pin mypy version <1.0.0. 
Mypy-1.0.0 is crashing look similar to https://github.com/python/mypy/issues/14631
```
mypy 1.0.0
(compiled:
yes)
Traceback (most recent call last):
  File "/home/circleci/.pyenv/versions/3.9.16/bin/mypy", line 8, in <module>
    sys.exit(console_entry())
  File "/home/circleci/.pyenv/versions/3.9.16/lib/python3.9/site-packages/mypy/__main__.py", line 15, in console_entry
    main()
  File "mypy/main.py", line 95, in main
  File "mypy/main.py", line 174, in run_build
  File "mypy/build.py", line 194, in build
  File "mypy/build.py", line 277, in _build
  File "mypy/build.py", line 2923, in dispatch
  File "mypy/build.py", line 3320, in process_graph
  File "mypy/build.py", line 3443, in process_stale_scc
  File "mypy/build.py", line 2504, in write_cache
  File "mypy/build.py", line 1574, in write_cache
  File "mypy/nodes.py", line 377, in serialize
  File "mypy/nodes.py", line 3841, in serialize
  File "mypy/nodes.py", line 3778, in serialize
  File "mypy/nodes.py", line 3514, in serialize
  File "mypy/types.py", line 2072, in serialize
  File "mypy/types.py", line 605, in serialize
  File "mypy/types.py", line 2876, in serialize
AssertionError: Internal error: unresolved placeholder type None

Exited with code exit status 1
CircleCI received exit code 1

```