### PR TITLE
Increase snapshot creation max_attempts to 100

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -67,7 +67,7 @@ with DAG(
         snapshot_identifier=f"{REDSHIFT_CLUSTER_IDENTIFIER}-snapshot",
         cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
         wait_for_completion=True,
-        max_attempt=40,
+        max_attempt=100,
         aws_conn_id=AWS_CONN_ID,
     )
 


### PR DESCRIPTION
Previously, the max_attempts was set to 40 and the poll interval is 15 seconds.
However, it looks like this duration of 40 * 15=600 seconds(10 mins) is not enough
at times as it takes longer for snapshot creation and the task fails. Hence, we're
increasing the max_attempts to 100, meaning we will wait for
100 * 15=1500seconds(25 mins) now.  