### PR TITLE
Check whether the task finishes before deferring the task for S3KeysUnchangedSensorAsync

### DIFF
--- a/astronomer/providers/amazon/aws/hooks/s3.py
+++ b/astronomer/providers/amazon/aws/hooks/s3.py
@@ -350,7 +350,13 @@ class S3HookAsync(AwsBaseHookAsync):
             }
 
         if last_activity_time:
-            inactivity_seconds = int((datetime.now() - last_activity_time).total_seconds())
+            try:
+                inactivity_seconds = int((datetime.now() - last_activity_time).total_seconds())
+            except TypeError:
+                # TypeError: can't subtract offset-naive and offset-aware datetimes
+                inactivity_seconds = int(
+                    (datetime.now(last_activity_time.tzinfo) - last_activity_time).total_seconds()
+                )
         else:
             # Handles the first poke where last inactivity time is None.
             last_activity_time = datetime.now()

--- a/astronomer/providers/amazon/aws/sensors/s3.py
+++ b/astronomer/providers/amazon/aws/sensors/s3.py
@@ -185,7 +185,7 @@ class S3KeysUnchangedSensorAsync(S3KeysUnchangedSensor):
                     allow_delete=self.allow_delete,
                     aws_conn_id=self.aws_conn_id,
                     verify=self.verify,
-                    last_activity_time=None,
+                    last_activity_time=self.last_activity_time,
                 ),
                 method_name="execute_complete",
             )

--- a/astronomer/providers/amazon/aws/sensors/s3.py
+++ b/astronomer/providers/amazon/aws/sensors/s3.py
@@ -172,22 +172,23 @@ class S3KeysUnchangedSensorAsync(S3KeysUnchangedSensor):
 
     def execute(self, context: Context) -> None:
         """Defers Trigger class to check for changes in the number of objects at prefix in AWS S3"""
-        self.defer(
-            timeout=timedelta(seconds=self.timeout),
-            trigger=S3KeysUnchangedTrigger(
-                bucket_name=self.bucket_name,
-                prefix=self.prefix,
-                inactivity_period=self.inactivity_period,
-                min_objects=self.min_objects,
-                previous_objects=self.previous_objects,
-                inactivity_seconds=self.inactivity_seconds,
-                allow_delete=self.allow_delete,
-                aws_conn_id=self.aws_conn_id,
-                verify=self.verify,
-                last_activity_time=self.last_activity_time,
-            ),
-            method_name="execute_complete",
-        )
+        if not self.poke(context):
+            self.defer(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=S3KeysUnchangedTrigger(
+                    bucket_name=self.bucket_name,
+                    prefix=self.prefix,
+                    inactivity_period=self.inactivity_period,
+                    min_objects=self.min_objects,
+                    previous_objects=self.previous_objects,
+                    inactivity_seconds=self.inactivity_seconds,
+                    allow_delete=self.allow_delete,
+                    aws_conn_id=self.aws_conn_id,
+                    verify=self.verify,
+                    last_activity_time=self.last_activity_time,
+                ),
+                method_name="execute_complete",
+            )
 
     def execute_complete(self, context: Context, event: Any = None) -> None:
         """

--- a/astronomer/providers/amazon/aws/sensors/s3.py
+++ b/astronomer/providers/amazon/aws/sensors/s3.py
@@ -185,7 +185,7 @@ class S3KeysUnchangedSensorAsync(S3KeysUnchangedSensor):
                     allow_delete=self.allow_delete,
                     aws_conn_id=self.aws_conn_id,
                     verify=self.verify,
-                    last_activity_time=self.last_activity_time,
+                    last_activity_time=None,
                 ),
                 method_name="execute_complete",
             )

--- a/tests/amazon/aws/hooks/test_s3_hooks.py
+++ b/tests/amazon/aws/hooks/test_s3_hooks.py
@@ -2,6 +2,7 @@ import unittest
 from datetime import datetime
 from unittest import mock
 
+import pendulum
 import pytest
 from botocore.exceptions import ClientError
 
@@ -331,6 +332,37 @@ class TestS3HookAsync:
             inactivity_seconds=0,
             allow_delete=True,
             last_activity_time=datetime(2020, 8, 14, 17, 19, 34),
+        )
+
+        assert response == {
+            "message": (
+                "SUCCESS: Sensor found 1 objects at test_bucket/test. "
+                "Waited at least 1 seconds, with no new objects uploaded."
+            ),
+            "status": "success",
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch("astronomer.providers.amazon.aws.triggers.s3.S3HookAsync.get_client_async")
+    @mock.patch("astronomer.providers.amazon.aws.triggers.s3.S3HookAsync._list_keys")
+    async def test_s3_key_hook_is_keys_unchanged_true_with_tz_info(self, mock_list_keys, mock_client):
+        """
+        Test is_key_unchanged gives AirflowException
+        :return:
+        """
+        mock_list_keys.return_value = ["test_file"]
+
+        s3_hook_async = S3HookAsync(client_type="S3", resource_type="S3")
+        response = await s3_hook_async.is_keys_unchanged(
+            client=mock_client.return_value,
+            bucket_name="test_bucket",
+            prefix="test",
+            inactivity_period=1,
+            min_objects=1,
+            previous_objects=set("t"),
+            inactivity_seconds=0,
+            allow_delete=True,
+            last_activity_time=pendulum.datetime(2020, 8, 14, 17, 19, 34),
         )
 
         assert response == {

--- a/tests/amazon/aws/sensors/test_s3_sensors.py
+++ b/tests/amazon/aws/sensors/test_s3_sensors.py
@@ -21,6 +21,8 @@ from astronomer.providers.amazon.aws.triggers.s3 import (
     S3KeyTrigger,
 )
 
+MODULE = "astronomer.providers.amazon.aws.sensors.s3"
+
 
 class TestS3KeySensorAsync:
     def test_bucket_name_none_and_bucket_key_as_relative_path(self, context):
@@ -223,8 +225,18 @@ class TestS3KeySensorAsync:
 
 
 class TestS3KeysUnchangedSensorAsync:
+    @mock.patch(f"{MODULE}.S3KeysUnchangedSensorAsync.defer")
+    @mock.patch(f"{MODULE}.S3KeysUnchangedSensorAsync.poke", return_value=True)
+    def test_s3_keys_unchanged_sensor_async_finish_before_deferred(self, mock_poke, mock_defer, context):
+        """Assert task is not deferred when it receives a finish status before deferring"""
+        S3KeysUnchangedSensorAsync(
+            task_id="s3_keys_unchanged_sensor", bucket_name="test_bucket", prefix="test"
+        )
+        assert not mock_defer.called
+
+    @mock.patch(f"{MODULE}.S3KeysUnchangedSensorAsync.poke", return_value=False)
     @mock.patch("airflow.providers.amazon.aws.sensors.s3.S3Hook")
-    def test_s3_keys_unchanged_sensor_check_trigger_instance(self, mock_hook, context):
+    def test_s3_keys_unchanged_sensor_check_trigger_instance(self, mock_hook, mock_poke, context):
         """
         Asserts that a task is deferred and an S3KeysUnchangedTrigger will be fired
         when the S3KeysUnchangedSensorAsync is executed.
@@ -243,8 +255,9 @@ class TestS3KeysUnchangedSensorAsync:
         ), "Trigger is not a S3KeysUnchangedTrigger"
 
     @parameterized.expand([["bucket", "test"]])
+    @mock.patch(f"{MODULE}.S3KeysUnchangedSensorAsync.poke", return_value=False)
     @mock.patch("airflow.providers.amazon.aws.sensors.s3.S3Hook")
-    def test_s3_keys_unchanged_sensor_execute_complete_success(self, bucket, prefix, mock_hook):
+    def test_s3_keys_unchanged_sensor_execute_complete_success(self, bucket, prefix, mock_hook, mock_poke):
         """
         Asserts that a task completed with success status
         """
@@ -258,8 +271,9 @@ class TestS3KeysUnchangedSensorAsync:
         assert sensor.execute_complete(context={}, event={"status": "success"}) is None
 
     @parameterized.expand([["bucket", "test"]])
+    @mock.patch(f"{MODULE}.S3KeysUnchangedSensorAsync.poke", return_value=False)
     @mock.patch("airflow.providers.amazon.aws.sensors.s3.S3Hook")
-    def test_s3_keys_unchanged_sensor_execute_complete_error(self, bucket, prefix, mock_hook):
+    def test_s3_keys_unchanged_sensor_execute_complete_error(self, bucket, prefix, mock_hook, mock_poke):
         """
         Asserts that a task is completed with error.
         """
@@ -273,7 +287,8 @@ class TestS3KeysUnchangedSensorAsync:
         with pytest.raises(AirflowException):
             sensor.execute_complete(context={}, event={"status": "error", "message": "Mocked error"})
 
-    def test_s3_keys_unchanged_sensor_raise_value_error(self):
+    @mock.patch(f"{MODULE}.S3KeysUnchangedSensorAsync.poke", return_value=False)
+    def test_s3_keys_unchanged_sensor_raise_value_error(self, mock_poke):
         """
         Test if the S3KeysUnchangedTrigger raises Value error for negative inactivity_period.
         """


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we need to verify if the task has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. To accomplish this, we can use the poke method found in the sync counterpart of most sensors.
