### PR TITLE
build(setup.cfg): pinning snowflake-sqlalchemy to greater than or eqaul to 1.4.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -126,7 +126,6 @@ all =
     apache-airflow-providers-google>=8.1.0
     apache-airflow-providers-http
     apache-airflow-providers-snowflake
-    snowflake-sqlalchemy>=1.4.4  # Temporary solution for https://github.com/astronomer/astronomer-providers/issues/958, we should pin apache-airflow-providers-snowflake version after it pins this package to great than or equal to 1.4.4.
     apache-airflow-providers-sftp
     apache-airflow-providers-microsoft-azure
     asyncssh>=2.12.0
@@ -139,6 +138,7 @@ all =
     openlineage-airflow>=0.12.0
     paramiko
     protobuf<=3.20.0  # Bigquery provider isn't compatible with it. Details in https://github.com/apache/airflow/commit/25a9ae3b2eec85dfd500b0a921045fc95ab8ffd6
+    snowflake-sqlalchemy>=1.4.4  # Temporary solution for https://github.com/astronomer/astronomer-providers/issues/958, we should pin apache-airflow-providers-snowflake version after it pins this package to great than or equal to 1.4.4.
 
 [options.packages.find]
 include =

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ sftp =
     asyncssh>=2.12.0
 snowflake =
     apache-airflow-providers-snowflake
+    snowflake-sqlalchemy>=1.4.4  # Temporary solution for https://github.com/astronomer/astronomer-providers/issues/958, we should pin apache-airflow-providers-snowflake version after it pins this package to great than or equal to 1.4.4.
 # If in future we move Openlineage extractors out of the repo, this dependency should be removed
 openlineage =
     openlineage-airflow>=0.12.0
@@ -125,6 +126,7 @@ all =
     apache-airflow-providers-google>=8.1.0
     apache-airflow-providers-http
     apache-airflow-providers-snowflake
+    snowflake-sqlalchemy>=1.4.4  # Temporary solution for https://github.com/astronomer/astronomer-providers/issues/958, we should pin apache-airflow-providers-snowflake version after it pins this package to great than or equal to 1.4.4.
     apache-airflow-providers-sftp
     apache-airflow-providers-microsoft-azure
     asyncssh>=2.12.0


### PR DESCRIPTION
As discussed in #958, we might need to pin snowflake-sqlalchemy >= 1.4.4 to resolved the issue. For the next step, I'm thinking of sending a PR to pin it to >= 1.4.4 on `apache-airflow-providers-snowflake` and then pin the `apache-airflow-providers-snowflake` in this repo after it's released