### PR TITLE
Revert "Schedule daily run of AWS nuke DAG temporarily (#1040)"

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
@@ -21,7 +21,7 @@ default_args = {
 with DAG(
     dag_id="example_aws_nuke",
     start_date=datetime(2022, 1, 1),
-    schedule="30 20 * * *",
+    schedule=None,
     catchup=False,
     default_args=default_args,
     tags=["example", "aws-nuke"],


### PR DESCRIPTION
This reverts commit 0f8635742f9171427ea482945fddcbdc1372a604.

Since, we have AWS nuke DAG working on KE deployment now, we can disable scheduled runs of the AWS nuke DAG now.