### PR TITLE
Schedule daily run of AWS nuke DAG temporarily

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
@@ -21,7 +21,7 @@ default_args = {
 with DAG(
     dag_id="example_aws_nuke",
     start_date=datetime(2022, 1, 1),
-    schedule=None,
+    schedule="30 20 * * *",
     catchup=False,
     default_args=default_args,
     tags=["example", "aws-nuke"],


### PR DESCRIPTION
With the change in PR #1019, we set the schedule of nuke DAG to none as it runs from the master DAG now. However, there are some abnomalities in the KubernetesExecutor deployment and also the nuke DAG does not run there. As a result resources are not cleaned up post the master DAG run in KubernetesExecutor (which runs after the master DAG in CeleryExecutor). As a result, on next day, DAGs in CeleryExecutor deployment also fail due to resouce already exists error. Hence, for the time being until KubernetesExecutor deployment is all well, we would like to renable the Nuke DAG to run daily at 20:30 Hrs.