### PR TITLE
Combine aws configure with aws nuke in single operator

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
@@ -29,18 +29,14 @@ with DAG(
 ) as dag:
     start = DummyOperator(task_id="start")
 
-    set_aws_config = BashOperator(
-        task_id="aws_config",
-        bash_command=f"aws configure set aws_access_key_id {AWS_ACCESS_KEY_ID}; "
-        f"aws configure set aws_secret_access_key {AWS_SECRET_ACCESS_KEY}; "
-        f"aws configure set default.region {AWS_DEFAULT_REGION}; ",
-    )
-
     execute_aws_nuke = BashOperator(
         task_id="execute_aws_nuke",
-        bash_command="aws-nuke -c /usr/local/airflow/dags/nuke-config.yml --profile default --force --no-dry-run; ",
+        bash_command=f"aws configure set aws_access_key_id {AWS_ACCESS_KEY_ID}; "
+        f"aws configure set aws_secret_access_key {AWS_SECRET_ACCESS_KEY}; "
+        f"aws configure set default.region {AWS_DEFAULT_REGION}; "
+        f"aws-nuke -c /usr/local/airflow/dags/nuke-config.yml --profile default --force --no-dry-run; ",
     )
 
     end = DummyOperator(task_id="end")
 
-    start >> set_aws_config >> execute_aws_nuke >> end
+    start >> execute_aws_nuke >> end


### PR DESCRIPTION
It is observed on KubernetesExecutor deployment that the AWS Nuke DAG fails
with permission issues that it cannot assume an AWS role to perform operations
in our AWS account. The preliminary guess is that since we run authentication
and nuke commands in separate operators, they get launched in separate pods
and hence the authentication/authorization is missing the second pod which triggers
the nuke. This PR combines the two operators in a single operator so that the Nuke
DAG runs fine on our KubernetesExecutor deployment