### PR TITLE
Check whether the task finishes before deferring the task for GCSObjectUpdateSensorAsync

### DIFF
--- a/astronomer/providers/google/cloud/sensors/gcs.py
+++ b/astronomer/providers/google/cloud/sensors/gcs.py
@@ -289,18 +289,20 @@ class GCSObjectUpdateSensorAsync(GCSObjectUpdateSensor):
         hook_params = {"impersonation_chain": self.impersonation_chain}
         if hasattr(self, "delegate_to"):
             hook_params["delegate_to"] = self.delegate_to
-        self.defer(
-            timeout=timedelta(seconds=self.timeout),
-            trigger=GCSCheckBlobUpdateTimeTrigger(
-                bucket=self.bucket,
-                object_name=self.object,
-                ts=self.ts_func(context),
-                poke_interval=self.poke_interval,
-                google_cloud_conn_id=self.google_cloud_conn_id,
-                hook_params=hook_params,
-            ),
-            method_name="execute_complete",
-        )
+
+        if not self.poke(context):
+            self.defer(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=GCSCheckBlobUpdateTimeTrigger(
+                    bucket=self.bucket,
+                    object_name=self.object,
+                    ts=self.ts_func(context),
+                    poke_interval=self.poke_interval,
+                    google_cloud_conn_id=self.google_cloud_conn_id,
+                    hook_params=hook_params,
+                ),
+                method_name="execute_complete",
+            )
 
     def execute_complete(self, context: Dict[str, Any], event: Optional[Dict[str, str]] = None) -> str:
         """

--- a/tests/google/cloud/sensors/test_gcs.py
+++ b/tests/google/cloud/sensors/test_gcs.py
@@ -23,6 +23,8 @@ TEST_GCP_CONN_ID = "TEST_GCP_CONN_ID"
 TEST_INACTIVITY_PERIOD = 5
 TEST_MIN_OBJECTS = 1
 
+MODULE = "astronomer.providers.google.cloud.sensors.gcs"
+
 
 class TestGCSObjectExistenceSensorAsync:
     OPERATOR = GCSObjectExistenceSensorAsync(
@@ -171,6 +173,14 @@ class TestGCSObjectUpdateSensorAsync:
         google_cloud_conn_id=TEST_GCP_CONN_ID,
     )
 
+    @mock.patch(f"{MODULE}.GCSObjectUpdateSensorAsync.defer")
+    @mock.patch(f"{MODULE}.GCSObjectUpdateSensorAsync.poke", return_value=True)
+    def test_gcs_object_update_sensor_async_finish_before_deferred(self, mock_poke, mock_defer, context):
+        """Assert task is not deferred when it receives a finish status before deferring"""
+        self.OPERATOR.execute(create_context(self.OPERATOR))
+        assert not mock_defer.called
+
+    @mock.patch(f"{MODULE}.GCSObjectUpdateSensorAsync.poke", return_value=False)
     def test_gcs_object_update_sensor_async(self, context):
         """
         Asserts that a task is deferred and a GCSBlobTrigger will be fired


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we need to verify if the task has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. To accomplish this, we can use the poke method found in the sync counterpart of most sensors.
