### PR TITLE
Make amazon sagemaker async operators compatible with new amazon provider

### DIFF
--- a/astronomer/providers/amazon/aws/operators/sagemaker.py
+++ b/astronomer/providers/amazon/aws/operators/sagemaker.py
@@ -157,7 +157,7 @@ class SageMakerTransformOperatorAsync(SageMakerTransformOperator):
                 self._check_if_transform_job_exists()
             except AttributeError:
                 # for apache-airflow-providers-amazon>=7.3.0
-                transform_config["TransformJobName"] = self._get_unique_job_name(
+                transform_config["TransformJobName"] = self._get_unique_job_name(  # type: ignore[attr-defined]
                     transform_config["TransformJobName"],
                     self.action_if_job_exists == "fail",
                     self.hook.describe_transform_job,
@@ -245,7 +245,7 @@ class SageMakerTrainingOperatorAsync(SageMakerTrainingOperator):
                 self._check_if_job_exists()
             except TypeError:
                 # for apache-airflow-providers-amazon>=7.3.0
-                self.config["TrainingJobName"] = self._get_unique_job_name(
+                self.config["TrainingJobName"] = self._get_unique_job_name(  # type: ignore[attr-defined]
                     self.config["TrainingJobName"],
                     self.action_if_job_exists == "fail",
                     self.hook.describe_training_job,

--- a/tests/amazon/aws/operators/test_sagemaker.py
+++ b/tests/amazon/aws/operators/test_sagemaker.py
@@ -231,6 +231,7 @@ class TestSagemakerTransformOperatorAsync:
         task = SageMakerTransformOperatorAsync(
             config=CONFIG,
             task_id=self.TASK_ID,
+            check_if_job_exists=False,
             check_interval=self.CHECK_INTERVAL,
             max_ingestion_time=self.MAX_INGESTION_TIME,
         )
@@ -250,6 +251,7 @@ class TestSagemakerTransformOperatorAsync:
         task = SageMakerTransformOperatorAsync(
             config=CONFIG,
             task_id=self.TASK_ID,
+            check_if_job_exists=False,
             check_interval=self.CHECK_INTERVAL,
         )
         with pytest.raises(AirflowException):
@@ -321,6 +323,7 @@ class TestSagemakerTrainingOperatorAsync:
         task = SageMakerTrainingOperatorAsync(
             config=TRAINING_CONFIG,
             task_id=self.TASK_ID,
+            check_if_job_exists=False,
             print_log=mock_print_log_attr,
             check_interval=self.CHECK_INTERVAL,
             max_ingestion_time=self.MAX_INGESTION_TIME,
@@ -340,6 +343,7 @@ class TestSagemakerTrainingOperatorAsync:
         task = SageMakerTrainingOperatorAsync(
             config=TRAINING_CONFIG,
             task_id=self.TASK_ID,
+            check_if_job_exists=False,
             check_interval=self.CHECK_INTERVAL,
             max_ingestion_time=self.MAX_INGESTION_TIME,
         )


### PR DESCRIPTION
With the new RC release, the test cases were failing and dag was failing due to https://app.circleci.com/pipelines/github/astronomer/astronomer-providers/4127/workflows/1c8507c3-d802-46fc-9c1f-49c7fd9cc37e/jobs/19074,
This PR makes sagemaker operator compatible with an older and newer versions also.