### PR TITLE
Check whether the upload completes before deferring the task for GCSUploadSessionCompleteSensorAsync

### DIFF
--- a/astronomer/providers/google/cloud/sensors/gcs.py
+++ b/astronomer/providers/google/cloud/sensors/gcs.py
@@ -214,21 +214,22 @@ class GCSUploadSessionCompleteSensorAsync(GCSUploadSessionCompleteSensor):
         hook_params = {"impersonation_chain": self.impersonation_chain}
         if hasattr(self, "delegate_to"):
             hook_params["delegate_to"] = self.delegate_to
-        self.defer(
-            timeout=timedelta(seconds=self.timeout),
-            trigger=GCSUploadSessionTrigger(
-                bucket=self.bucket,
-                prefix=self.prefix,
-                poke_interval=self.poke_interval,
-                google_cloud_conn_id=self.google_cloud_conn_id,
-                inactivity_period=self.inactivity_period,
-                min_objects=self.min_objects,
-                previous_objects=self.previous_objects,
-                allow_delete=self.allow_delete,
-                hook_params=hook_params,
-            ),
-            method_name="execute_complete",
-        )
+        if not self.poke(context):
+            self.defer(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=GCSUploadSessionTrigger(
+                    bucket=self.bucket,
+                    prefix=self.prefix,
+                    poke_interval=self.poke_interval,
+                    google_cloud_conn_id=self.google_cloud_conn_id,
+                    inactivity_period=self.inactivity_period,
+                    min_objects=self.min_objects,
+                    previous_objects=self.previous_objects,
+                    allow_delete=self.allow_delete,
+                    hook_params=hook_params,
+                ),
+                method_name="execute_complete",
+            )
 
     def execute_complete(self, context: Dict[str, Any], event: Optional[Dict[str, str]] = None) -> str:
         """

--- a/tests/google/cloud/sensors/test_gcs.py
+++ b/tests/google/cloud/sensors/test_gcs.py
@@ -23,6 +23,8 @@ TEST_GCP_CONN_ID = "TEST_GCP_CONN_ID"
 TEST_INACTIVITY_PERIOD = 5
 TEST_MIN_OBJECTS = 1
 
+MODULE = "astronomer.providers.google.cloud.sensors.gcs"
+
 
 class TestGCSObjectExistenceSensorAsync:
     OPERATOR = GCSObjectExistenceSensorAsync(
@@ -121,6 +123,16 @@ class TestGCSUploadSessionCompleteSensorAsync:
         min_objects=TEST_MIN_OBJECTS,
     )
 
+    @mock.patch(f"{MODULE}.GCSUploadSessionCompleteSensorAsync.defer")
+    @mock.patch(f"{MODULE}.GCSUploadSessionCompleteSensorAsync.poke", return_value=True)
+    def test_gcs_upload_session_complete_sensor_async_finish_before_deferred(
+        self, mock_poke, mock_defer, context
+    ):
+        """Assert task is not deferred when it receives a finish status before deferring"""
+        self.OPERATOR.execute(context)
+        assert not mock_defer.called
+
+    @mock.patch(f"{MODULE}.GCSUploadSessionCompleteSensorAsync.poke", return_value=False)
     def test_gcs_upload_session_complete_sensor_async(self, context):
         """
         Asserts that a task is deferred and a GCSUploadSessionTrigger will be fired


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we need to verify if the task has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. To accomplish this, we can use the poke method found in the sync counterpart of most sensors.
