### PR TITLE
Nuke SageMaker model as part of AWS nuke DAG

### DIFF
--- a/.circleci/integration-tests/nuke-config.yml
+++ b/.circleci/integration-tests/nuke-config.yml
@@ -27,6 +27,7 @@ resource-types:
     - EKSCluster
     - S3MultipartUpload
     - RedshiftCluster
+    - SageMakerModel
 accounts:
   '396807896376':  # aws-airflow-providers-main
     filters:       # won't delete the filtered resources


### PR DESCRIPTION
Nukes SageMaker models left undeleted.

closes: #1055 