### PR TITLE
Add max attempts to Redshift Cluster dag to wait

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -58,6 +58,7 @@ with DAG(
             {"Key": "Purpose", "Value": "ProviderTest"},
         ],
         wait_for_completion=True,
+        max_attempt=30,
         aws_conn_id=AWS_CONN_ID,
     )
 


### PR DESCRIPTION
Currently, when the dag was running by default max attempt was 5 and the interval period is 60 default. it will check for 5 mins and error out if the cluster is not brought up by then with the below error.
<img width="895" alt="image" src="https://user-images.githubusercontent.com/92459020/228224049-c4875eea-59e4-4245-a6ab-b54e4624e106.png">


but in the subsequent retry when it tries to bring up the cluster and throws an error saying ClusterAlreadyExists error.
<img width="1303" alt="image" src="https://user-images.githubusercontent.com/92459020/228224744-58a60e43-59cb-4bff-a8d5-3aa7c352bac1.png">



So this PR adds a max attempt of 30 which waits for a maximum of 30 mins to cluster to bring up.
