### PR TITLE
Check whether the object exists before deferring the task for GCSObjectsWithPrefixExistenceSensorAsync

### DIFF
--- a/astronomer/providers/google/cloud/sensors/gcs.py
+++ b/astronomer/providers/google/cloud/sensors/gcs.py
@@ -131,17 +131,18 @@ class GCSObjectsWithPrefixExistenceSensorAsync(GCSObjectsWithPrefixExistenceSens
         hook_params = {"impersonation_chain": self.impersonation_chain}
         if hasattr(self, "delegate_to"):
             hook_params["delegate_to"] = self.delegate_to
-        self.defer(
-            timeout=timedelta(seconds=self.timeout),
-            trigger=GCSPrefixBlobTrigger(
-                bucket=self.bucket,
-                prefix=self.prefix,
-                poke_interval=self.poke_interval,
-                google_cloud_conn_id=self.google_cloud_conn_id,
-                hook_params=hook_params,
-            ),
-            method_name="execute_complete",
-        )
+        if not self.poke(context):
+            self.defer(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=GCSPrefixBlobTrigger(
+                    bucket=self.bucket,
+                    prefix=self.prefix,
+                    poke_interval=self.poke_interval,
+                    google_cloud_conn_id=self.google_cloud_conn_id,
+                    hook_params=hook_params,
+                ),
+                method_name="execute_complete",
+            )
 
     def execute_complete(
         self, context: Dict[str, Any], event: Dict[str, Union[str, List[str]]]

--- a/astronomer/providers/google/cloud/sensors/gcs.py
+++ b/astronomer/providers/google/cloud/sensors/gcs.py
@@ -56,7 +56,7 @@ class GCSObjectExistenceSensorAsync(GCSObjectExistenceSensor):
             )
         super().__init__(**kwargs)
 
-    def execute(self, context: "Context") -> None:
+    def execute(self, context: Context) -> None:
         """Airflow runs this method on the worker and defers using the trigger."""
         hook_params = {"impersonation_chain": self.impersonation_chain}
         if hasattr(self, "delegate_to"):
@@ -126,7 +126,7 @@ class GCSObjectsWithPrefixExistenceSensorAsync(GCSObjectsWithPrefixExistenceSens
             )
         super().__init__(**kwargs)
 
-    def execute(self, context: Dict[str, Any]) -> None:  # type: ignore[override]
+    def execute(self, context: Context) -> None:  # type: ignore[override]
         """Airflow runs this method on the worker and defers using the trigger."""
         hook_params = {"impersonation_chain": self.impersonation_chain}
         if hasattr(self, "delegate_to"):

--- a/tests/google/cloud/sensors/test_gcs.py
+++ b/tests/google/cloud/sensors/test_gcs.py
@@ -23,6 +23,8 @@ TEST_GCP_CONN_ID = "TEST_GCP_CONN_ID"
 TEST_INACTIVITY_PERIOD = 5
 TEST_MIN_OBJECTS = 1
 
+MODULE = "astronomer.providers.google.cloud.sensors.gcs"
+
 
 class TestGCSObjectExistenceSensorAsync:
     OPERATOR = GCSObjectExistenceSensorAsync(
@@ -68,6 +70,16 @@ class TestGCSObjectsWithPrefixExistenceSensorAsync:
         google_cloud_conn_id=TEST_GCP_CONN_ID,
     )
 
+    @mock.patch(f"{MODULE}.GCSObjectsWithPrefixExistenceSensorAsync.defer")
+    @mock.patch(f"{MODULE}.GCSObjectsWithPrefixExistenceSensorAsync.poke", return_value=True)
+    def test_gcs_object_with_prefix_existence_sensor_async_finish_before_deferred(
+        self, mock_poke, mock_defer, context
+    ):
+        """Assert task is not deferred when it receives a finish status before deferring"""
+        self.OPERATOR.execute(context)
+        assert not mock_defer.called
+
+    @mock.patch(f"{MODULE}.GCSObjectsWithPrefixExistenceSensorAsync.poke", return_value=False)
     def test_gcs_object_with_prefix_existence_sensor_async(self, context):
         """
         Asserts that a task is deferred and a GCSPrefixBlobTrigger will be fired


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we need to verify if the task has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. To accomplish this, we can use the poke method found in the sync counterpart of most sensors.