### PR TITLE
Fix sagemaker operator for Amazon provider release 8.0.0

### DIFF
--- a/astronomer/providers/amazon/aws/operators/sagemaker.py
+++ b/astronomer/providers/amazon/aws/operators/sagemaker.py
@@ -60,10 +60,17 @@ class SageMakerProcessingOperatorAsync(SageMakerProcessingOperator):
         """
         self.preprocess_config()
         processing_job_name = self.config["ProcessingJobName"]
-        if self.hook.find_processing_job_by_name(processing_job_name):
-            raise AirflowException(
-                f"A SageMaker processing job with name {processing_job_name} already exists."
-            )
+        try:
+            if self.hook.count_processing_jobs_by_name(processing_job_name):
+                raise AirflowException(
+                    f"A SageMaker processing job with name {processing_job_name} already exists."
+                )
+        except AttributeError:  # pragma: no cover
+            # For apache-airflow-providers-amazon<8.0.0
+            if self.hook.find_processing_job_by_name(processing_job_name):
+                raise AirflowException(
+                    f"A SageMaker processing job with name {processing_job_name} already exists."
+                )
         self.log.info("Creating SageMaker processing job %s.", self.config["ProcessingJobName"])
         response = self.hook.create_processing_job(
             self.config,

--- a/tests/amazon/aws/operators/test_sagemaker.py
+++ b/tests/amazon/aws/operators/test_sagemaker.py
@@ -140,7 +140,7 @@ class TestSagemakerProcessingOperatorAsync:
         "create_processing_job",
         return_value={"ProcessingJobArn": "test_arn", "ResponseMetadata": {"HTTPStatusCode": 200}},
     )
-    @mock.patch.object(SageMakerHook, "find_processing_job_by_name", return_value=False)
+    @mock.patch.object(SageMakerHook, "count_processing_jobs_by_name", return_value=False)
     def test_sagemakerprocessing_op_async(self, mock_hook, mock_processing, context):
         """Assert SageMakerProcessingOperatorAsync deferred properlu"""
         task = SageMakerProcessingOperatorAsync(
@@ -155,7 +155,7 @@ class TestSagemakerProcessingOperatorAsync:
             exc.value.trigger, SagemakerProcessingTrigger
         ), "Trigger is not a SagemakerProcessingTrigger"
 
-    @mock.patch.object(SageMakerHook, "find_processing_job_by_name", return_value=True)
+    @mock.patch.object(SageMakerHook, "count_processing_jobs_by_name", return_value=True)
     def test_sagemakerprocessing_op_async_duplicate_failure(self, mock_hook, context):
         """Tests that an AirflowException is raised in case of error event from find_processing_job_name"""
         task = SageMakerProcessingOperatorAsync(
@@ -171,7 +171,7 @@ class TestSagemakerProcessingOperatorAsync:
         "create_processing_job",
         return_value={"ProcessingJobArn": "test_arn", "ResponseMetadata": {"HTTPStatusCode": 404}},
     )
-    @mock.patch.object(SageMakerHook, "find_processing_job_by_name", return_value=False)
+    @mock.patch.object(SageMakerHook, "count_processing_jobs_by_name", return_value=False)
     def test_sagemakerprocessing_op_async_failure(self, mock_hook, mock_processing_job, context):
         """Tests that an AirflowException is raised in case of error event from create_processing_job"""
         task = SageMakerProcessingOperatorAsync(


### PR DESCRIPTION
The `find_processing_job_by_name` method on the Sagemaker hook has been replaced with `count_processing_jobs_by_name` and hence make the necessary changes for the release ensuring backward compatibility for the older versions of the provider.

related to: #977