### PR TITLE
Mark EMR Sensor DAG failed if any of the tasks fail

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
@@ -2,13 +2,17 @@
 
 import os
 from datetime import datetime, timedelta
+from typing import Any
 
 from airflow import DAG
+from airflow.operators.python import PythonOperator
 from airflow.providers.amazon.aws.operators.emr import (
     EmrAddStepsOperator,
     EmrCreateJobFlowOperator,
     EmrTerminateJobFlowOperator,
 )
+from airflow.utils.state import State
+from airflow.utils.trigger_rule import TriggerRule
 
 from astronomer.providers.amazon.aws.sensors.emr import (
     EmrJobFlowSensorAsync,
@@ -59,6 +63,16 @@ DEFAULT_ARGS = {
 }
 
 
+def check_dag_status(**kwargs: Any) -> None:
+    """Raises an exception if any of the DAG's tasks failed and as a result marking the DAG failed."""
+    for task_instance in kwargs["dag_run"].get_task_instances():
+        if (
+            task_instance.current_state() != State.SUCCESS
+            and task_instance.task_id != kwargs["task_instance"].task_id
+        ):
+            raise Exception(f"Task {task_instance.task_id} failed. Failing this DAG run")
+
+
 with DAG(
     dag_id="example_emr_sensor",
     schedule=None,
@@ -69,7 +83,7 @@ with DAG(
 ) as dag:
     # For apache-airflow-providers-amazon < 4.1.0 you will also have to pass emr_conn_id param
     # [START howto_operator_emr_create_job_flow_steps_tasks]
-    cluster_creator = EmrCreateJobFlowOperator(
+    create_job_flow = EmrCreateJobFlowOperator(
         task_id="create_job_flow",
         job_flow_overrides=JOB_FLOW_OVERRIDES,
         aws_conn_id=AWS_CONN_ID,
@@ -77,9 +91,9 @@ with DAG(
     # [END howto_operator_emr_create_job_flow_steps_tasks]
 
     # [START howto_operator_emr_add_steps]
-    step_adder = EmrAddStepsOperator(
+    add_steps = EmrAddStepsOperator(
         task_id="add_steps",
-        job_flow_id=str(cluster_creator.output),
+        job_flow_id=create_job_flow.output,
         steps=SPARK_STEPS,
         aws_conn_id=AWS_CONN_ID,
     )
@@ -87,27 +101,36 @@ with DAG(
 
     # [START howto_sensor_emr_job_flow_async]
     job_flow_sensor = EmrJobFlowSensorAsync(
-        task_id="job_flow_sensor", job_flow_id=cluster_creator.output, aws_conn_id=AWS_CONN_ID
+        task_id="job_flow_sensor", job_flow_id=create_job_flow.output, aws_conn_id=AWS_CONN_ID
     )
     # [END howto_sensor_emr_job_flow_async]
 
     # [START howto_sensor_emr_step_async]
-    step_checker = EmrStepSensorAsync(
+    watch_step = EmrStepSensorAsync(
         task_id="watch_step",
-        job_flow_id=str(cluster_creator.output),
+        job_flow_id=create_job_flow.output,
         step_id="{{ task_instance.xcom_pull(task_ids='add_steps', key='return_value')[0] }}",
         aws_conn_id=AWS_CONN_ID,
     )
     # [END howto_sensor_emr_step_async]
 
     # [START howto_operator_emr_terminate_job_flow]
-    cluster_remover = EmrTerminateJobFlowOperator(
-        task_id="remove_cluster",
-        job_flow_id=str(cluster_creator.output),
+    remove_job_flow = EmrTerminateJobFlowOperator(
+        task_id="remove_job_flow",
+        job_flow_id=create_job_flow.output,
         aws_conn_id=AWS_CONN_ID,
         trigger_rule="all_done",
     )
     # [END howto_operator_emr_terminate_job_flow]
 
-    [job_flow_sensor, step_checker] >> cluster_remover
-    step_adder >> step_checker
+    dag_final_status = PythonOperator(
+        task_id="dag_final_status",
+        provide_context=True,
+        python_callable=check_dag_status,
+        trigger_rule=TriggerRule.ALL_DONE,  # Ensures this task runs even if upstream fails
+        dag=dag,
+        retries=0,
+    )
+
+    add_steps >> watch_step
+    [job_flow_sensor, watch_step] >> remove_job_flow >> dag_final_status

--- a/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
@@ -93,7 +93,7 @@ with DAG(
     # [START howto_operator_emr_add_steps]
     add_steps = EmrAddStepsOperator(
         task_id="add_steps",
-        job_flow_id=create_job_flow.output,
+        job_flow_id=create_job_flow.output,  # type: ignore[arg-type]
         steps=SPARK_STEPS,
         aws_conn_id=AWS_CONN_ID,
     )
@@ -108,7 +108,7 @@ with DAG(
     # [START howto_sensor_emr_step_async]
     watch_step = EmrStepSensorAsync(
         task_id="watch_step",
-        job_flow_id=create_job_flow.output,
+        job_flow_id=create_job_flow.output,  # type: ignore[arg-type]
         step_id="{{ task_instance.xcom_pull(task_ids='add_steps', key='return_value')[0] }}",
         aws_conn_id=AWS_CONN_ID,
     )
@@ -117,7 +117,7 @@ with DAG(
     # [START howto_operator_emr_terminate_job_flow]
     remove_job_flow = EmrTerminateJobFlowOperator(
         task_id="remove_job_flow",
-        job_flow_id=create_job_flow.output,
+        job_flow_id=create_job_flow.output,  # type: ignore[arg-type]
         aws_conn_id=AWS_CONN_ID,
         trigger_rule="all_done",
     )


### PR DESCRIPTION
Currently, as seen in the issue the DAG is marked success based
on the status of only the last task even if any of the intermediate tasks
fail. As a result, the master DAG does show the status of the DAG as
successful even though its intermediate tasks fail. This does not reflect
the correct top-level view of the statuses of the DAGs triggered from the master DAG.
The commit adds a PythonOperator task at the end of the DAG to check the
statuses of all of the DAG's tasks and marks the DAG as failed if any of its tasks
fail.

closes: #1059 