### PR TITLE
SFTPSensorAsync using newer_than doesn't work well with file_pattern

### DIFF
--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -28,7 +28,7 @@ class SFTPHookAsync(BaseHook):
     default_conn_name = "sftp_default"
     conn_type = "sftp"
     hook_name = "SFTP"
-    default_known_hosts = '"~/.ssh/known_hosts"'
+    default_known_hosts = "none"
 
     def __init__(  # nosec: B107
         self,
@@ -118,23 +118,20 @@ class SFTPHookAsync(BaseHook):
         except asyncssh.SFTPNoSuchFile:
             return None
 
-    async def get_file_by_pattern(self, path: str = "", fnmatch_pattern: str = "") -> str:
+    async def get_files_by_pattern(self, path: str = "", fnmatch_pattern: str = "") -> List[str]:
         """
         Returns the name of a file matching the file pattern at the provided path, if one exists
         Otherwise, raises an AirflowException to be handled upstream for deferring
         """
         files_list = await self.list_directory(path)
-
+        matched_files = []
         if files_list is None:
             raise AirflowException(f"No files at path {path} found...")
 
         for file in files_list:
-            if not fnmatch(file, fnmatch_pattern):
-                pass
-            else:
-                return file
-
-        raise AirflowException(f"No files matching file pattern were found at {path} — Deferring")
+            if fnmatch(file, fnmatch_pattern):
+                matched_files.append(file)
+        return matched_files
 
     async def get_mod_time(self, path: str) -> str:
         """

--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -124,13 +124,9 @@ class SFTPHookAsync(BaseHook):
         Otherwise, raises an AirflowException to be handled upstream for deferring
         """
         files_list = await self.list_directory(path)
-        matched_files = []
         if files_list is None:
             raise AirflowException(f"No files at path {path} found...")
-
-        for file in files_list:
-            if fnmatch(file, fnmatch_pattern):
-                matched_files.append(file)
+        matched_files = [file for file in files_list if fnmatch(file, fnmatch_pattern)]
         return matched_files
 
     async def get_mod_time(self, path: str) -> str:

--- a/tests/sftp/hooks/test_sftp.py
+++ b/tests/sftp/hooks/test_sftp.py
@@ -198,9 +198,9 @@ class TestSFTPHookAsync:
         mock_hook_get_conn.return_value = MockSSHClient()
         hook = SFTPHookAsync()
 
-        file = await hook.get_file_by_pattern(path="/path/exists/", fnmatch_pattern="file")
+        file = await hook.get_files_by_pattern(path="/path/exists/", fnmatch_pattern="file")
 
-        assert file == "file"
+        assert file == ["file"]
 
     @pytest.mark.asyncio
     @patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")
@@ -210,11 +210,9 @@ class TestSFTPHookAsync:
         """
         mock_hook_get_conn.return_value = MockSSHClient()
         hook = SFTPHookAsync()
+        file = await hook.get_files_by_pattern(path="/path/exists/", fnmatch_pattern="file_does_not_exist")
 
-        with pytest.raises(AirflowException) as exc:
-            await hook.get_file_by_pattern(path="/path/exists/", fnmatch_pattern="file_does_not_exist")
-
-        assert str(exc.value) == "No files matching file pattern were found at /path/exists/ — Deferring"
+        assert file == []
 
     @pytest.mark.asyncio
     @patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")

--- a/tests/sftp/triggers/test_sftp.py
+++ b/tests/sftp/triggers/test_sftp.py
@@ -138,11 +138,11 @@ class TestSFTPTrigger:
 
     @pytest.mark.asyncio
     @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_files_by_pattern")
-    async def test_sftp_trigger_run_trigger_failure_state(self, get_files_by_pattern):
+    async def test_sftp_trigger_run_trigger_failure_state(self, mock_get_files_by_pattern):
         """
         Mock the hook to raise other than an AirflowException and assert that a TriggerEvent with a failure status
         """
-        get_files_by_pattern.side_effect = Exception("An unexpected exception")
+        mock_get_files_by_pattern.side_effect = Exception("An unexpected exception")
 
         trigger = SFTPTrigger(path="test/path/", sftp_conn_id="sftp_default", file_pattern="my_test_file")
 
@@ -161,9 +161,10 @@ class TestSFTPTrigger:
         Assert that a the task does not complete if the hook raises an AirflowException,
         indicating that the task needs to be deferred
         """
-        mock_get_files_by_pattern.side_effect = AirflowException("No files at path found...")
 
-        trigger = SFTPTrigger(path="test/path/", sftp_conn_id="sftp_default", file_pattern="my_test_file")
+        mock_get_files_by_pattern.side_effect = AirflowException("No files at path /test/path/ found...")
+
+        trigger = SFTPTrigger(path="/test/path/", sftp_conn_id="sftp_default", file_pattern="my_test_file")
 
         task = asyncio.create_task(trigger.run().__anext__())
         await asyncio.sleep(0.5)


### PR DESCRIPTION
 When we use file_pattern and newer_than in SFTPSensorAsync to find only the files that landed in SFTP after the data interval of the prior successful DAG run ({{ prev_data_interval_end_success  }}).
I have four text files (file.txt, file1.txt, file2.txt and file3.txt) but only file3.txt has the last modification date after the data interval of the prior successful DAG run. I use the following file pattern: "*.txt".
The moment the first file (file.txt) was matched and the modification date did not meet the requirement.


The other files matching the pattern should be checked as well.

closes #903 
closes #904 