### PR TITLE
fix(google): add back removed utility function get_gke_config_file

### DIFF
--- a/astronomer/providers/google/cloud/__init__.py
+++ b/astronomer/providers/google/cloud/__init__.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import contextmanager
+from typing import Generator, Sequence
+
+from airflow.exceptions import AirflowException
+from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
+from airflow.utils.process_utils import execute_in_subprocess, patch_environ
+
+KUBE_CONFIG_ENV_VAR = "KUBECONFIG"
+
+
+@contextmanager
+def _get_gke_config_file(
+    gcp_conn_id: str,
+    project_id: str | None,
+    cluster_name: str,
+    impersonation_chain: str | Sequence[str] | None,
+    regional: bool,
+    location: str,
+    use_internal_ip: bool,
+) -> Generator[str, None, None]:
+    hook = GoogleBaseHook(gcp_conn_id=gcp_conn_id)
+    project_id = project_id or hook.project_id
+
+    if not project_id:
+        raise AirflowException(
+            "The project id must be passed either as "
+            "keyword project_id parameter or as project_id extra "
+            "in Google Cloud connection definition. Both are not set!"
+        )
+
+    # Write config to a temp file and set the environment variable to point to it.
+    # This is to avoid race conditions of reading/writing a single file
+    with tempfile.NamedTemporaryFile() as conf_file, patch_environ(
+        {KUBE_CONFIG_ENV_VAR: conf_file.name}
+    ), hook.provide_authorized_gcloud():
+        # Attempt to get/update credentials
+        # We call gcloud directly instead of using google-cloud-python api
+        # because there is no way to write kubernetes config to a file, which is
+        # required by KubernetesPodOperator.
+        # The gcloud command looks at the env variable `KUBECONFIG` for where to save
+        # the kubernetes config file.
+        cmd = [
+            "gcloud",
+            "container",
+            "clusters",
+            "get-credentials",
+            cluster_name,
+            "--project",
+            project_id,
+        ]
+        if impersonation_chain:
+            if isinstance(impersonation_chain, str):
+                impersonation_account = impersonation_chain
+            elif len(impersonation_chain) == 1:
+                impersonation_account = impersonation_chain[0]
+            else:
+                raise AirflowException(
+                    "Chained list of accounts is not supported, please specify only one service account"
+                )
+
+            cmd.extend(
+                [
+                    "--impersonate-service-account",
+                    impersonation_account,
+                ]
+            )
+        if regional:
+            cmd.append("--region")
+        else:
+            cmd.append("--zone")
+        cmd.append(location)
+        if use_internal_ip:
+            cmd.append("--internal-ip")
+        execute_in_subprocess(cmd)
+
+        # Tell `KubernetesPodOperator` where the config file is located
+        yield os.environ[KUBE_CONFIG_ENV_VAR]

--- a/astronomer/providers/google/cloud/__init__.py
+++ b/astronomer/providers/google/cloud/__init__.py
@@ -13,7 +13,7 @@ KUBE_CONFIG_ENV_VAR = "KUBECONFIG"
 
 
 @contextmanager
-def _get_gke_config_file(
+def _get_gke_config_file(  # pragma: no cover
     gcp_conn_id: str,
     project_id: str | None,
     cluster_name: str,

--- a/astronomer/providers/google/cloud/__init__.py
+++ b/astronomer/providers/google/cloud/__init__.py
@@ -13,7 +13,7 @@ KUBE_CONFIG_ENV_VAR = "KUBECONFIG"
 
 
 @contextmanager
-def _get_gke_config_file(  # pragma: no cover
+def _get_gke_config_file(
     gcp_conn_id: str,
     project_id: str | None,
     cluster_name: str,
@@ -21,7 +21,7 @@ def _get_gke_config_file(  # pragma: no cover
     regional: bool,
     location: str,
     use_internal_ip: bool,
-) -> Generator[str, None, None]:
+) -> Generator[str, None, None]: # pragma: no cover
     hook = GoogleBaseHook(gcp_conn_id=gcp_conn_id)
     project_id = project_id or hook.project_id
 

--- a/astronomer/providers/google/cloud/__init__.py
+++ b/astronomer/providers/google/cloud/__init__.py
@@ -21,7 +21,7 @@ def _get_gke_config_file(
     regional: bool,
     location: str,
     use_internal_ip: bool,
-) -> Generator[str, None, None]: # pragma: no cover
+) -> Generator[str, None, None]:  # pragma: no cover
     hook = GoogleBaseHook(gcp_conn_id=gcp_conn_id)
     project_id = project_id or hook.project_id
 

--- a/astronomer/providers/google/cloud/operators/kubernetes_engine.py
+++ b/astronomer/providers/google/cloud/operators/kubernetes_engine.py
@@ -5,9 +5,6 @@ from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
     KubernetesPodOperator,
 )
-from airflow.providers.google.cloud.operators.kubernetes_engine import (
-    GKEStartPodOperator,
-)
 from kubernetes.client import models as k8s
 
 from astronomer.providers.cncf.kubernetes.operators.kubernetes_pod import (
@@ -16,6 +13,7 @@ from astronomer.providers.cncf.kubernetes.operators.kubernetes_pod import (
 from astronomer.providers.cncf.kubernetes.triggers.wait_container import (
     PodLaunchTimeoutException,
 )
+from astronomer.providers.google.cloud import _get_gke_config_file
 from astronomer.providers.google.cloud.triggers.kubernetes_engine import (
     GKEStartPodTrigger,
 )
@@ -92,7 +90,7 @@ class GKEStartPodOperatorAsync(KubernetesPodOperator):
 
     def _get_or_create_pod(self, context: Context) -> None:
         """A wrapper to fetch GKE config and get or create a pod"""
-        with GKEStartPodOperator.get_gke_config_file(
+        with _get_gke_config_file(
             gcp_conn_id=self.gcp_conn_id,
             project_id=self.project_id,
             cluster_name=self.cluster_name,
@@ -158,7 +156,7 @@ class GKEStartPodOperatorAsync(KubernetesPodOperator):
         remote_pod = None
         self.raise_for_trigger_status(event)
         try:
-            with GKEStartPodOperator.get_gke_config_file(
+            with _get_gke_config_file(
                 gcp_conn_id=self.gcp_conn_id,
                 project_id=self.project_id,
                 cluster_name=self.cluster_name,

--- a/astronomer/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/astronomer/providers/google/cloud/triggers/kubernetes_engine.py
@@ -1,9 +1,6 @@
 from typing import Any, AsyncIterator, Dict, Optional, Sequence, Tuple, Union
 
 from airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase
-from airflow.providers.google.cloud.operators.kubernetes_engine import (
-    GKEStartPodOperator,
-)
 from airflow.triggers.base import TriggerEvent
 from kubernetes_asyncio.client import CoreV1Api
 
@@ -11,6 +8,7 @@ from astronomer.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
 from astronomer.providers.cncf.kubernetes.triggers.wait_container import (
     WaitContainerTrigger,
 )
+from astronomer.providers.google.cloud import _get_gke_config_file
 
 
 class GKEStartPodTrigger(WaitContainerTrigger):
@@ -99,7 +97,7 @@ class GKEStartPodTrigger(WaitContainerTrigger):
     async def run(self) -> AsyncIterator["TriggerEvent"]:
         """Wait for pod to reach terminal state"""
         try:
-            with GKEStartPodOperator.get_gke_config_file(
+            with _get_gke_config_file(
                 gcp_conn_id=self.gcp_conn_id,
                 project_id=self.project_id,
                 cluster_name=self.cluster_name,

--- a/tests/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/google/cloud/operators/test_kubernetes_engine.py
@@ -53,9 +53,7 @@ class TestGKEStartPodOperatorAsync:
         get_logs=True,
     )
 
-    @mock.patch(
-        "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file"
-    )
+    @mock.patch("astronomer.providers.google.cloud.operators.kubernetes_engine._get_gke_config_file")
     @mock.patch(
         "airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.build_pod_request_obj"
     )
@@ -122,9 +120,7 @@ class TestGKEStartPodOperatorAsync:
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.fetch_container_logs")
     @mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
-    @mock.patch(
-        "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file"
-    )
+    @mock.patch("astronomer.providers.google.cloud.operators.kubernetes_engine._get_gke_config_file")
     @mock.patch(
         "astronomer.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperatorAsync.extract_xcom"
     )
@@ -167,9 +163,7 @@ class TestGKEStartPodOperatorAsync:
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.fetch_container_logs")
     @mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
-    @mock.patch(
-        "airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file"
-    )
+    @mock.patch("astronomer.providers.google.cloud.operators.kubernetes_engine._get_gke_config_file")
     def test_no_pod(
         self,
         mock_gke_config,

--- a/tests/google/cloud/triggers/test_kubernetes_engine.py
+++ b/tests/google/cloud/triggers/test_kubernetes_engine.py
@@ -75,7 +75,7 @@ class TestGKEStartPodTrigger:
     @mock.patch(
         "astronomer.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHookAsync.get_api_client_async"
     )
-    @mock.patch(f"{MODULE_GOOGLE}.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file")
+    @mock.patch("astronomer.providers.google.cloud.triggers.kubernetes_engine._get_gke_config_file")
     async def test_run(self, mock_tmp, get_api_client_async, wait_for_pod_start, mock_state, expected_value):
         """assert that when wait_for_pod_start succeeded run method yield correct event"""
         my_tmp = mock_tmp.__enter__()
@@ -93,7 +93,7 @@ class TestGKEStartPodTrigger:
     @mock.patch(
         "astronomer.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHookAsync.get_api_client_async"
     )
-    @mock.patch(f"{MODULE_GOOGLE}.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file")
+    @mock.patch("astronomer.providers.google.cloud.triggers.kubernetes_engine._get_gke_config_file")
     async def test_run_pending(
         self, mock_tmp, get_api_client_async, wait_for_pod_start, wait_for_container_completion
     ):
@@ -107,7 +107,7 @@ class TestGKEStartPodTrigger:
         assert await self.TRIGGER.run().__anext__() == TriggerEvent({"status": "done"})
 
     @pytest.mark.asyncio
-    @mock.patch(f"{MODULE_GOOGLE}.operators.kubernetes_engine.GKEStartPodOperator.get_gke_config_file")
+    @mock.patch("astronomer.providers.google.cloud.triggers.kubernetes_engine._get_gke_config_file")
     async def test_run_exception(self, mock_tmp):
         """assert that run raise exception when fail to fetch GKE kube config file"""
         my_tmp = mock_tmp.__enter__()


### PR DESCRIPTION
Contradicted to the previous discussion with @pankajkoti . I dig into the code on both sides a bit. It seems to me that adding the removed function back makes more sense.

1. GKEStartPodOperatorAsync is not inherited from GKEStartPodOperator. They’re different operators from the beginning. If we’re to copy the logic from GKEStartPodOperator, it might make more sense for us to remove  GKEStartPodOperatorAsync  as GKEStartPodOperator now supports deferrable as well.
2. get_gke_config_file can be used alone and doesn’t necessary need to tide to a class which might make sense to make it a utility function

closes #947 