### PR TITLE
Check whether the task finishes before deferring the task for WasbBlobSensorAsync

### DIFF
--- a/astronomer/providers/microsoft/azure/sensors/wasb.py
+++ b/astronomer/providers/microsoft/azure/sensors/wasb.py
@@ -53,17 +53,18 @@ class WasbBlobSensorAsync(WasbBlobSensor):
 
     def execute(self, context: Context) -> None:
         """Defers trigger class to poll for state of the job run until it reaches a failure state or success state"""
-        self.defer(
-            timeout=timedelta(seconds=self.timeout),
-            trigger=WasbBlobSensorTrigger(
-                container_name=self.container_name,
-                blob_name=self.blob_name,
-                wasb_conn_id=self.wasb_conn_id,
-                public_read=self.public_read,
-                poke_interval=self.poke_interval,
-            ),
-            method_name="execute_complete",
-        )
+        if not self.poke(context):
+            self.defer(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=WasbBlobSensorTrigger(
+                    container_name=self.container_name,
+                    blob_name=self.blob_name,
+                    wasb_conn_id=self.wasb_conn_id,
+                    public_read=self.public_read,
+                    poke_interval=self.poke_interval,
+                ),
+                method_name="execute_complete",
+            )
 
     def execute_complete(self, context: Context, event: Dict[str, str]) -> None:
         """

--- a/tests/microsoft/azure/sensors/test_wasb.py
+++ b/tests/microsoft/azure/sensors/test_wasb.py
@@ -17,6 +17,8 @@ TEST_DATA_STORAGE_BLOB_NAME = "test_blob_providers_team.txt"
 TEST_DATA_STORAGE_CONTAINER_NAME = "test-container-providers-team"
 TEST_DATA_STORAGE_BLOB_PREFIX = TEST_DATA_STORAGE_BLOB_NAME[:10]
 
+MODULE = "astronomer.providers.microsoft.azure.sensors.wasb"
+
 
 class TestWasbBlobSensorAsync:
     SENSOR = WasbBlobSensorAsync(
@@ -25,7 +27,15 @@ class TestWasbBlobSensorAsync:
         blob_name=TEST_DATA_STORAGE_BLOB_NAME,
     )
 
-    def test_wasb_blob_sensor_async(self):
+    @mock.patch(f"{MODULE}.WasbBlobSensorAsync.defer")
+    @mock.patch(f"{MODULE}.WasbBlobSensorAsync.poke", return_value=True)
+    def test_wasb_blob_sensor_async_finish_before_deferred(self, mock_poke, mock_defer, context):
+        """Assert task is not deferred when it receives a finish status before deferring"""
+        self.SENSOR.execute(create_context(self.SENSOR))
+        assert not mock_defer.called
+
+    @mock.patch(f"{MODULE}.WasbBlobSensorAsync.poke", return_value=False)
+    def test_wasb_blob_sensor_async(self, mock_poke):
         """Assert execute method defer for wasb blob sensor"""
 
         with pytest.raises(TaskDeferred) as exc:


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we need to verify if the task has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. To accomplish this, we can use the poke method found in the sync counterpart of most sensors.
