### PR TITLE
Bigquery operator backward compatibility

### DIFF
--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -72,7 +72,7 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
     :param poll_interval: polling period in seconds to check for the status of job. Defaults to 4 seconds.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.poll_interval = kwargs.pop("poll_interval", None)
         super().__init__(*args, **kwargs)
 
@@ -152,7 +152,7 @@ class BigQueryCheckOperatorAsync(BigQueryCheckOperator):
     for the status in async mode by using the job id
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.poll_interval = kwargs.pop("poll_interval", None)
         super().__init__(*args, **kwargs)
 
@@ -258,7 +258,7 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
     :param poll_interval: polling period in seconds to check for the status of job. Defaults to 4 seconds
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.poll_interval = kwargs.pop("poll_interval", None)
         super().__init__(*args, **kwargs)
 
@@ -365,7 +365,7 @@ class BigQueryIntervalCheckOperatorAsync(BigQueryIntervalCheckOperator):
     :param poll_interval: polling period in seconds to check for the status of job. Defaults to 4 seconds.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.poll_interval = kwargs.pop("poll_interval", None)
         super().__init__(*args, **kwargs)
 
@@ -432,7 +432,7 @@ class BigQueryIntervalCheckOperatorAsync(BigQueryIntervalCheckOperator):
 
 
 class BigQueryValueCheckOperatorAsync(BigQueryValueCheckOperator):  # noqa: D101
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.poll_interval = kwargs.pop("poll_interval", None)
         super().__init__(*args, **kwargs)
 

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -73,7 +73,7 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.poll_interval = kwargs.pop("poll_interval", None)
+        self.poll_interval: float = kwargs.pop("poll_interval", 4.0)
         super().__init__(*args, **kwargs)
 
     def execute(self, context: Context) -> None:  # noqa: D102
@@ -153,7 +153,7 @@ class BigQueryCheckOperatorAsync(BigQueryCheckOperator):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.poll_interval = kwargs.pop("poll_interval", None)
+        self.poll_interval: float = kwargs.pop("poll_interval", 4.0)
         super().__init__(*args, **kwargs)
 
     def _submit_job(
@@ -259,7 +259,7 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.poll_interval = kwargs.pop("poll_interval", None)
+        self.poll_interval: float = kwargs.pop("poll_interval", 4.0)
         super().__init__(*args, **kwargs)
 
     def _submit_job(  # type: ignore[override]
@@ -366,7 +366,7 @@ class BigQueryIntervalCheckOperatorAsync(BigQueryIntervalCheckOperator):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.poll_interval = kwargs.pop("poll_interval", None)
+        self.poll_interval: float = kwargs.pop("poll_interval", 4.0)
         super().__init__(*args, **kwargs)
 
     def _submit_job(
@@ -433,7 +433,7 @@ class BigQueryIntervalCheckOperatorAsync(BigQueryIntervalCheckOperator):
 
 class BigQueryValueCheckOperatorAsync(BigQueryValueCheckOperator):  # noqa: D101
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.poll_interval = kwargs.pop("poll_interval", None)
+        self.poll_interval: float = kwargs.pop("poll_interval", 4.0)
         super().__init__(*args, **kwargs)
 
     def _submit_job(

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -73,8 +73,9 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.poll_interval: float = kwargs.pop("poll_interval", 4.0)
+        poll_interval: float = kwargs.pop("poll_interval", 4.0)
         super().__init__(*args, **kwargs)
+        self.poll_interval = poll_interval
 
     def execute(self, context: Context) -> None:  # noqa: D102
         hook = BigQueryHook(
@@ -153,8 +154,9 @@ class BigQueryCheckOperatorAsync(BigQueryCheckOperator):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.poll_interval: float = kwargs.pop("poll_interval", 4.0)
+        poll_interval: float = kwargs.pop("poll_interval", 4.0)
         super().__init__(*args, **kwargs)
+        self.poll_interval = poll_interval
 
     def _submit_job(
         self,
@@ -259,8 +261,9 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.poll_interval: float = kwargs.pop("poll_interval", 4.0)
+        poll_interval: float = kwargs.pop("poll_interval", 4.0)
         super().__init__(*args, **kwargs)
+        self.poll_interval = poll_interval
 
     def _submit_job(  # type: ignore[override]
         self,
@@ -366,8 +369,9 @@ class BigQueryIntervalCheckOperatorAsync(BigQueryIntervalCheckOperator):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.poll_interval: float = kwargs.pop("poll_interval", 4.0)
+        poll_interval: float = kwargs.pop("poll_interval", 4.0)
         super().__init__(*args, **kwargs)
+        self.poll_interval = poll_interval
 
     def _submit_job(
         self,
@@ -433,8 +437,9 @@ class BigQueryIntervalCheckOperatorAsync(BigQueryIntervalCheckOperator):
 
 class BigQueryValueCheckOperatorAsync(BigQueryValueCheckOperator):  # noqa: D101
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.poll_interval: float = kwargs.pop("poll_interval", 4.0)
+        poll_interval: float = kwargs.pop("poll_interval", 4.0)
         super().__init__(*args, **kwargs)
+        self.poll_interval = poll_interval
 
     def _submit_job(
         self,

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -72,6 +72,10 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
     :param poll_interval: polling period in seconds to check for the status of job. Defaults to 4 seconds.
     """
 
+    def __init__(self, *args, **kwargs):
+        self.poll_interval = kwargs.pop("poll_interval", None)
+        super().__init__(*args, **kwargs)
+
     def execute(self, context: Context) -> None:  # noqa: D102
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
@@ -147,6 +151,10 @@ class BigQueryCheckOperatorAsync(BigQueryCheckOperator):
     BigQueryCheckOperatorAsync is asynchronous operator, submit the job and check
     for the status in async mode by using the job id
     """
+
+    def __init__(self, *args, **kwargs):
+        self.poll_interval = kwargs.pop("poll_interval", None)
+        super().__init__(*args, **kwargs)
 
     def _submit_job(
         self,
@@ -249,6 +257,10 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
         account from the list granting this role to the originating account (templated).
     :param poll_interval: polling period in seconds to check for the status of job. Defaults to 4 seconds
     """
+
+    def __init__(self, *args, **kwargs):
+        self.poll_interval = kwargs.pop("poll_interval", None)
+        super().__init__(*args, **kwargs)
 
     def _submit_job(  # type: ignore[override]
         self,
@@ -353,6 +365,10 @@ class BigQueryIntervalCheckOperatorAsync(BigQueryIntervalCheckOperator):
     :param poll_interval: polling period in seconds to check for the status of job. Defaults to 4 seconds.
     """
 
+    def __init__(self, *args, **kwargs):
+        self.poll_interval = kwargs.pop("poll_interval", None)
+        super().__init__(*args, **kwargs)
+
     def _submit_job(
         self,
         hook: BigQueryHook,
@@ -416,6 +432,10 @@ class BigQueryIntervalCheckOperatorAsync(BigQueryIntervalCheckOperator):
 
 
 class BigQueryValueCheckOperatorAsync(BigQueryValueCheckOperator):  # noqa: D101
+    def __init__(self, *args, **kwargs):
+        self.poll_interval = kwargs.pop("poll_interval", None)
+        super().__init__(*args, **kwargs)
+
     def _submit_job(
         self,
         hook: BigQueryHook,


### PR DESCRIPTION
Bigquery operator backward compatibility
currently, the task fails if we have astronomer provider 1.15.3 and apache-airflow-providers-google < 8.11.0

Add init in affected operators and if `poll_interval` is pass by user then use it otherwise use default trigger poll_interval

with new google provider
<img width="927" alt="Screenshot 2023-04-19 at 10 13 13 PM" src="https://user-images.githubusercontent.com/98807258/233144063-54330a5e-33d7-49d6-a11a-34dc53a0ae72.png">

with a old google provider

<img width="926" alt="Screenshot 2023-04-19 at 10 14 07 PM" src="https://user-images.githubusercontent.com/98807258/233144106-e584161f-76a2-4d89-894c-945fcebad135.png">



closes: https://github.com/astronomer/astronomer-providers/issues/966