### PR TITLE
Check whether the task finishes before deferring the task for RedshiftClusterSensorAsync

### DIFF
--- a/astronomer/providers/amazon/aws/sensors/redshift_cluster.py
+++ b/astronomer/providers/amazon/aws/sensors/redshift_cluster.py
@@ -38,17 +38,18 @@ class RedshiftClusterSensorAsync(RedshiftClusterSensor):
 
     def execute(self, context: Context) -> None:
         """Check for the target_status and defers using the trigger"""
-        self.defer(
-            timeout=timedelta(seconds=self.timeout),
-            trigger=RedshiftClusterSensorTrigger(
-                task_id=self.task_id,
-                aws_conn_id=self.aws_conn_id,
-                cluster_identifier=self.cluster_identifier,
-                target_status=self.target_status,
-                poke_interval=self.poke_interval,
-            ),
-            method_name="execute_complete",
-        )
+        if not self.poke(context):
+            self.defer(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=RedshiftClusterSensorTrigger(
+                    task_id=self.task_id,
+                    aws_conn_id=self.aws_conn_id,
+                    cluster_identifier=self.cluster_identifier,
+                    target_status=self.target_status,
+                    poke_interval=self.poke_interval,
+                ),
+                method_name="execute_complete",
+            )
 
     def execute_complete(self, context: Context, event: Optional[Dict[Any, Any]] = None) -> None:
         """

--- a/tests/amazon/aws/sensors/test_redshift_sensor.py
+++ b/tests/amazon/aws/sensors/test_redshift_sensor.py
@@ -13,6 +13,8 @@ from astronomer.providers.amazon.aws.triggers.redshift_cluster import (
 TASK_ID = "redshift_sensor_check"
 POLLING_PERIOD_SECONDS = 1.0
 
+MODULE = "astronomer.providers.amazon.aws.sensors.redshift_cluster"
+
 
 class TestRedshiftClusterSensorAsync:
     TASK = RedshiftClusterSensorAsync(
@@ -21,6 +23,14 @@ class TestRedshiftClusterSensorAsync:
         target_status="available",
     )
 
+    @mock.patch(f"{MODULE}.RedshiftClusterSensorAsync.defer")
+    @mock.patch(f"{MODULE}.RedshiftClusterSensorAsync.poke", return_value=True)
+    def test_redshift_cluster_sensor_async_finish_before_deferred(self, mock_poke, mock_defer, context):
+        """Assert task is not deferred when it receives a finish status before deferring"""
+        self.TASK.execute(context)
+        assert not mock_defer.called
+
+    @mock.patch(f"{MODULE}.RedshiftClusterSensorAsync.poke", return_value=False)
     def test_redshift_cluster_sensor_async(self, context):
         """Test RedshiftClusterSensorAsync that a task with wildcard=True
         is deferred and an RedshiftClusterSensorTrigger will be fired when executed method is called"""


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we need to verify if the task has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. To accomplish this, we can use the poke method found in the sync counterpart of most sensors.
