### PR TITLE
 Check whether the job finishes before deferring the task for BigQueryInsertJobOperatorAsync

### DIFF
--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -79,7 +79,7 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
         super().__init__(*args, **kwargs)
         self.poll_interval = poll_interval
 
-    def execute(self, context: Context) -> None:  # noqa: D102
+    def execute(self, context: Context) -> Any:  # noqa: D102
         kwargs: dict[Any, Any] = {}
         if hasattr(self, "delegate_to"):
             kwargs["delegate_to"] = self.delegate_to
@@ -124,18 +124,23 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
 
         self.job_id = job.job_id
         context["ti"].xcom_push(key="job_id", value=self.job_id)
-        self.defer(
-            timeout=self.execution_timeout,
-            trigger=BigQueryInsertJobTrigger(
-                conn_id=self.gcp_conn_id,
-                job_id=self.job_id,
-                project_id=self.project_id,
-                impersonation_chain=self.impersonation_chain,
-                poll_interval=self.poll_interval,
-                **kwargs,
-            ),
-            method_name="execute_complete",
-        )
+        if job.running():
+            self.defer(
+                timeout=self.execution_timeout,
+                trigger=BigQueryInsertJobTrigger(
+                    conn_id=self.gcp_conn_id,
+                    job_id=self.job_id,
+                    project_id=self.project_id,
+                    impersonation_chain=self.impersonation_chain,
+                    poll_interval=self.poll_interval,
+                    **kwargs,
+                ),
+                method_name="execute_complete",
+            )
+        else:
+            job.result()
+            self._handle_job_error(job)
+            return self.job_id
 
     def execute_complete(self, context: Context, event: dict[str, Any]) -> None:
         """

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -142,7 +142,7 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
             self._handle_job_error(job)
             return self.job_id
 
-    def execute_complete(self, context: Context, event: dict[str, Any]) -> None:
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> Any:
         """
         Callback for when the trigger fires - returns immediately.
         Relies on trigger to throw an exception, otherwise it assumes execution was
@@ -155,6 +155,7 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator, BaseOperator):
             self.task_id,
             event["message"],
         )
+        return self.job_id
 
 
 class BigQueryCheckOperatorAsync(BigQueryCheckOperator):


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we try to verify if the submitted job has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. 


Same as #1041 (I accidentally delete the branch)