### PR TITLE
Install new version of dependencies in Integration tests

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -70,7 +70,9 @@ ENV HADOOP_CONF_DIR=$HADOOP_HOME/conf
 ENV PATH $PATH:$JAVA_HOME/bin::$HIVE_HOME/bin:$HADOOP_HOME/bin
 
 COPY astronomer-providers /tmp/astronomer-providers
-RUN pip install /tmp/astronomer-providers[all]
+RUN  python3 -m pip install --upgrade pip
+# Ideally we should install using constraints file
+RUN pip install  --upgrade --force-reinstall  --no-cache-dir /tmp/astronomer-providers[all]
 RUN pip install apache-airflow[slack]
 
 


### PR DESCRIPTION
In integration test docker file we use `RUN pip install /tmp/astronomer-providers[all] ` to install astronomer-provider which uses cache and because of that it does not install latest version of dependent apache airflow provider. In this PR I'm making changes to install latest version and not use cache. 
cons: increase deployment time
pros: run against latest provider so we can use improvement   