### PR TITLE
Update ExternalTaskSensorAsync and SnowflakeSensorAsync to check on worker first

### DIFF
--- a/tests/snowflake/sensors/test_snowflake.py
+++ b/tests/snowflake/sensors/test_snowflake.py
@@ -4,7 +4,6 @@ from unittest import mock
 import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.models.dag import DAG
-
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 from astronomer.providers.snowflake.sensors.snowflake import SnowflakeSensorAsync
@@ -36,13 +35,9 @@ class TestPytestSnowflakeSensorAsync:
             timeout=TASK_TIMEOUT * 60,
         )
 
-        mock_hook.get_connection.return_value.get_hook.return_value = (
-            mock.MagicMock(spec=DbApiHook)
-        )
+        mock_hook.get_connection.return_value.get_hook.return_value = mock.MagicMock(spec=DbApiHook)
 
-        mock_get_records = (
-            mock_hook.get_connection.return_value.get_hook.return_value.get_records
-        )
+        mock_get_records = mock_hook.get_connection.return_value.get_hook.return_value.get_records
 
         mock_get_records.return_value = []
 
@@ -109,6 +104,4 @@ class TestPytestSnowflakeSensorAsync:
 
         with mock.patch.object(operator.log, "info") as mock_log_info:
             operator.execute_complete(context=None)
-        mock_log_info.assert_called_with(
-            "%s completed successfully.", "execute_complete"
-        )
+        mock_log_info.assert_called_with("%s completed successfully.", "execute_complete")


### PR DESCRIPTION
Based on internal discussion to mitigate race condition on deferrable sensor immediately getting successful, made the changes to the sensors to check on the worker first, then defer if the condition is not met.
- SnowflakeSensorAsync refactored to inherit from `SqlSensor` and rewrote the test
- ExternalTaskSensorAsync
- ExternalDeploymentTaskSensorAsync