### PR TITLE
Set TriggerDagRunOperator's trigger_rule to all_done in master_dag

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -78,6 +78,7 @@ def prepare_dag_dependency(task_info, execution_time):
                 reset_dag_run=True,
                 execution_date=execution_time,
                 allowed_states=["success", "failed", "skipped"],
+                trigger_rule="all_done",
             )
         )
     return _task_list, _dag_run_ids

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,6 +96,7 @@ repos:
         # Excluding Example DAGs temporarily until they can be fixed
         exclude: ^tests/.*\.py$|.*example_dags/.*
         args: ["-c", "./pyproject.toml"]
+        additional_dependencies: [".[toml]"]
 
   - repo: local
     hooks:


### PR DESCRIPTION
The `master_dag` has implemented chaining of DAGs by grouping them based on providers. However, if one of the DAG fails in the chain, subsequent DAGs are not run and hence we do not test them. As such, the DAGs do not need to depend on each other and hence we can set the `trigger_rule` in the `TriggerDagRunOperator` to `all_done` so that we test all the DAGs irrespective of whether the previous DAG in the chain succeeded.

closes: #949 