### PR TITLE
Add a make target to bump version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: dev logs stop clean build build-emr_eks_container_example_dag-image build-aws build-google-cloud build-run docs
 .PHONY: restart restart-all run-tests run-static-checks run-mypy run-local-lineage-server test-rc-deps shell help
 
+ASTRO_PROVIDER_VERSION ?= "dev"
+
 # If the first argument is "run"...
 ifeq (run-mypy,$(firstword $(MAKECMDGOALS)))
   # use the rest as arguments for "run"
@@ -97,6 +99,13 @@ test-rc-deps: ## Test providers RC by building an image with given dependencies 
 
 shell:  ## Runs a shell within a container (Allows interactive session)
 	docker compose -f dev/docker-compose.yaml run --rm airflow-scheduler bash
+
+bump-version:  ## Bump versions in files locally. By default bump to DEV. set env ASTRO_PROVIDER_VERSION to change default value (dev | patch | major | minor).
+	@if [ $(ASTRO_PROVIDER_VERSION) = "dev" ]; then\
+		cz bump --version-type semver --increment minor --devrelease 1 --files-only;\
+	else \
+	  cz bump --version-type semver --files-only --increment $(ASTRO_PROVIDER_VERSION);\
+    fi
 
 help: ## Prints this message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-41s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -103,8 +103,8 @@ shell:  ## Runs a shell within a container (Allows interactive session)
 bump-version:  ## Bump versions in files locally. By default bump to DEV. set env ASTRO_PROVIDER_VERSION to change default version. see docs https://github.com/astronomer/astronomer-providers/blob/main/RELEASING.rst#update-the-version-number
 	@if [ $(ASTRO_PROVIDER_VERSION) = "dev" ]; then\
 		cz bump --version-type semver --increment minor --devrelease 1 --files-only;\
-	else \
-	  cz bump $(ASTRO_PROVIDER_VERSION) --files-only;\
+	else\
+		cz bump $(ASTRO_PROVIDER_VERSION) --files-only;\
     fi
 
 help: ## Prints this message

--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,11 @@ test-rc-deps: ## Test providers RC by building an image with given dependencies 
 shell:  ## Runs a shell within a container (Allows interactive session)
 	docker compose -f dev/docker-compose.yaml run --rm airflow-scheduler bash
 
-bump-version:  ## Bump versions in files locally. By default bump to DEV. set env ASTRO_PROVIDER_VERSION to change default value (dev | patch | major | minor).
+bump-version:  ## Bump versions in files locally. By default bump to DEV. set env ASTRO_PROVIDER_VERSION to change default version (1.0.0 | 1.1.0 | 1.1.1).
 	@if [ $(ASTRO_PROVIDER_VERSION) = "dev" ]; then\
 		cz bump --version-type semver --increment minor --devrelease 1 --files-only;\
 	else \
-	  cz bump --version-type semver --files-only --increment $(ASTRO_PROVIDER_VERSION);\
+	  cz bump $(ASTRO_PROVIDER_VERSION) --files-only;\
     fi
 
 help: ## Prints this message

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ test-rc-deps: ## Test providers RC by building an image with given dependencies 
 shell:  ## Runs a shell within a container (Allows interactive session)
 	docker compose -f dev/docker-compose.yaml run --rm airflow-scheduler bash
 
-bump-version:  ## Bump versions in files locally. By default bump to DEV. set env ASTRO_PROVIDER_VERSION to change default version (1.0.0 | 1.1.0 | 1.1.1).
+bump-version:  ## Bump versions in files locally. By default bump to DEV. set env ASTRO_PROVIDER_VERSION to change default version. see docs https://github.com/astronomer/astronomer-providers/blob/main/RELEASING.rst#update-the-version-number
 	@if [ $(ASTRO_PROVIDER_VERSION) = "dev" ]; then\
 		cz bump --version-type semver --increment minor --devrelease 1 --files-only;\
 	else \

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -25,6 +25,17 @@ You will need to update it in:
 
 You can also use `commitizen <https://github.com/commitizen-tools/commitizen>`_ to update the version in these files
 
+Install commitizen on mac
+
+```
+brew install commitizen
+```
+
+Bump versions locally
+
+```
+make ASTRO_PROVIDER_VERSION=patch bump-version
+```
 
 Write the changelog
 -------------------

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -34,7 +34,7 @@ brew install commitizen
 Bump versions locally
 
 ```
-make ASTRO_PROVIDER_VERSION=patch bump-version
+make ASTRO_PROVIDER_VERSION=(1.0.0 | 1.1.0 | 1.1.1) bump-version
 ```
 
 Write the changelog

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -34,8 +34,10 @@ brew install commitizen
 Bump versions locally
 
 ```
-make ASTRO_PROVIDER_VERSION=(1.0.0 | 1.1.0 | 1.1.1) bump-version
+make ASTRO_PROVIDER_VERSION=<RELEASE_VERSION> bump-version
 ```
+
+Note: ```RELEASE_VERSION``` is the software version you want to release.
 
 Write the changelog
 -------------------


### PR DESCRIPTION
Add a make target to bump the version locally.
 example
```
make ASTRO_PROVIDER_VERSION=dev bump-version  // this will set the version to next minor-version-dev1 example 1.1.0-dev1
make ASTRO_PROVIDER_VERSION=1.1.1 bump-version
make ASTRO_PROVIDER_VERSION=1.1.0 bump-version 
make ASTRO_PROVIDER_VERSION=1.0.0 bump-version
```