### PR TITLE
Check whether the job reaches a failure or a success state before deferring the task for BatchSensorAsync

### DIFF
--- a/astronomer/providers/amazon/aws/sensors/batch.py
+++ b/astronomer/providers/amazon/aws/sensors/batch.py
@@ -45,16 +45,17 @@ class BatchSensorAsync(BatchSensor):
 
     def execute(self, context: Context) -> None:
         """Defers trigger class to poll for state of the job run until it reaches a failure or a success state"""
-        self.defer(
-            timeout=timedelta(seconds=self.timeout),
-            trigger=BatchSensorTrigger(
-                job_id=self.job_id,
-                aws_conn_id=self.aws_conn_id,
-                region_name=self.region_name,
-                poke_interval=self.poke_interval,
-            ),
-            method_name="execute_complete",
-        )
+        if not self.poke(context):
+            self.defer(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=BatchSensorTrigger(
+                    job_id=self.job_id,
+                    aws_conn_id=self.aws_conn_id,
+                    region_name=self.region_name,
+                    poke_interval=self.poke_interval,
+                ),
+                method_name="execute_complete",
+            )
 
     def execute_complete(self, context: Context, event: Dict[str, Any]) -> None:
         """

--- a/tests/amazon/aws/sensors/test_batch_sensors.py
+++ b/tests/amazon/aws/sensors/test_batch_sensors.py
@@ -6,6 +6,8 @@ from airflow.exceptions import AirflowException, TaskDeferred
 from astronomer.providers.amazon.aws.sensors.batch import BatchSensorAsync
 from astronomer.providers.amazon.aws.triggers.batch import BatchSensorTrigger
 
+MODULE = "astronomer.providers.amazon.aws.sensors.batch"
+
 
 class TestBatchSensorAsync:
     JOB_ID = "8ba9d676-4108-4474-9dca-8bbac1da9b19"
@@ -18,6 +20,14 @@ class TestBatchSensorAsync:
         region_name=REGION_NAME,
     )
 
+    @mock.patch(f"{MODULE}.BatchSensorAsync.defer")
+    @mock.patch(f"{MODULE}.BatchSensorAsync.poke", return_value=True)
+    def test_batch_sensor_async_finish_before_deferred(self, mock_poke, mock_defer, context):
+        """Assert task is not deferred when it receives a finish status before deferring"""
+        self.TASK.execute(context)
+        assert not mock_defer.called
+
+    @mock.patch(f"{MODULE}.BatchSensorAsync.poke", return_value=False)
     def test_batch_sensor_async(self, context):
         """
         Asserts that a task is deferred and a BatchSensorTrigger will be fired


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we need to verify if the task has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. To accomplish this, we can use the poke method found in the sync counterpart of most sensors.
