### PR TITLE
Fix bigquery & gcs operators & sensors for Google provider 10.0.0

### DIFF
--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -59,9 +59,9 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
     :param project_id: Google Cloud Project where the job is running
     :param location: location the job is running
     :param gcp_conn_id: The connection ID used to connect to Google Cloud.
-    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead) The account to impersonate using domain-wide
-        delegation of authority, if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
+    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead)
+        The account to impersonate using domain-wide delegation of authority, if any. For this to work, the service
+        account making the request must have domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -250,9 +250,9 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
     :param selected_fields: List of fields to return (comma-separated). If
         unspecified, all fields are returned.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead) The account to impersonate using domain-wide
-        delegation of authority, if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
+    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead)
+        The account to impersonate using domain-wide delegation of authority, if any. For this to work, the service
+        account making the request must have domain-wide delegation enabled.
     :param location: The location used for the operation.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -59,7 +59,7 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
     :param project_id: Google Cloud Project where the job is running
     :param location: location the job is running
     :param gcp_conn_id: The connection ID used to connect to Google Cloud.
-    :param delegate_to: (Previously deprecated and removed in 10.0.0) The account to impersonate using domain-wide
+    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead) The account to impersonate using domain-wide
         delegation of authority, if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
@@ -250,7 +250,7 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
     :param selected_fields: List of fields to return (comma-separated). If
         unspecified, all fields are returned.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: (Previously deprecated and removed in 10.0.0) The account to impersonate using domain-wide
+    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead) The account to impersonate using domain-wide
         delegation of authority, if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :param location: The location used for the operation.

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -1,5 +1,7 @@
 """This module contains Google BigQueryAsync providers."""
-from typing import Any, Dict
+from __future__ import annotations
+
+from typing import Any
 
 from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator
@@ -78,7 +80,7 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
         self.poll_interval = poll_interval
 
     def execute(self, context: Context) -> None:  # noqa: D102
-        kwargs = {}
+        kwargs: dict[Any, Any] = {}
         if hasattr(self, "delegate_to"):
             kwargs["delegate_to"] = self.delegate_to
         hook = BigQueryHook(
@@ -135,7 +137,7 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
             method_name="execute_complete",
         )
 
-    def execute_complete(self, context: Context, event: Dict[str, Any]) -> None:
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> None:
         """
         Callback for when the trigger fires - returns immediately.
         Relies on trigger to throw an exception, otherwise it assumes execution was
@@ -196,7 +198,7 @@ class BigQueryCheckOperatorAsync(BigQueryCheckOperator):
             method_name="execute_complete",
         )
 
-    def execute_complete(self, context: Context, event: Dict[str, Any]) -> None:
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> None:
         """
         Callback for when the trigger fires - returns immediately.
         Relies on trigger to throw an exception, otherwise it assumes execution was
@@ -272,7 +274,7 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
         self,
         hook: BigQueryHook,
         job_id: str,
-        configuration: Dict[str, Any],
+        configuration: dict[str, Any],
     ) -> BigQueryJob:
         """Submit a new job and get the job id for polling the status using Triggerer."""
         return hook.insert_job(
@@ -299,7 +301,7 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
     def execute(self, context: Context) -> None:  # noqa: D102
         get_query = self.generate_query()
         configuration = {"query": {"query": get_query}}
-        kwargs = {}
+        kwargs: dict[Any, Any] = {}
         if hasattr(self, "delegate_to"):
             kwargs["delegate_to"] = self.delegate_to
         hook = BigQueryHook(
@@ -328,7 +330,7 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
             method_name="execute_complete",
         )
 
-    def execute_complete(self, context: Context, event: Dict[str, Any]) -> Any:
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> Any:
         """
         Callback for when the trigger fires - returns immediately.
         Relies on trigger to throw an exception, otherwise it assumes execution was
@@ -424,7 +426,7 @@ class BigQueryIntervalCheckOperatorAsync(BigQueryIntervalCheckOperator):
             method_name="execute_complete",
         )
 
-    def execute_complete(self, context: Context, event: Dict[str, Any]) -> None:
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> None:
         """
         Callback for when the trigger fires - returns immediately.
         Relies on trigger to throw an exception, otherwise it assumes execution was
@@ -489,7 +491,7 @@ class BigQueryValueCheckOperatorAsync(BigQueryValueCheckOperator):  # noqa: D101
             method_name="execute_complete",
         )
 
-    def execute_complete(self, context: Context, event: Dict[str, Any]) -> None:
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> None:
         """
         Callback for when the trigger fires - returns immediately.
         Relies on trigger to throw an exception, otherwise it assumes execution was

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -57,8 +57,8 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
     :param project_id: Google Cloud Project where the job is running
     :param location: location the job is running
     :param gcp_conn_id: The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
+    :param delegate_to: (Previously deprecated and removed in 10.0.0) The account to impersonate using domain-wide
+        delegation of authority, if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -78,11 +78,14 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
         self.poll_interval = poll_interval
 
     def execute(self, context: Context) -> None:  # noqa: D102
+        kwargs = {}
+        if hasattr(self, "delegate_to"):
+            kwargs["delegate_to"] = self.delegate_to
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
             location=self.location,
+            **kwargs,
         )
 
         self.hook = hook
@@ -125,9 +128,9 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
                 conn_id=self.gcp_conn_id,
                 job_id=self.job_id,
                 project_id=self.project_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
                 poll_interval=self.poll_interval,
+                **kwargs,
             ),
             method_name="execute_complete",
         )
@@ -245,8 +248,8 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
     :param selected_fields: List of fields to return (comma-separated). If
         unspecified, all fields are returned.
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
+    :param delegate_to: (Previously deprecated and removed in 10.0.0) The account to impersonate using domain-wide
+        delegation of authority, if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :param location: The location used for the operation.
     :param impersonation_chain: Optional service account to impersonate using short-term
@@ -296,12 +299,14 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
     def execute(self, context: Context) -> None:  # noqa: D102
         get_query = self.generate_query()
         configuration = {"query": {"query": get_query}}
-
+        kwargs = {}
+        if hasattr(self, "delegate_to"):
+            kwargs["delegate_to"] = self.delegate_to
         hook = BigQueryHook(
             gcp_conn_id=self.gcp_conn_id,
-            delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
+            **kwargs,
         )
 
         self.hook = hook
@@ -316,9 +321,9 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
                 dataset_id=self.dataset_id,
                 table_id=self.table_id,
                 project_id=hook.project_id,
-                delegate_to=self.delegate_to,
                 impersonation_chain=self.impersonation_chain,
                 poll_interval=self.poll_interval,
+                **kwargs,
             ),
             method_name="execute_complete",
         )

--- a/astronomer/providers/google/cloud/sensors/bigquery.py
+++ b/astronomer/providers/google/cloud/sensors/bigquery.py
@@ -25,9 +25,9 @@ class BigQueryTableExistenceSensorAsync(BigQueryTableExistenceSensor):
     :param gcp_conn_id: The connection ID used to connect to Google Cloud.
     :param bigquery_conn_id: (Deprecated) The connection ID used to connect to Google Cloud.
        This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
-    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead) The account to impersonate using domain-wide
-        delegation of authority, if any. For this to work, the service account making the request must have domain-wide
-        delegation enabled.
+    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead)
+        The account to impersonate using domain-wide delegation of authority, if any. For this to work, the service
+        account making the request must have domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
        credentials, or chained list of accounts required to get the access_token
        of the last account in the list, which will be impersonated in the request.

--- a/astronomer/providers/google/cloud/sensors/bigquery.py
+++ b/astronomer/providers/google/cloud/sensors/bigquery.py
@@ -25,7 +25,7 @@ class BigQueryTableExistenceSensorAsync(BigQueryTableExistenceSensor):
     :param gcp_conn_id: The connection ID used to connect to Google Cloud.
     :param bigquery_conn_id: (Deprecated) The connection ID used to connect to Google Cloud.
        This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
-    :param delegate_to: (Previously deprecated and removed in 10.0.0) The account to impersonate using domain-wide
+    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead) The account to impersonate using domain-wide
         delegation of authority, if any. For this to work, the service account making the request must have domain-wide
         delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term

--- a/astronomer/providers/google/cloud/sensors/gcs.py
+++ b/astronomer/providers/google/cloud/sensors/gcs.py
@@ -27,7 +27,7 @@ class GCSObjectExistenceSensorAsync(GCSObjectExistenceSensor):
     :param bucket: The Google Cloud Storage bucket where the object is.
     :param object: The name of the object to check in the Google cloud storage bucket.
     :param google_cloud_conn_id: The connection ID to use when connecting to Google Cloud Storage.
-    :param delegate_to: (Previously deprecated and removed in 10.0.0) The account to impersonate using domain-wide
+    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead) The account to impersonate using domain-wide
         delegation of authority, if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
@@ -96,7 +96,7 @@ class GCSObjectsWithPrefixExistenceSensorAsync(GCSObjectsWithPrefixExistenceSens
     :param bucket: The Google Cloud Storage bucket where the object is.
     :param prefix: The name of the prefix to check in the Google cloud storage bucket.
     :param google_cloud_conn_id: The connection ID to use when connecting to Google Cloud Storage.
-    :param delegate_to: (Previously deprecated and removed in 10.0.0) The account to impersonate using domain-wide
+    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead) The account to impersonate using domain-wide
         delegation of authority, if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
@@ -179,7 +179,7 @@ class GCSUploadSessionCompleteSensorAsync(GCSUploadSessionCompleteSensor):
         when this happens. If false an error will be raised.
     :param google_cloud_conn_id: The connection ID to use when connecting
         to Google Cloud Storage.
-    :param delegate_to: (Previously deprecated and removed in 10.0.0) The account to impersonate using domain-wide
+    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead) The account to impersonate using domain-wide
         delegation of authority, if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
@@ -255,7 +255,7 @@ class GCSObjectUpdateSensorAsync(GCSObjectUpdateSensor):
         as parameter.
     :param google_cloud_conn_id: The connection ID to use when
         connecting to Google Cloud Storage.
-    :param delegate_to: (Previously deprecated and removed in 10.0.0) The account to impersonate using domain-wide
+    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead) The account to impersonate using domain-wide
         delegation of authority, if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term

--- a/astronomer/providers/google/cloud/sensors/gcs.py
+++ b/astronomer/providers/google/cloud/sensors/gcs.py
@@ -27,8 +27,8 @@ class GCSObjectExistenceSensorAsync(GCSObjectExistenceSensor):
     :param bucket: The Google Cloud Storage bucket where the object is.
     :param object: The name of the object to check in the Google cloud storage bucket.
     :param google_cloud_conn_id: The connection ID to use when connecting to Google Cloud Storage.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
+    :param delegate_to: (Previously deprecated and removed in 10.0.0) The account to impersonate using domain-wide
+        delegation of authority, if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -58,6 +58,9 @@ class GCSObjectExistenceSensorAsync(GCSObjectExistenceSensor):
 
     def execute(self, context: "Context") -> None:
         """Airflow runs this method on the worker and defers using the trigger."""
+        hook_params = {"impersonation_chain": self.impersonation_chain}
+        if hasattr(self, "delegate_to"):
+            hook_params["delegate_to"] = self.delegate_to
         self.defer(
             timeout=timedelta(seconds=self.timeout),
             trigger=GCSBlobTrigger(
@@ -65,10 +68,7 @@ class GCSObjectExistenceSensorAsync(GCSObjectExistenceSensor):
                 object_name=self.object,
                 poke_interval=self.poke_interval,
                 google_cloud_conn_id=self.google_cloud_conn_id,
-                hook_params={
-                    "delegate_to": self.delegate_to,
-                    "impersonation_chain": self.impersonation_chain,
-                },
+                hook_params=hook_params,
             ),
             method_name="execute_complete",
         )
@@ -96,8 +96,8 @@ class GCSObjectsWithPrefixExistenceSensorAsync(GCSObjectsWithPrefixExistenceSens
     :param bucket: The Google Cloud Storage bucket where the object is.
     :param prefix: The name of the prefix to check in the Google cloud storage bucket.
     :param google_cloud_conn_id: The connection ID to use when connecting to Google Cloud Storage.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
+    :param delegate_to: (Previously deprecated and removed in 10.0.0) The account to impersonate using domain-wide
+        delegation of authority, if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -128,6 +128,9 @@ class GCSObjectsWithPrefixExistenceSensorAsync(GCSObjectsWithPrefixExistenceSens
 
     def execute(self, context: Dict[str, Any]) -> None:  # type: ignore[override]
         """Airflow runs this method on the worker and defers using the trigger."""
+        hook_params = {"impersonation_chain": self.impersonation_chain}
+        if hasattr(self, "delegate_to"):
+            hook_params["delegate_to"] = self.delegate_to
         self.defer(
             timeout=timedelta(seconds=self.timeout),
             trigger=GCSPrefixBlobTrigger(
@@ -135,10 +138,7 @@ class GCSObjectsWithPrefixExistenceSensorAsync(GCSObjectsWithPrefixExistenceSens
                 prefix=self.prefix,
                 poke_interval=self.poke_interval,
                 google_cloud_conn_id=self.google_cloud_conn_id,
-                hook_params={
-                    "delegate_to": self.delegate_to,
-                    "impersonation_chain": self.impersonation_chain,
-                },
+                hook_params=hook_params,
             ),
             method_name="execute_complete",
         )
@@ -179,8 +179,8 @@ class GCSUploadSessionCompleteSensorAsync(GCSUploadSessionCompleteSensor):
         when this happens. If false an error will be raised.
     :param google_cloud_conn_id: The connection ID to use when connecting
         to Google Cloud Storage.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
+    :param delegate_to: (Previously deprecated and removed in 10.0.0) The account to impersonate using domain-wide
+        delegation of authority, if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -211,6 +211,9 @@ class GCSUploadSessionCompleteSensorAsync(GCSUploadSessionCompleteSensor):
 
     def execute(self, context: Context) -> None:
         """Airflow runs this method on the worker and defers using the trigger."""
+        hook_params = {"impersonation_chain": self.impersonation_chain}
+        if hasattr(self, "delegate_to"):
+            hook_params["delegate_to"] = self.delegate_to
         self.defer(
             timeout=timedelta(seconds=self.timeout),
             trigger=GCSUploadSessionTrigger(
@@ -222,10 +225,7 @@ class GCSUploadSessionCompleteSensorAsync(GCSUploadSessionCompleteSensor):
                 min_objects=self.min_objects,
                 previous_objects=self.previous_objects,
                 allow_delete=self.allow_delete,
-                hook_params={
-                    "delegate_to": self.delegate_to,
-                    "impersonation_chain": self.impersonation_chain,
-                },
+                hook_params=hook_params,
             ),
             method_name="execute_complete",
         )
@@ -255,8 +255,8 @@ class GCSObjectUpdateSensorAsync(GCSObjectUpdateSensor):
         as parameter.
     :param google_cloud_conn_id: The connection ID to use when
         connecting to Google Cloud Storage.
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
+    :param delegate_to: (Previously deprecated and removed in 10.0.0) The account to impersonate using domain-wide
+        delegation of authority, if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
@@ -286,6 +286,9 @@ class GCSObjectUpdateSensorAsync(GCSObjectUpdateSensor):
 
     def execute(self, context: Context) -> None:
         """Airflow runs this method on the worker and defers using the trigger."""
+        hook_params = {"impersonation_chain": self.impersonation_chain}
+        if hasattr(self, "delegate_to"):
+            hook_params["delegate_to"] = self.delegate_to
         self.defer(
             timeout=timedelta(seconds=self.timeout),
             trigger=GCSCheckBlobUpdateTimeTrigger(
@@ -294,10 +297,7 @@ class GCSObjectUpdateSensorAsync(GCSObjectUpdateSensor):
                 ts=self.ts_func(context),
                 poke_interval=self.poke_interval,
                 google_cloud_conn_id=self.google_cloud_conn_id,
-                hook_params={
-                    "delegate_to": self.delegate_to,
-                    "impersonation_chain": self.impersonation_chain,
-                },
+                hook_params=hook_params,
             ),
             method_name="execute_complete",
         )

--- a/astronomer/providers/google/cloud/sensors/gcs.py
+++ b/astronomer/providers/google/cloud/sensors/gcs.py
@@ -27,9 +27,9 @@ class GCSObjectExistenceSensorAsync(GCSObjectExistenceSensor):
     :param bucket: The Google Cloud Storage bucket where the object is.
     :param object: The name of the object to check in the Google cloud storage bucket.
     :param google_cloud_conn_id: The connection ID to use when connecting to Google Cloud Storage.
-    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead) The account to impersonate using domain-wide
-        delegation of authority, if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
+    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead)
+        The account to impersonate using domain-wide delegation of authority, if any. For this to work, the service
+        account making the request must have domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -96,9 +96,9 @@ class GCSObjectsWithPrefixExistenceSensorAsync(GCSObjectsWithPrefixExistenceSens
     :param bucket: The Google Cloud Storage bucket where the object is.
     :param prefix: The name of the prefix to check in the Google cloud storage bucket.
     :param google_cloud_conn_id: The connection ID to use when connecting to Google Cloud Storage.
-    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead) The account to impersonate using domain-wide
-        delegation of authority, if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
+    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead)
+        The account to impersonate using domain-wide delegation of authority, if any. For this to work, the service
+        account making the request must have domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -179,9 +179,9 @@ class GCSUploadSessionCompleteSensorAsync(GCSUploadSessionCompleteSensor):
         when this happens. If false an error will be raised.
     :param google_cloud_conn_id: The connection ID to use when connecting
         to Google Cloud Storage.
-    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead) The account to impersonate using domain-wide
-        delegation of authority, if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
+    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead)
+        The account to impersonate using domain-wide delegation of authority, if any. For this to work, the service
+        account making the request must have domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.
@@ -255,9 +255,9 @@ class GCSObjectUpdateSensorAsync(GCSObjectUpdateSensor):
         as parameter.
     :param google_cloud_conn_id: The connection ID to use when
         connecting to Google Cloud Storage.
-    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead) The account to impersonate using domain-wide
-        delegation of authority, if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
+    :param delegate_to: (Removed in apache-airflow-providers-google release 10.0.0, use impersonation_chain instead)
+        The account to impersonate using domain-wide delegation of authority, if any. For this to work, the service
+        account making the request must have domain-wide delegation enabled.
     :param impersonation_chain: Optional service account to impersonate using short-term
         credentials, or chained list of accounts required to get the access_token
         of the last account in the list, which will be impersonated in the request.


### PR DESCRIPTION
The delegate_to parameter has been removed in the release 10.0.0; the commit makes sure to integrate that change while ensuring that the backward compatibility is maintained for older versions of the provider.

related to: #977