### PR TITLE
Mark Livy DAG failed if any of the tasks fail

### DIFF
--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -246,6 +246,7 @@ def get_cluster_details(task_instance: Any) -> None:
 
 
 def dag_final_status(**kwargs):
+    """Raises an exception if any of the DAG's tasks failed and as a result marking the DAG failed."""
     for task_instance in kwargs["dag_run"].get_task_instances():
         if (
             task_instance.current_state() != State.SUCCESS

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -17,6 +17,8 @@ from airflow.providers.amazon.aws.operators.emr import (
     EmrCreateJobFlowOperator,
     EmrTerminateJobFlowOperator,
 )
+from airflow.utils.state import State
+from airflow.utils.trigger_rule import TriggerRule
 from botocore.exceptions import ClientError
 from requests import get
 
@@ -243,6 +245,15 @@ def get_cluster_details(task_instance: Any) -> None:
     )
 
 
+def dag_final_status(**kwargs):
+    for task_instance in kwargs["dag_run"].get_task_instances():
+        if (
+            task_instance.current_state() != State.SUCCESS
+            and task_instance.task_id != kwargs["task_instance"].task_id
+        ):
+            raise Exception(f"Task {task_instance.task_id} failed. Failing this DAG run")
+
+
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
     "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
@@ -321,6 +332,15 @@ with DAG(
     )
     # [END howto_operator_emr_terminate_job_flow]
 
+    dag_final_status = PythonOperator(
+        task_id="dag_final_status",
+        provide_context=True,
+        python_callable=dag_final_status,
+        trigger_rule=TriggerRule.ALL_DONE,  # Ensures this task runs even if upstream fails
+        dag=dag,
+        retries=0,
+    )
+
     (
         cluster_creator
         >> describe_created_cluster
@@ -330,4 +350,5 @@ with DAG(
         >> livy_java_task
         >> livy_python_task
         >> remove_cluster
+        >> dag_final_status
     )

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -245,7 +245,7 @@ def get_cluster_details(task_instance: Any) -> None:
     )
 
 
-def dag_final_status(**kwargs):
+def check_dag_status(**kwargs: Any) -> None:
     """Raises an exception if any of the DAG's tasks failed and as a result marking the DAG failed."""
     for task_instance in kwargs["dag_run"].get_task_instances():
         if (
@@ -336,7 +336,7 @@ with DAG(
     dag_final_status = PythonOperator(
         task_id="dag_final_status",
         provide_context=True,
-        python_callable=dag_final_status,
+        python_callable=check_dag_status,
         trigger_rule=TriggerRule.ALL_DONE,  # Ensures this task runs even if upstream fails
         dag=dag,
         retries=0,


### PR DESCRIPTION
Currently, as seen in the issue the DAG is marked success based
on the status of only the last task even if any of the intermediate tasks
fail. As a result, the master DAG does show the status of the DAG as
successful even though its intermediate tasks fail. This does not reflect
the correct top-level view of statuses of the DAGs triggered from the master DAG.
The commit adds a PythonOperator task at the end of the DAG to check the
statuses of all of the DAG's tasks and marks the DAG as failed if any of its tasks
fail.

closes: #1001 