### PR TITLE
Check whether the job finishes before deferring the task for AzureDataFactoryRunPipelineOperatorAsync

### DIFF
--- a/tests/microsoft/azure/operators/test_data_factory.py
+++ b/tests/microsoft/azure/operators/test_data_factory.py
@@ -2,6 +2,10 @@ from unittest import mock
 
 import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
+from airflow.providers.microsoft.azure.hooks.data_factory import (
+    AzureDataFactoryPipelineRunException,
+    AzureDataFactoryPipelineRunStatus,
+)
 
 from astronomer.providers.microsoft.azure.operators.data_factory import (
     AzureDataFactoryRunPipelineOperatorAsync,
@@ -13,6 +17,8 @@ from tests.utils.airflow_util import create_context
 
 AZ_PIPELINE_RUN_ID = "7f8c6c72-c093-11ec-a83d-0242ac120007"
 
+MODULE = "astronomer.providers.microsoft.azure.operators.data_factory"
+
 
 class TestAzureDataFactoryRunPipelineOperatorAsync:
     OPERATOR = AzureDataFactoryRunPipelineOperatorAsync(
@@ -21,8 +27,51 @@ class TestAzureDataFactoryRunPipelineOperatorAsync:
         parameters={"myParam": "value"},
     )
 
+    @mock.patch(f"{MODULE}.AzureDataFactoryRunPipelineOperatorAsync.defer")
+    @mock.patch(
+        "airflow.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHook.get_pipeline_run_status",
+        return_value=AzureDataFactoryPipelineRunStatus.SUCCEEDED,
+    )
     @mock.patch("airflow.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHook.run_pipeline")
-    def test_azure_data_factory_run_pipeline_operator_async(self, mock_run_pipeline):
+    def test_azure_data_factory_run_pipeline_operator_async_succeeded_before_deferred(
+        self, mock_run_pipeline, mock_get_status, mock_defer
+    ):
+        class CreateRunResponse:
+            pass
+
+        CreateRunResponse.run_id = AZ_PIPELINE_RUN_ID
+        mock_run_pipeline.return_value = CreateRunResponse
+
+        self.OPERATOR.execute(context=create_context(self.OPERATOR))
+        assert not mock_defer.called
+
+    @pytest.mark.parametrize("status", AzureDataFactoryPipelineRunStatus.FAILURE_STATES)
+    @mock.patch(f"{MODULE}.AzureDataFactoryRunPipelineOperatorAsync.defer")
+    @mock.patch(
+        "airflow.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHook.get_pipeline_run_status",
+    )
+    @mock.patch("airflow.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHook.run_pipeline")
+    def test_azure_data_factory_run_pipeline_operator_async_error_before_deferred(
+        self, mock_run_pipeline, mock_get_status, mock_defer, status
+    ):
+        mock_get_status.return_value = status
+
+        class CreateRunResponse:
+            pass
+
+        CreateRunResponse.run_id = AZ_PIPELINE_RUN_ID
+        mock_run_pipeline.return_value = CreateRunResponse
+
+        with pytest.raises(AzureDataFactoryPipelineRunException):
+            self.OPERATOR.execute(context=create_context(self.OPERATOR))
+        assert not mock_defer.called
+
+    @pytest.mark.parametrize("status", AzureDataFactoryPipelineRunStatus.INTERMEDIATE_STATES)
+    @mock.patch(
+        "airflow.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHook.get_pipeline_run_status",
+    )
+    @mock.patch("airflow.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHook.run_pipeline")
+    def test_azure_data_factory_run_pipeline_operator_async(self, mock_run_pipeline, mock_get_status, status):
         """Assert that AzureDataFactoryRunPipelineOperatorAsync deferred"""
 
         class CreateRunResponse:


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we try to verify if the submitted job has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. 