### PR TITLE
Check whether the pipeline finishes before deferring the task for AzureDataFactoryPipelineRunStatusSensorAsync

### DIFF
--- a/astronomer/providers/microsoft/azure/sensors/data_factory.py
+++ b/astronomer/providers/microsoft/azure/sensors/data_factory.py
@@ -43,17 +43,18 @@ class AzureDataFactoryPipelineRunStatusSensorAsync(AzureDataFactoryPipelineRunSt
 
     def execute(self, context: Context) -> None:
         """Defers trigger class to poll for state of the job run until it reaches a failure state or success state"""
-        self.defer(
-            timeout=timedelta(seconds=self.timeout),
-            trigger=ADFPipelineRunStatusSensorTrigger(
-                run_id=self.run_id,
-                azure_data_factory_conn_id=self.azure_data_factory_conn_id,
-                resource_group_name=self.resource_group_name,
-                factory_name=self.factory_name,
-                poke_interval=self.poke_interval,
-            ),
-            method_name="execute_complete",
-        )
+        if not self.poke(context):
+            self.defer(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=ADFPipelineRunStatusSensorTrigger(
+                    run_id=self.run_id,
+                    azure_data_factory_conn_id=self.azure_data_factory_conn_id,
+                    resource_group_name=self.resource_group_name,
+                    factory_name=self.factory_name,
+                    poke_interval=self.poke_interval,
+                ),
+                method_name="execute_complete",
+            )
 
     def execute_complete(self, context: Context, event: Dict[str, str]) -> None:
         """


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we need to verify if the task has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. To accomplish this, we can use the poke method found in the sync counterpart of most sensors.
