### PR TITLE
Check whether the task finishes before deferring the task for S3KeySensorAsync

### DIFF
--- a/astronomer/providers/amazon/aws/sensors/s3.py
+++ b/astronomer/providers/amazon/aws/sensors/s3.py
@@ -69,9 +69,10 @@ class S3KeySensorAsync(S3KeySensor):
         verify: str | bool | None = None,
         **kwargs: Any,
     ):
+        self.bucket_key: list[str] = [bucket_key] if isinstance(bucket_key, str) else bucket_key
         super().__init__(
             bucket_name=bucket_name,
-            bucket_key=[bucket_key] if isinstance(bucket_key, str) else bucket_key,
+            bucket_key=self.bucket_key,
             wildcard_match=wildcard_match,
             check_fn=check_fn,
             aws_conn_id=aws_conn_id,
@@ -82,12 +83,11 @@ class S3KeySensorAsync(S3KeySensor):
     def execute(self, context: Context) -> None:
         """Check for a keys in s3 and defers using the trigger"""
         if not self.poke(context):
-            self.hook: S3Hook | None = None  # type: ignore[assignment]
             self.defer(
                 timeout=timedelta(seconds=self.timeout),
                 trigger=S3KeyTrigger(
                     bucket_name=cast(str, self.bucket_name),
-                    bucket_key=self.bucket_key,  # type: ignore[arg-type]
+                    bucket_key=self.bucket_key,
                     wildcard_match=self.wildcard_match,
                     check_fn=self.check_fn,
                     aws_conn_id=self.aws_conn_id,

--- a/astronomer/providers/amazon/aws/sensors/s3.py
+++ b/astronomer/providers/amazon/aws/sensors/s3.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
 import typing
 import warnings
 from datetime import timedelta
-from typing import Any, Callable, List, Optional, Sequence, Union, cast
+from typing import Any, Callable, List, Sequence, cast
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.providers.amazon.aws.sensors.s3 import S3KeysUnchangedSensor
+from airflow.providers.amazon.aws.sensors.s3 import S3KeySensor, S3KeysUnchangedSensor
 from airflow.sensors.base import BaseSensorOperator
 
 from astronomer.providers.amazon.aws.triggers.s3 import (
@@ -15,7 +17,7 @@ from astronomer.providers.amazon.aws.triggers.s3 import (
 from astronomer.providers.utils.typing_compat import Context
 
 
-class S3KeySensorAsync(BaseSensorOperator):
+class S3KeySensorAsync(S3KeySensor):
     """
     Waits for one or multiple keys (a file-like instance on S3) to be present in a S3 bucket.
     S3 being a key/value it does not support folders. The path is just a key
@@ -59,31 +61,33 @@ class S3KeySensorAsync(BaseSensorOperator):
     def __init__(
         self,
         *,
-        bucket_key: Union[str, List[str]],
-        bucket_name: Optional[str] = None,
+        bucket_key: str | list[str],
+        bucket_name: str | None = None,
         wildcard_match: bool = False,
-        check_fn: Optional[Callable[..., bool]] = None,
+        check_fn: Callable[..., bool] | None = None,
         aws_conn_id: str = "aws_default",
-        verify: Optional[Union[str, bool]] = None,
+        verify: str | bool | None = None,
         **kwargs: Any,
     ):
-        super().__init__(**kwargs)
-        self.bucket_name = bucket_name
-        self.bucket_key = [bucket_key] if isinstance(bucket_key, str) else bucket_key
-        self.wildcard_match = wildcard_match
-        self.check_fn = check_fn
-        self.aws_conn_id = aws_conn_id
-        self.verify = verify
-        self.hook: Optional[S3Hook] = None
+        super().__init__(
+            bucket_name=bucket_name,
+            bucket_key=[bucket_key] if isinstance(bucket_key, str) else bucket_key,
+            wildcard_match=wildcard_match,
+            check_fn=check_fn,
+            aws_conn_id=aws_conn_id,
+            verify=verify,
+            **kwargs,
+        )
 
     def execute(self, context: Context) -> None:
         """Check for a keys in s3 and defers using the trigger"""
         if not self.poke(context):
+            self.hook: S3Hook | None = None  # type: ignore[assignment]
             self.defer(
                 timeout=timedelta(seconds=self.timeout),
                 trigger=S3KeyTrigger(
                     bucket_name=cast(str, self.bucket_name),
-                    bucket_key=self.bucket_key,
+                    bucket_key=self.bucket_key,  # type: ignore[arg-type]
                     wildcard_match=self.wildcard_match,
                     check_fn=self.check_fn,
                     aws_conn_id=self.aws_conn_id,
@@ -93,7 +97,7 @@ class S3KeySensorAsync(BaseSensorOperator):
                 method_name="execute_complete",
             )
 
-    def execute_complete(self, context: Context, event: Any = None) -> Optional[bool]:
+    def execute_complete(self, context: Context, event: Any = None) -> bool | None:
         """
         Callback for when the trigger fires - returns immediately.
         Relies on trigger to throw an exception, otherwise it assumes execution was
@@ -117,7 +121,7 @@ class S3KeySizeSensorAsync(S3KeySensorAsync):
     def __init__(
         self,
         *,
-        check_fn: Optional[Callable[..., bool]] = None,
+        check_fn: Callable[..., bool] | None = None,
         **kwargs: Any,
     ):
         warnings.warn(
@@ -212,10 +216,10 @@ class S3PrefixSensorAsync(BaseSensorOperator):
         self,
         *,
         bucket_name: str,
-        prefix: Union[str, List[str]],
+        prefix: str | list[str],
         delimiter: str = "/",
         aws_conn_id: str = "aws_default",
-        verify: Optional[Union[str, bool]] = None,
+        verify: str | bool | None = None,
         **kwargs: Any,
     ):
         warnings.warn(

--- a/astronomer/providers/amazon/aws/sensors/s3.py
+++ b/astronomer/providers/amazon/aws/sensors/s3.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from typing import Any, Callable, List, Sequence, cast
 
 from airflow.exceptions import AirflowException
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.sensors.s3 import S3KeySensor, S3KeysUnchangedSensor
 from airflow.sensors.base import BaseSensorOperator
 

--- a/astronomer/providers/amazon/aws/sensors/s3.py
+++ b/astronomer/providers/amazon/aws/sensors/s3.py
@@ -78,19 +78,20 @@ class S3KeySensorAsync(BaseSensorOperator):
 
     def execute(self, context: Context) -> None:
         """Check for a keys in s3 and defers using the trigger"""
-        self.defer(
-            timeout=timedelta(seconds=self.timeout),
-            trigger=S3KeyTrigger(
-                bucket_name=cast(str, self.bucket_name),
-                bucket_key=self.bucket_key,
-                wildcard_match=self.wildcard_match,
-                check_fn=self.check_fn,
-                aws_conn_id=self.aws_conn_id,
-                verify=self.verify,
-                poke_interval=self.poke_interval,
-            ),
-            method_name="execute_complete",
-        )
+        if not self.poke(context):
+            self.defer(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=S3KeyTrigger(
+                    bucket_name=cast(str, self.bucket_name),
+                    bucket_key=self.bucket_key,
+                    wildcard_match=self.wildcard_match,
+                    check_fn=self.check_fn,
+                    aws_conn_id=self.aws_conn_id,
+                    verify=self.verify,
+                    poke_interval=self.poke_interval,
+                ),
+                method_name="execute_complete",
+            )
 
     def execute_complete(self, context: Context, event: Any = None) -> Optional[bool]:
         """

--- a/astronomer/providers/amazon/aws/triggers/s3.py
+++ b/astronomer/providers/amazon/aws/triggers/s3.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import asyncio
 from datetime import datetime
-from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, AsyncIterator, Callable
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 
@@ -27,9 +29,9 @@ class S3KeyTrigger(BaseTrigger):
     def __init__(
         self,
         bucket_name: str,
-        bucket_key: List[str],
+        bucket_key: list[str],
         wildcard_match: bool = False,
-        check_fn: Optional[Callable[..., bool]] = None,
+        check_fn: Callable[..., bool] | None = None,
         aws_conn_id: str = "aws_default",
         poke_interval: float = 5.0,
         **hook_params: Any,
@@ -43,7 +45,7 @@ class S3KeyTrigger(BaseTrigger):
         self.hook_params = hook_params
         self.poke_interval = poke_interval
 
-    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+    def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serialize S3KeyTrigger arguments and classpath."""
         return (
             "astronomer.providers.amazon.aws.triggers.s3.S3KeyTrigger",
@@ -58,7 +60,7 @@ class S3KeyTrigger(BaseTrigger):
             },
         )
 
-    async def run(self) -> AsyncIterator["TriggerEvent"]:
+    async def run(self) -> AsyncIterator[TriggerEvent]:
         """Make an asynchronous connection using S3HookAsync."""
         try:
             hook = self._get_async_hook()
@@ -110,11 +112,11 @@ class S3KeysUnchangedTrigger(BaseTrigger):
         inactivity_period: float = 60 * 60,
         min_objects: int = 1,
         inactivity_seconds: int = 0,
-        previous_objects: Optional[Set[str]] = None,
+        previous_objects: set[str] | None = None,
         allow_delete: bool = True,
         aws_conn_id: str = "aws_default",
-        last_activity_time: Optional[datetime] = None,
-        verify: Optional[Union[bool, str]] = None,
+        last_activity_time: datetime | None = None,
+        verify: bool | str | None = None,
     ):
         super().__init__()
         self.bucket_name = bucket_name
@@ -129,11 +131,11 @@ class S3KeysUnchangedTrigger(BaseTrigger):
         self.inactivity_seconds = inactivity_seconds
         self.allow_delete = allow_delete
         self.aws_conn_id = aws_conn_id
-        self.last_activity_time: Optional[datetime] = last_activity_time
+        self.last_activity_time: datetime | None = last_activity_time
         self.verify = verify
         self.polling_period_seconds = 0
 
-    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+    def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serialize S3KeysUnchangedTrigger arguments and classpath."""
         return (
             "astronomer.providers.amazon.aws.triggers.s3.S3KeysUnchangedTrigger",
@@ -150,7 +152,7 @@ class S3KeysUnchangedTrigger(BaseTrigger):
             },
         )
 
-    async def run(self) -> AsyncIterator["TriggerEvent"]:
+    async def run(self) -> AsyncIterator[TriggerEvent]:
         """Make an asynchronous connection using S3HookAsync."""
         try:
             hook = self._get_async_hook()


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we need to verify if the task has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. To accomplish this, we can use the poke method found in the sync counterpart of most sensors.
