### PR TITLE
Check whether the task finishes before deferring the task for EmrStepSensorAsync

### DIFF
--- a/astronomer/providers/amazon/aws/sensors/emr.py
+++ b/astronomer/providers/amazon/aws/sensors/emr.py
@@ -79,18 +79,19 @@ class EmrStepSensorAsync(EmrStepSensor):
 
     def execute(self, context: Context) -> None:
         """Deferred and give control to trigger"""
-        self.defer(
-            timeout=timedelta(seconds=self.timeout),
-            trigger=EmrStepSensorTrigger(
-                job_flow_id=self.job_flow_id,
-                step_id=self.step_id,
-                target_states=self.target_states,
-                failed_states=self.failed_states,
-                aws_conn_id=self.aws_conn_id,
-                poke_interval=self.poke_interval,
-            ),
-            method_name="execute_complete",
-        )
+        if not self.poke(context):
+            self.defer(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=EmrStepSensorTrigger(
+                    job_flow_id=self.job_flow_id,
+                    step_id=self.step_id,
+                    target_states=self.target_states,
+                    failed_states=self.failed_states,
+                    aws_conn_id=self.aws_conn_id,
+                    poke_interval=self.poke_interval,
+                ),
+                method_name="execute_complete",
+            )
 
     def execute_complete(self, context: Context, event: Dict[str, Any]) -> None:
         """


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we need to verify if the task has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. To accomplish this, we can use the poke method found in the sync counterpart of most sensors.
