### PR TITLE
feat(hive): check state before deferring NamedHivePartitionSensorAsync

### DIFF
--- a/astronomer/providers/amazon/aws/operators/redshift_sql.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_sql.py
@@ -8,7 +8,7 @@ except ImportError:  # pragma: no cover
     # For apache-airflow-providers-amazon > 6.0.0
     # currently added type: ignore[no-redef, attr-defined] and pragma: no cover because this import
     # path won't be available in current setup
-    from airflow.providers.common.sql.operators.sql import (
+    from airflow.providers.common.sql.operators.sql import (  # type: ignore[assignment]
         SQLExecuteQueryOperator as RedshiftSQLOperator,
     )
 

--- a/astronomer/providers/amazon/aws/operators/redshift_sql.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_sql.py
@@ -8,7 +8,7 @@ except ImportError:  # pragma: no cover
     # For apache-airflow-providers-amazon > 6.0.0
     # currently added type: ignore[no-redef, attr-defined] and pragma: no cover because this import
     # path won't be available in current setup
-    from airflow.providers.common.sql.operators.sql import (  # type: ignore[assignment]
+    from airflow.providers.common.sql.operators.sql import (
         SQLExecuteQueryOperator as RedshiftSQLOperator,
     )
 


### PR DESCRIPTION
Similar to [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we want to check whether the task has finished before it's deferred. For most sensors, we have a poke method in its sync counter part which can help us do such check.