### PR TITLE
Fix mypy and add snowflake sensor dag to master dag

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -171,6 +171,7 @@ with DAG(
     snowflake_task_info = [
         {"snowflake_dag": "example_snowflake"},
         {"snowflake_sql_api_dag": "example_snowflake_sql_api"},
+        {"example_snowflake_sensor": "example_snowflake_sensor"},
     ]
     snowflake_trigger_tasks, ids = prepare_dag_dependency(snowflake_task_info, "{{ ds }}")
     dag_run_ids.extend(ids)

--- a/astronomer/providers/snowflake/hooks/snowflake.py
+++ b/astronomer/providers/snowflake/hooks/snowflake.py
@@ -16,7 +16,7 @@ from snowflake.connector.util_text import split_statements
 
 def fetch_all_snowflake_handler(
     cursor: SnowflakeCursor,
-) -> list[dict[str, Any] | tuple[Any, ...] | None]: 
+) -> list[dict[str, Any] | tuple[Any, ...] | None]:
     """Handler for SnowflakeCursor to return results"""
     return cursor.fetchall()
 
@@ -86,7 +86,7 @@ class SnowflakeHookAsync(SnowflakeHook):
                         cur.execute_async(sql_statement, parameters)
                     else:
                         cur.execute_async(sql_statement)
-                    query_id: str  = cur.sfqid
+                    query_id: str = cur.sfqid
                     self.log.info("Snowflake query id: %s", query_id)
                     self.query_ids.append(query_id)
 

--- a/astronomer/providers/snowflake/hooks/snowflake.py
+++ b/astronomer/providers/snowflake/hooks/snowflake.py
@@ -16,7 +16,7 @@ from snowflake.connector.util_text import split_statements
 
 def fetch_all_snowflake_handler(
     cursor: SnowflakeCursor,
-) -> list[dict[str, Any] | tuple[Any, ...] | None]:
+) -> list[dict[str, Any] | tuple[Any, ...] | None]: 
     """Handler for SnowflakeCursor to return results"""
     return cursor.fetchall()
 
@@ -69,7 +69,7 @@ class SnowflakeHookAsync(SnowflakeHook):
         :param autocommit: What to set the connection's autocommit setting to before executing the query.
         :param parameters: The parameters to render the SQL query with.
         """
-        self.query_ids: list[str] = []
+        self.query_ids = []
         with closing(self.get_conn()) as conn:
             self.log.info("SQL statement to be executed: %s ", sql)
             if isinstance(sql, str):
@@ -86,7 +86,7 @@ class SnowflakeHookAsync(SnowflakeHook):
                         cur.execute_async(sql_statement, parameters)
                     else:
                         cur.execute_async(sql_statement)
-                    query_id = cur.sfqid
+                    query_id: str  = cur.sfqid
                     self.log.info("Snowflake query id: %s", query_id)
                     self.query_ids.append(query_id)
 

--- a/astronomer/providers/snowflake/hooks/snowflake.py
+++ b/astronomer/providers/snowflake/hooks/snowflake.py
@@ -86,7 +86,7 @@ class SnowflakeHookAsync(SnowflakeHook):
                         cur.execute_async(sql_statement, parameters)
                     else:
                         cur.execute_async(sql_statement)
-                    query_id = cur.sfqid  
+                    query_id = cur.sfqid
                     self.log.info("Snowflake query id: %s", query_id)
                     self.query_ids.append(query_id)  # type: ignore[arg-type]
 

--- a/astronomer/providers/snowflake/hooks/snowflake.py
+++ b/astronomer/providers/snowflake/hooks/snowflake.py
@@ -88,7 +88,8 @@ class SnowflakeHookAsync(SnowflakeHook):
                         cur.execute_async(sql_statement)
                     query_id = cur.sfqid
                     self.log.info("Snowflake query id: %s", query_id)
-                    self.query_ids.append(query_id)  # type: ignore[arg-type]
+                    if query_id:
+                        self.query_ids.append(query_id)
 
             # If autocommit was set to False for db that supports autocommit,
             # or if db does not supports autocommit, we do a manual commit.

--- a/astronomer/providers/snowflake/hooks/snowflake.py
+++ b/astronomer/providers/snowflake/hooks/snowflake.py
@@ -86,7 +86,7 @@ class SnowflakeHookAsync(SnowflakeHook):
                         cur.execute_async(sql_statement, parameters)
                     else:
                         cur.execute_async(sql_statement)
-                    query_id = cur.sfqid # type: ignore[assignment]
+                    query_id = cur.sfqid  # type: ignore[assignment]
                     self.log.info("Snowflake query id: %s", query_id)
                     self.query_ids.append(query_id)
 

--- a/astronomer/providers/snowflake/hooks/snowflake.py
+++ b/astronomer/providers/snowflake/hooks/snowflake.py
@@ -16,7 +16,7 @@ from snowflake.connector.util_text import split_statements
 
 def fetch_all_snowflake_handler(
     cursor: SnowflakeCursor,
-) -> list[tuple[Any, ...]] | list[dict[str, Any]] | None:
+) -> list[dict[str, Any] | tuple[Any, ...] | None]: 
     """Handler for SnowflakeCursor to return results"""
     return cursor.fetchall()
 
@@ -69,7 +69,7 @@ class SnowflakeHookAsync(SnowflakeHook):
         :param autocommit: What to set the connection's autocommit setting to before executing the query.
         :param parameters: The parameters to render the SQL query with.
         """
-        self.query_ids = []
+        self.query_ids: list[str] = []
         with closing(self.get_conn()) as conn:
             self.log.info("SQL statement to be executed: %s ", sql)
             if isinstance(sql, str):

--- a/astronomer/providers/snowflake/hooks/snowflake.py
+++ b/astronomer/providers/snowflake/hooks/snowflake.py
@@ -16,7 +16,7 @@ from snowflake.connector.util_text import split_statements
 
 def fetch_all_snowflake_handler(
     cursor: SnowflakeCursor,
-) -> list[dict[str, Any] | tuple[Any, ...] | None]: 
+) -> list[dict[str, Any] | tuple[Any, ...] | None]:
     """Handler for SnowflakeCursor to return results"""
     return cursor.fetchall()
 

--- a/astronomer/providers/snowflake/hooks/snowflake.py
+++ b/astronomer/providers/snowflake/hooks/snowflake.py
@@ -86,9 +86,9 @@ class SnowflakeHookAsync(SnowflakeHook):
                         cur.execute_async(sql_statement, parameters)
                     else:
                         cur.execute_async(sql_statement)
-                    query_id = cur.sfqid  # type: ignore[assignment]
+                    query_id = cur.sfqid  
                     self.log.info("Snowflake query id: %s", query_id)
-                    self.query_ids.append(query_id)
+                    self.query_ids.append(query_id)  # type: ignore[arg-type]
 
             # If autocommit was set to False for db that supports autocommit,
             # or if db does not supports autocommit, we do a manual commit.

--- a/astronomer/providers/snowflake/hooks/snowflake.py
+++ b/astronomer/providers/snowflake/hooks/snowflake.py
@@ -86,7 +86,7 @@ class SnowflakeHookAsync(SnowflakeHook):
                         cur.execute_async(sql_statement, parameters)
                     else:
                         cur.execute_async(sql_statement)
-                    query_id: str = cur.sfqid
+                    query_id = cur.sfqid # type: ignore[assignment]
                     self.log.info("Snowflake query id: %s", query_id)
                     self.query_ids.append(query_id)
 


### PR DESCRIPTION
Fix mypy issues on main and  currently, the `example_snowflake_sensor` dag was not included as part of the master dag and this dag was not running on astro cloud. 
This PR adds the `example_snowflake_sensor` into master_dag.