### PR TITLE
Use runtime image 8.0.0-alpha1 so that nightly job succeeds

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -1,5 +1,5 @@
 # Deploy from astro runtime image
-FROM quay.io/astronomer/astro-runtime-dev:8.0.0-alpha1-base
+FROM quay.io/astronomer/astro-runtime-dev:8.0.0-alpha2-base
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0

--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -1,5 +1,5 @@
 # Deploy from astro runtime image
-FROM quay.io/astronomer/astro-runtime-dev:8.0.0-alpha2-base
+FROM quay.io/astronomer/astro-runtime-dev:8.0.0-alpha1-base
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0

--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -1,5 +1,5 @@
 # Deploy from astro runtime image
-FROM quay.io/astronomer/astro-runtime:7.4.2-base
+FROM quay.io/astronomer/astro-runtime-dev:8.0.0-alpha1-base
 
 ENV AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=False
 ENV AWS_NUKE_VERSION=v2.17.0


### PR DESCRIPTION
We recently deployed 8.0.0-alpha1 to our provider-integartion-tests deployment. The current nightly job tries to deploy 7.4.2 image, but it fails as Astro does not allow to downgrade the runtime image for a deployment. So, until the stable runtime image is out, let's deploy the alpha-1 image so that we ensure there are no failures as there are multiple provider releases in short span of time.