### PR TITLE
Fix read of Pandas json for S3 and GCS custom XCOM backend

### DIFF
--- a/astronomer/providers/amazon/aws/xcom_backends/s3.py
+++ b/astronomer/providers/amazon/aws/xcom_backends/s3.py
@@ -100,7 +100,7 @@ class _S3XComBackend:
             return pickle.loads(data)  # nosec
         elif filename.endswith(_S3XComBackend.PANDAS_DATAFRAME):
             if isinstance(data, bytes):
-                data = BytesIO(data)
+                return pd.read_json(BytesIO(data))
             return pd.read_json(data)
         elif filename.endswith(_S3XComBackend.DATETIME_OBJECT):
             return datetime.fromisoformat(str(data))

--- a/astronomer/providers/amazon/aws/xcom_backends/s3.py
+++ b/astronomer/providers/amazon/aws/xcom_backends/s3.py
@@ -4,6 +4,7 @@ import os
 import pickle  # nosec
 import uuid
 from datetime import date, datetime
+from io import BytesIO
 from typing import Any
 
 import pandas as pd
@@ -98,6 +99,8 @@ class _S3XComBackend:
         if conf.getboolean("core", "enable_xcom_pickling"):
             return pickle.loads(data)  # nosec
         elif filename.endswith(_S3XComBackend.PANDAS_DATAFRAME):
+            if isinstance(data, bytes):
+                data = BytesIO(data)
             return pd.read_json(data)
         elif filename.endswith(_S3XComBackend.DATETIME_OBJECT):
             return datetime.fromisoformat(str(data))

--- a/astronomer/providers/google/cloud/xcom_backends/gcs.py
+++ b/astronomer/providers/google/cloud/xcom_backends/gcs.py
@@ -93,7 +93,7 @@ class _GCSXComBackend:
             return pickle.loads(data)  # nosec
         elif filename.endswith(_GCSXComBackend.PANDAS_DATAFRAME):
             if isinstance(data, bytes):
-                data = BytesIO(data)
+                return pd.read_json(BytesIO(data))
             return pd.read_json(data)
         elif filename.endswith(_GCSXComBackend.DATETIME_OBJECT):
             return datetime.fromisoformat(str(data))

--- a/astronomer/providers/google/cloud/xcom_backends/gcs.py
+++ b/astronomer/providers/google/cloud/xcom_backends/gcs.py
@@ -4,6 +4,7 @@ import os
 import pickle  # nosec
 import uuid
 from datetime import date, datetime
+from io import BytesIO
 from typing import Any
 
 import pandas as pd
@@ -91,6 +92,8 @@ class _GCSXComBackend:
         if conf.getboolean("core", "enable_xcom_pickling"):
             return pickle.loads(data)  # nosec
         elif filename.endswith(_GCSXComBackend.PANDAS_DATAFRAME):
+            if isinstance(data, bytes):
+                data = BytesIO(data)
             return pd.read_json(data)
         elif filename.endswith(_GCSXComBackend.DATETIME_OBJECT):
             return datetime.fromisoformat(str(data))

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -25,6 +25,11 @@ x-airflow-common:
     OPENLINEAGE_EXTRACTORS: "astronomer.providers.google.cloud.extractors.bigquery.BigQueryAsyncExtractor;\
                             astronomer.providers.snowflake.extractors.snowflake.SnowflakeAsyncExtractor;\
                             astronomer.providers.amazon.aws.extractors.redshift.RedshiftAsyncExtractor"
+
+    # For enabling custom XCOM backend, uncomment the below variables and ensure that the given bucket exists.
+    # AIRFLOW__CORE__XCOM_BACKEND: astronomer.providers.amazon.aws.xcom_backends.s3.S3XComBackend
+    # XCOM_BACKEND_BUCKET_NAME: "test-xcom-bucket"
+
   volumes:
     - ./dags:/usr/local/airflow/dags
     - ./logs:/usr/local/airflow/logs

--- a/tests/amazon/aws/xcom_backends/test_s3.py
+++ b/tests/amazon/aws/xcom_backends/test_s3.py
@@ -162,25 +162,29 @@ class TestS3XComBackend:
         assert result == job_id
 
     @pytest.mark.parametrize(
-        "job_id",
-        ["gcs_xcom_1234_dataframe"],
+        "job_id, mock_df_data",
+        [
+            ("s3_xcom_1234_dataframe", pd.DataFrame({"numbers": [1], "colors": ["red"]}).to_json()),
+            (
+                "s3_xcom_1234_dataframe",
+                bytes(pd.DataFrame({"numbers": [1], "colors": ["red"]}).to_json(), "utf-8"),
+            ),
+        ],
     )
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.download_file")
     @mock.patch("builtins.open", create=True)
-    def test_download_and_read_value_pandas(self, mock_open, mock_download, job_id):
+    def test_download_and_read_value_pandas(self, mock_open, mock_download, job_id, mock_df_data):
         """
         Asserts that custom xcom is read the pandas data and validate it.
         """
-        mock_open.side_effect = [
-            mock.mock_open(read_data=pd.DataFrame({"numbers": [1], "colors": ["red"]}).to_json()).return_value
-        ]
+        mock_open.side_effect = [mock.mock_open(read_data=mock_df_data).return_value]
         mock_download.return_value = job_id
         result = _S3XComBackend().download_and_read_value(job_id)
         assert_frame_equal(result, pd.DataFrame({"numbers": [1], "colors": ["red"]}))
 
     @pytest.mark.parametrize(
         "job_id",
-        ["gcs_xcom_1234_datetime"],
+        ["s3_xcom_1234_datetime"],
     )
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.download_file")
     @mock.patch("builtins.open", create=True)
@@ -197,7 +201,7 @@ class TestS3XComBackend:
     @conf_vars({("core", "enable_xcom_pickling"): "True"})
     @pytest.mark.parametrize(
         "job_id",
-        ["gcs_xcom_1234"],
+        ["s3_xcom_1234"],
     )
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.download_file")
     @mock.patch("builtins.open", create=True)
@@ -212,7 +216,7 @@ class TestS3XComBackend:
 
     @pytest.mark.parametrize(
         "job_id",
-        ["gcs_xcom_1234"],
+        ["s3_xcom_1234"],
     )
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.download_file")
     @mock.patch("builtins.open", create=True)
@@ -227,7 +231,7 @@ class TestS3XComBackend:
 
     @pytest.mark.parametrize(
         "job_id",
-        ["gcs_xcom_1234.gz"],
+        ["s3_xcom_1234.gz"],
     )
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.download_file")
     @mock.patch("builtins.open", create=True)

--- a/tests/google/cloud/xcom_backends/test_gcs.py
+++ b/tests/google/cloud/xcom_backends/test_gcs.py
@@ -132,13 +132,19 @@ class TestGCSXComBackend:
         assert result == job_id
 
     @pytest.mark.parametrize(
-        "job_id",
-        ["gcs_xcom_1234_dataframe"],
+        "job_id, mock_df_data",
+        [
+            ("gcs_xcom_1234_dataframe", pd.DataFrame({"numbers": [1], "colors": ["red"]}).to_json()),
+            (
+                "gcs_xcom_1234_dataframe",
+                bytes(pd.DataFrame({"numbers": [1], "colors": ["red"]}).to_json(), "utf-8"),
+            ),
+        ],
     )
     @mock.patch("airflow.providers.google.cloud.hooks.gcs.GCSHook.download")
-    def test_custom_xcom_gcs_deserialize_pandas(self, mock_read_value, job_id):
+    def test_custom_xcom_gcs_deserialize_pandas(self, mock_read_value, job_id, mock_df_data):
         """Asserts that custom xcom is deserialized and check for data"""
-        mock_read_value.return_value = pd.DataFrame({"numbers": [1], "colors": ["red"]}).to_json()
+        mock_read_value.return_value = mock_df_data
         result = _GCSXComBackend.download_and_read_value(job_id)
         assert_frame_equal(result, pd.DataFrame({"numbers": [1], "colors": ["red"]}))
 


### PR DESCRIPTION
The downloaded file content from AWS and Google hook return bytes instance which the pandas read_json cannot read; hence, we fix this by converting it to BytesIO instance which the pandas read_json method reads well.

closes: #955