### PR TITLE
S3KeyTrigger yields two trigger events when check_fn is none.

### DIFF
--- a/astronomer/providers/amazon/aws/triggers/s3.py
+++ b/astronomer/providers/amazon/aws/triggers/s3.py
@@ -67,10 +67,11 @@ class S3KeyTrigger(BaseTrigger):
                     if await hook.check_key(client, self.bucket_name, self.bucket_key, self.wildcard_match):
                         if self.check_fn is None:
                             yield TriggerEvent({"status": "success"})
-                        s3_objects = await hook.get_files(
-                            client, self.bucket_name, self.bucket_key, self.wildcard_match
-                        )
-                        yield TriggerEvent({"status": "success", "s3_objects": s3_objects})
+                        else:
+                            s3_objects = await hook.get_files(
+                                client, self.bucket_name, self.bucket_key, self.wildcard_match
+                            )
+                            yield TriggerEvent({"status": "success", "s3_objects": s3_objects})
                     await asyncio.sleep(self.poke_interval)
 
         except Exception as e:


### PR DESCRIPTION
When check_fn = None, i see in logs two TriggerEvent - one with success status and another with error status:
```
[2023-03-07 13:32:30,215] {triggerer_job.py:362} INFO - Trigger <astronomer.providers.amazon.aws.triggers.s3.S3KeyTrigger bucket_name=None, bucket_key=['s3://my_path/_SUCCESS'], wildcard_match=False, check_fn=None, aws_conn_id=aws_default, hook_params={'hook_params': {'verify': None}}, poke_interval=60> (ID 1086) fired: TriggerEvent<{'status': 'success'}>
[2023-03-07 13:32:30,222] {triggerer_job.py:362} INFO - Trigger <astronomer.providers.amazon.aws.triggers.s3.S3KeyTrigger bucket_name=None, bucket_key=['s3://my_path/_SUCCESS'], wildcard_match=False, check_fn=None, aws_conn_id=aws_default, hook_params={'hook_params': {'verify': None}}, poke_interval=60> (ID 1086) fired: TriggerEvent<{'status': 'error', 'message': 'expected string or bytes-like object'}>
```

This PR makes sure to it sends only one trigger event.

Closes #915 