### PR TITLE
Check whether table exists before deferring the task for BigQueryTableExistenceSensorAsync

### DIFF
--- a/astronomer/providers/google/cloud/sensors/bigquery.py
+++ b/astronomer/providers/google/cloud/sensors/bigquery.py
@@ -62,18 +62,20 @@ class BigQueryTableExistenceSensorAsync(BigQueryTableExistenceSensor):
         hook_params = {"impersonation_chain": self.impersonation_chain}
         if hasattr(self, "delegate_to"):  # pragma: no cover
             hook_params["delegate_to"] = self.delegate_to
-        self.defer(
-            timeout=timedelta(seconds=self.timeout),
-            trigger=BigQueryTableExistenceTrigger(
-                dataset_id=self.dataset_id,
-                table_id=self.table_id,
-                project_id=self.project_id,
-                poke_interval=self.poke_interval,
-                gcp_conn_id=self.gcp_conn_id,
-                hook_params=hook_params,
-            ),
-            method_name="execute_complete",
-        )
+
+        if not self.poke(context=context):
+            self.defer(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=BigQueryTableExistenceTrigger(
+                    dataset_id=self.dataset_id,
+                    table_id=self.table_id,
+                    project_id=self.project_id,
+                    poke_interval=self.poke_interval,
+                    gcp_conn_id=self.gcp_conn_id,
+                    hook_params=hook_params,
+                ),
+                method_name="execute_complete",
+            )
 
     def execute_complete(self, context: Dict[str, Any], event: Optional[Dict[str, str]] = None) -> str:
         """

--- a/tests/google/cloud/sensors/test_bigquery.py
+++ b/tests/google/cloud/sensors/test_bigquery.py
@@ -14,6 +14,8 @@ PROJECT_ID = "test-astronomer-airflow-providers"
 DATASET_NAME = "test-astro_dataset"
 TABLE_NAME = "test-partitioned_table"
 
+MODULE = "astronomer.providers.google.cloud.sensors.bigquery"
+
 
 class TestBigQueryTableExistenceSensorAsync:
     SENSOR = BigQueryTableExistenceSensorAsync(
@@ -23,6 +25,16 @@ class TestBigQueryTableExistenceSensorAsync:
         table_id=TABLE_NAME,
     )
 
+    @mock.patch(f"{MODULE}.BigQueryTableExistenceSensorAsync.defer")
+    @mock.patch(f"{MODULE}.BigQueryTableExistenceSensorAsync.poke", return_value=True)
+    def test_big_query_table_existence_sensor_async_finish_before_deferred(
+        self, mock_poke, mock_defer, context
+    ):
+        """Assert task is not deferred when it receives a finish status before deferring"""
+        self.SENSOR.execute(context)
+        assert not mock_defer.called
+
+    @mock.patch(f"{MODULE}.BigQueryTableExistenceSensorAsync.poke", return_value=False)
     def test_big_query_table_existence_sensor_async(self, context):
         """
         Asserts that a task is deferred and a BigQueryTableExistenceTrigger will be fired


### PR DESCRIPTION
Similar to [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we want to check whether the task has finished before it's deferred. For most sensors, we have a poke method in its sync counter part which can help us do such check.