### PR TITLE
feat(livy): check state before deferring LivyOperatorAsync

### DIFF
--- a/astronomer/providers/apache/livy/operators/livy.py
+++ b/astronomer/providers/apache/livy/operators/livy.py
@@ -91,4 +91,5 @@ class LivyOperatorAsync(LivyOperator):
             self.task_id,
             event["response"],
         )
+        context["ti"].xcom_push(key="app_id", value=self.get_hook().get_batch(event["batch_id"])["appId"])
         return event["batch_id"]

--- a/tests/snowflake/operators/test_snowflake.py
+++ b/tests/snowflake/operators/test_snowflake.py
@@ -99,8 +99,7 @@ class TestSnowflakeOperatorAsync:
         mock_check.return_value = True
 
         operator.execute(create_context(operator))
-
-        # assert not mock_defer.called
+        assert not mock_defer.called
 
     @pytest.mark.parametrize("mock_sql", [TEST_SQL, [TEST_SQL]])
     @mock.patch(f"{MODULE}.operators.snowflake.SnowflakeOperatorAsync.get_db_hook")


### PR DESCRIPTION
Similar to [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we want to check whether the task has finished before it's deferred which can avoid unnecessarily deferring the task to the trigger. For most sensors, we have a poke method in its sync counterpart which can help us do such check


Closes: #995