### PR TITLE
Fix redshift delete cluster when cluster not exist

### DIFF
--- a/astronomer/providers/amazon/aws/hooks/redshift_cluster.py
+++ b/astronomer/providers/amazon/aws/hooks/redshift_cluster.py
@@ -71,6 +71,8 @@ class RedshiftHookAsync(AwsBaseHookAsync):
                             return expected_response
                 return {"status": "error", "cluster_state": status}
         except botocore.exceptions.ClientError as error:
+            if error.response.get("Error", {}).get("Code", "") == "ClusterNotFound":
+                return {"status": "success", "cluster_state": "cluster_not_found"}
             return {"status": "error", "message": str(error)}
 
     async def pause_cluster(

--- a/tests/amazon/aws/hooks/test_redshift_cluster.py
+++ b/tests/amazon/aws/hooks/test_redshift_cluster.py
@@ -128,6 +128,7 @@ class TestRedshiftHookAsync:
 
         assert task == cluster_state
 
+    @pytest.mark.asyncio
     @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_cluster.RedshiftHookAsync.get_client_async")
     async def test_delete_cluster_when_cluster_not_exist(self, mock_client):
         mock_client.return_value.__aenter__.return_value.delete_cluster.side_effect = ClientError(

--- a/tests/amazon/aws/hooks/test_redshift_cluster.py
+++ b/tests/amazon/aws/hooks/test_redshift_cluster.py
@@ -133,8 +133,10 @@ class TestRedshiftHookAsync:
     async def test_delete_cluster_when_cluster_not_exist(self, mock_client):
         mock_client.return_value.__aenter__.return_value.delete_cluster.side_effect = ClientError(
             {
-                "Code": "ClusterNotFound",
-                "Message": "cluster not found",
+                "Error": {
+                    "Code": "ClusterNotFound",
+                    "Message": "cluster not found",
+                }
             },
             operation_name="DeleteCluster",
         )


### PR DESCRIPTION
currently, if cluster not exist and we try to use redshift delete cluster then https://github.com/astronomer/astronomer-providers/blob/46864035c106999446816e3b86316a85d642dd43/astronomer/providers/amazon/aws/hooks/redshift_cluster.py#L57-L61 throw exception and task fail but I think should pass