### PR TITLE
Increase `RedshiftCreateClusterSnapshotOperator` max attempt to wait for snapshot creation.

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -67,6 +67,7 @@ with DAG(
         snapshot_identifier=f"{REDSHIFT_CLUSTER_IDENTIFIER}-snapshot",
         cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
         wait_for_completion=True,
+        max_attempt=40,
         aws_conn_id=AWS_CONN_ID,
     )
 


### PR DESCRIPTION
Currently, the RedshiftCreateClusterSnapshotOperator takes on avg of 4 mins to create the snapshot but sometimes it crosses 5 mins.  the default values in operator is for 15secs poll interval and 20 max_attempts and it fails with 
`botocore.exceptions.WaiterError: Waiter SnapshotAvailable failed: Max attempts exceeded`.

This PR increases the max attempt for the waiting of this operator to create the snapshot