### PR TITLE
Enhance SFTP Async sensor addressing user feedback

### DIFF
--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -20,7 +20,7 @@ class SFTPHookAsync(BaseHook):
     :param host: hostname of the SFTP server
     :param port: port of the SFTP server
     :param username: username used when authenticating to the SFTP server
-    :param password: password used when authenticating to the SFTP server
+    :param password: password used when authenticating to the SFTP server.
         Can be left blank if using a key file
     :param known_hosts: path to the known_hosts file on the local file system. Defaults to ``~/.ssh/known_hosts``.
     :param key_file: path to the client key file used for authentication to SFTP server

--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -73,13 +73,13 @@ class SFTPHookAsync(BaseHook):
         """Parse extra fields from the connection into instance fields"""
         extra_options = conn.extra_dejson
         if "key_file" in extra_options and self.key_file == "":
-            self.key_file = extra_options.get("key_file")
+            self.key_file = extra_options["key_file"]
         if "known_hosts" in extra_options:
-            self.known_hosts = extra_options.get("known_hosts")
+            self.known_hosts = extra_options["known_hosts"]
         if ("passphrase" or "private_key_passphrase") in extra_options:
-            self.passphrase = extra_options.get("passphrase")
+            self.passphrase = extra_options["passphrase"]
         if "private_key" in extra_options:
-            self.private_key = extra_options.get("private_key")
+            self.private_key = extra_options["private_key"]
 
         host_key = extra_options.get("host_key")
         no_host_key_check = extra_options.get("no_host_key_check")
@@ -234,7 +234,7 @@ class SFTPHookAsync(BaseHook):
         self, path: str = "", fnmatch_pattern: str = ""
     ) -> Sequence[asyncssh.sftp.SFTPName]:
         """
-        Returns the files along with their attributes matching the file pattern (e.g. *.pdf) at the provided path,
+        Returns the files along with their attributes matching the file pattern (e.g. ``*.pdf``) at the provided path,
         if one exists. Otherwise, raises an AirflowException to be handled upstream for deferring
         """
         files_list = await self.read_directory(path)

--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os.path
 from base64 import decodebytes
 from datetime import datetime
 from fnmatch import fnmatch
@@ -9,9 +10,11 @@ import asyncssh
 import paramiko
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
+from airflow.models.connection import Connection
 from asgiref.sync import sync_to_async
 from paramiko.config import SSH_PORT
-from tenacity import Retrying, stop_after_attempt, wait_fixed, wait_random
+from paramiko.ssh_exception import BadHostKeyException, SSHException
+from tenacity import RetryCallState, Retrying, stop_after_attempt, wait_fixed, wait_random
 
 
 class SFTPHookAsync(BaseHook):
@@ -24,8 +27,7 @@ class SFTPHookAsync(BaseHook):
     :param username: username used when authenticating to the SFTP server
     :param password: password used when authenticating to the SFTP server
                      Can be left blank if using a key file
-    :param known_hosts: path to the known_hosts file on the local file system
-                     If known_hosts is set to the literal "none", then no host verification is performed
+    :param known_hosts: path to the known_hosts file on the local file system. Defaults to ~/.ssh/known_hosts.
     :param key_file: path to the client key file used for authentication to SFTP server
     :param passphrase: passphrase used with the key_file for authentication to SFTP server
     """
@@ -34,7 +36,7 @@ class SFTPHookAsync(BaseHook):
     default_conn_name = "sftp_default"
     conn_type = "sftp"
     hook_name = "SFTP"
-    default_known_hosts = "none"
+    default_known_hosts = "~/.ssh/known_hosts"
 
     _host_key_mappings = {
         "rsa": paramiko.RSAKey,
@@ -60,11 +62,11 @@ class SFTPHookAsync(BaseHook):
         self.port = port
         self.username = username
         self.password = password
-        self.known_hosts = known_hosts
+        self.known_hosts = os.path.expanduser(known_hosts)
         self.key_file = key_file
         self.passphrase = passphrase
         self.private_key = private_key
-        self.no_host_key_check = True
+        self.no_host_key_check = False
         self.host_key = None
 
     async def _get_conn(self) -> asyncssh.SSHClientConnection:
@@ -78,113 +80,126 @@ class SFTPHookAsync(BaseHook):
         - known_hosts
         - passphrase
         """
-        if self.sftp_conn_id is not None:
-            conn = await sync_to_async(self.get_connection)(self.sftp_conn_id)
+        conn = await sync_to_async(self.get_connection)(self.sftp_conn_id)
+        if conn.extra is not None:
+            extra_options = conn.extra_dejson
+            if "key_file" in extra_options and self.key_file == "":
+                self.key_file = extra_options.get("key_file")
+            if "known_hosts" in extra_options:
+                self.known_hosts = extra_options.get("known_hosts")
+            if ("passphrase" or "private_key_passphrase") in extra_options:
+                self.passphrase = extra_options.get("passphrase")
+            if "private_key" in extra_options:
+                self.private_key = extra_options.get("private_key")
 
-            if conn.extra is not None:
-                extra_options = conn.extra_dejson
+            host_key = extra_options.get("host_key")
+            no_host_key_check = extra_options.get("no_host_key_check")
 
-                if "key_file" in extra_options and self.key_file == "":
-                    self.key_file = extra_options.get("key_file")
+            if no_host_key_check is not None:
+                no_host_key_check = str(no_host_key_check).lower() == "true"
+                if host_key is not None and no_host_key_check:
+                    raise ValueError("Must check host key when provided.")
+                self.no_host_key_check = no_host_key_check
 
-                if "known_hosts" in extra_options:
-                    self.known_hosts = extra_options.get("known_hosts")
+            if host_key is not None:
+                if host_key.startswith("ssh-"):
+                    key_type, host_key = host_key.split(None)[:2]
+                    key_constructor = self._host_key_mappings[key_type[4:]]
+                elif host_key.startswith("ecdsa-"):
+                    _, host_key = host_key.split(None)[:2]
+                    key_constructor = paramiko.ECDSAKey
+                else:
+                    key_constructor = paramiko.RSAKey
+                decoded_host_key = decodebytes(host_key.encode("utf-8"))
+                self.host_key = key_constructor(data=decoded_host_key)
 
-                if ("passphrase" or "private_key_passphrase") in extra_options:
-                    self.passphrase = extra_options.get("passphrase")
+        if self.no_host_key_check:
+            self.log.warning("No Host Key Verification. This won't protect against Man-In-The-Middle attacks")
+            self.known_hosts = "none"
+        else:
+            self._validate_host_key_using_paramiko(conn)
 
-                if "private_key" in extra_options:
-                    self.private_key = extra_options.get("private_key")
+        conn_config = {
+            "host": conn.host,
+            "port": conn.port,
+            "username": conn.login,
+            "password": conn.password,
+        }
+        if self.key_file:
+            conn_config.update(client_keys=self.key_file)
+        if self.known_hosts:
+            if self.known_hosts.lower() == "none":
+                conn_config.update(known_hosts=None)
+            else:
+                conn_config.update(known_hosts=self.known_hosts)
+        if self.private_key:
+            _private_key = asyncssh.import_private_key(self.private_key, self.passphrase)
+            conn_config.update(client_keys=[_private_key])
+        if self.passphrase:
+            conn_config.update(passphrase=self.passphrase)
+        ssh_client = await asyncssh.connect(**conn_config)
+        return ssh_client
 
-                host_key = extra_options.get("host_key")
-                no_host_key_check = extra_options.get("no_host_key_check")
-
-                if no_host_key_check is not None:
-                    no_host_key_check = str(no_host_key_check).lower() == "true"
-                    if host_key is not None and no_host_key_check:
-                        raise ValueError("Must check host key when provided")
-
-                    self.no_host_key_check = no_host_key_check
-
-                if host_key is not None:
-                    if host_key.startswith("ssh-"):
-                        key_type, host_key = host_key.split(None)[:2]
-                        key_constructor = self._host_key_mappings[key_type[4:]]
-                    else:
-                        key_constructor = paramiko.RSAKey
-                    decoded_host_key = decodebytes(host_key.encode("utf-8"))
-                    self.host_key = key_constructor(data=decoded_host_key)
-                    self.no_host_key_check = False
-
-            if self.no_host_key_check:
-                self.log.warning(
-                    "No Host Key Verification. This won't protect against Man-In-The-Middle attacks"
-                )
-            elif self.host_key is not None:
-                # The asyncssh client we use does not support host key verification other than the ones given in
-                # known_hosts file(Ref: https://github.com/ronf/asyncssh/issues/176). Hence, we use a paramiko client to
-                # validate the provided host key before proceeding for further operation.
-                with paramiko.SSHClient() as paramiko_client:
-                    client_host_keys = paramiko_client.get_host_keys()
-                    if conn.port == SSH_PORT:
-                        client_host_keys.add(conn.host, self.host_key.get_name(), self.host_key)
-                    else:
-                        client_host_keys.add(
-                            f"[{conn.host}]:{conn.port}", self.host_key.get_name(), self.host_key
-                        )
-                    connect_kwargs: dict[str, Any] = {
-                        "hostname": conn.host,
-                        "username": conn.login,
-                        "password": conn.password,
-                        "port": conn.port,
-                    }
-
-                    if self.private_key:
-                        connect_kwargs.update(pkey=self.private_key)
-
-                    if self.key_file:
-                        connect_kwargs.update(key_filename=self.key_file)
-
-                    def log_before_sleep(retry_state):
-                        return self.log.info(
-                            "Failed to connect. Sleeping before retry attempt %d", retry_state.attempt_number
-                        )
-
-                    for attempt in Retrying(
-                        reraise=True,
-                        wait=wait_fixed(3) + wait_random(0, 2),
-                        stop=stop_after_attempt(3),
-                        before_sleep=log_before_sleep,
-                    ):
-                        with attempt:
-                            paramiko_client.connect(**connect_kwargs)
-
-            conn_config = {
-                "host": conn.host,
-                "port": conn.port,
+    def _validate_host_key_using_paramiko(self, conn: Connection) -> None:
+        """
+        The asyncssh client we use does not support host key verification other than the ones given in
+        known_hosts file(Ref: https://github.com/ronf/asyncssh/issues/176). Hence, we use a paramiko client to
+        validate host keys before proceeding for further operation.
+        """
+        with paramiko.SSHClient() as paramiko_client:
+            connect_kwargs: dict[str, Any] = {
+                "hostname": conn.host,
                 "username": conn.login,
                 "password": conn.password,
+                "port": conn.port,
             }
-
-            if self.key_file:
-                conn_config.update(client_keys=self.key_file)
-
-            if self.known_hosts:
-                if self.known_hosts.lower() == "none":
-                    conn_config.update(known_hosts=None)
-                else:
-                    conn_config.update(known_hosts=self.known_hosts)
-
             if self.private_key:
-                _private_key = asyncssh.import_private_key(self.private_key, self.passphrase)
-                conn_config.update(client_keys=[_private_key])
+                connect_kwargs.update(pkey=self.private_key)
+            if self.key_file:
+                connect_kwargs.update(key_filename=self.key_file)
 
-            if self.passphrase:
-                conn_config.update(passphrase=self.passphrase)
+            paramiko_client.load_host_keys(filename=self.known_hosts)
+            client_host_keys = paramiko_client.get_host_keys()
+            if self.host_key:
+                if conn.port == SSH_PORT:
+                    client_host_keys.add(conn.host, self.host_key.get_name(), self.host_key)
+                else:
+                    client_host_keys.add(
+                        f"[{conn.host}]:{conn.port}", self.host_key.get_name(), self.host_key
+                    )
+                # We need to save the provided host_key back to known_hosts file as the AsyncSSH client we use can read
+                # keys from that file only. If the key is already present, it will be overwritten.
+                client_host_keys.save(self.known_hosts)
 
-            ssh_client = await asyncssh.connect(**conn_config)
+            def _log_before_sleep(retry_state: RetryCallState) -> None:
+                return self.log.info(
+                    "Failed to connect. Sleeping before retry attempt %d", retry_state.attempt_number
+                )
 
-            return ssh_client
+            for attempt in Retrying(
+                reraise=True,
+                wait=wait_fixed(3) + wait_random(0, 2),
+                stop=stop_after_attempt(3),
+                before_sleep=_log_before_sleep,
+            ):
+                with attempt:
+                    try:
+                        paramiko_client.connect(**connect_kwargs)
+                    except (BadHostKeyException, SSHException):
+                        # Reraise with less information as the BadHostKeyException includes the expected host key when
+                        # validating host keys.
+                        error_message = ""
+                        if self.host_key:
+                            error_message = (
+                                f"\nGiven host key '{self.host_key.get_name()} {self.host_key.get_base64()}' for "
+                                f"server '{conn.host}' does not match!\n"
+                            )
+                        error_message += (
+                            f"None of the host keys in the 'known_hosts' file '{self.known_hosts}' match!"
+                        )
+                        raise SSHException(error_message)
+
+        self.log.info("Validated host key successfully. Proceeding with further operations...")
 
     async def list_directory(self, path: str = "") -> list[str] | None:
         """Returns a list of files on the SFTP server at the provided path"""

--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -139,7 +139,7 @@ class SFTPHookAsync(BaseHook):
         except asyncssh.SFTPNoSuchFile:
             return None
 
-    async def get_files_by_pattern(
+    async def get_files_and_attrs_by_pattern(
         self, path: str = "", fnmatch_pattern: str = ""
     ) -> Sequence[asyncssh.sftp.SFTPName]:
         """
@@ -150,6 +150,19 @@ class SFTPHookAsync(BaseHook):
         if files_list is None:
             raise AirflowException(f"No files at path {path} found...")
         matched_files = [file for file in files_list if fnmatch(str(file.filename), fnmatch_pattern)]
+        return matched_files
+
+    async def get_files_by_pattern(
+        self, path: str = "", fnmatch_pattern: str = ""
+    ) -> Sequence[asyncssh.sftp.SFTPName]:
+        """
+        Returns the name of a file matching the file pattern at the provided path, if one exists
+        Otherwise, raises an AirflowException to be handled upstream for deferring
+        """
+        files_list = await self.list_directory(path)
+        if files_list is None:
+            raise AirflowException(f"No files at path {path} found...")
+        matched_files = [file for file in files_list if fnmatch(file, fnmatch_pattern)]
         return matched_files
 
     async def get_mod_time(self, path: str) -> str:

--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -1,20 +1,15 @@
 from __future__ import annotations
 
 import os.path
-from base64 import decodebytes
 from datetime import datetime
 from fnmatch import fnmatch
-from typing import Any, Sequence
+from typing import Sequence
 
 import asyncssh
-import paramiko
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models.connection import Connection
 from asgiref.sync import sync_to_async
-from paramiko.config import SSH_PORT
-from paramiko.ssh_exception import BadHostKeyException, SSHException
-from tenacity import RetryCallState, Retrying, stop_after_attempt, wait_fixed, wait_random
 
 
 class SFTPHookAsync(BaseHook):
@@ -38,13 +33,6 @@ class SFTPHookAsync(BaseHook):
     hook_name = "SFTP"
     default_known_hosts = "~/.ssh/known_hosts"
 
-    _host_key_mappings = {
-        "rsa": paramiko.RSAKey,
-        "dss": paramiko.DSSKey,
-        "ecdsa": paramiko.ECDSAKey,
-        "ed25519": paramiko.Ed25519Key,
-    }
-
     def __init__(  # nosec: B107
         self,
         sftp_conn_id: str = default_conn_name,
@@ -66,8 +54,6 @@ class SFTPHookAsync(BaseHook):
         self.key_file = key_file
         self.passphrase = passphrase
         self.private_key = private_key
-        self.no_host_key_check = False
-        self.host_key = None
 
     def _parse_extras(self, conn: Connection) -> None:
         """Parse extra fields from the connection into instance fields"""
@@ -88,22 +74,30 @@ class SFTPHookAsync(BaseHook):
             no_host_key_check = str(no_host_key_check).lower() == "true"
             if host_key is not None and no_host_key_check:
                 raise ValueError("Must check host key when provided.")
-            self.no_host_key_check = no_host_key_check
+            if no_host_key_check:
+                self.log.warning(
+                    "No Host Key Verification. This won't protect against Man-In-The-Middle attacks"
+                )
+                self.known_hosts = "none"
 
         if host_key is not None:
-            if host_key.startswith("ssh-"):
-                key_type, host_key = host_key.split(None)[:2]
-                key_constructor = self._host_key_mappings[key_type[4:]]
-            elif host_key.startswith("ecdsa-"):
-                _, host_key = host_key.split(None)[:2]
-                key_constructor = paramiko.ECDSAKey
-            else:
-                key_constructor = paramiko.RSAKey
-            decoded_host_key = decodebytes(host_key.encode("utf-8"))
-            self.host_key = key_constructor(data=decoded_host_key)
+            self.known_hosts = f"{conn.host} {host_key}".encode()
 
-    async def _get_asyncssh_client_connection(self, conn: Connection) -> asyncssh.SSHClientConnection:
-        """Return an asyncssh client connection object for the given connection"""
+    async def _get_conn(self) -> asyncssh.SSHClientConnection:
+        """
+        Asynchronously connect to the SFTP server as an SSH client
+
+        The following parameters are provided either in the extra json object in
+        the SFTP connection definition
+
+        - key_file
+        - known_hosts
+        - passphrase
+        """
+        conn = await sync_to_async(self.get_connection)(self.sftp_conn_id)
+        if conn.extra is not None:
+            self._parse_extras(conn)
+
         conn_config = {
             "host": conn.host,
             "port": conn.port,
@@ -124,91 +118,6 @@ class SFTPHookAsync(BaseHook):
             conn_config.update(passphrase=self.passphrase)
         ssh_client_conn = await asyncssh.connect(**conn_config)
         return ssh_client_conn
-
-    async def _get_conn(self) -> asyncssh.SSHClientConnection:
-        """
-        Asynchronously connect to the SFTP server as an SSH client
-
-        The following parameters are provided either in the extra json object in
-        the SFTP connection definition
-
-        - key_file
-        - known_hosts
-        - passphrase
-        """
-        conn = await sync_to_async(self.get_connection)(self.sftp_conn_id)
-        if conn.extra is not None:
-            self._parse_extras(conn)
-
-        if self.no_host_key_check:
-            self.log.warning("No Host Key Verification. This won't protect against Man-In-The-Middle attacks")
-            self.known_hosts = "none"
-        else:
-            self._validate_host_key_using_paramiko(conn)
-
-        ssh_client_conn = await self._get_asyncssh_client_connection(conn)
-        return ssh_client_conn
-
-    def _validate_host_key_using_paramiko(self, conn: Connection) -> None:
-        """
-        The asyncssh client we use does not support host key verification other than the ones given in
-        known_hosts file(Ref: https://github.com/ronf/asyncssh/issues/176). Hence, we use a paramiko client to
-        validate host keys before proceeding for further operation.
-        """
-        with paramiko.SSHClient() as paramiko_client:
-            connect_kwargs: dict[str, Any] = {
-                "hostname": conn.host,
-                "username": conn.login,
-                "password": conn.password,
-                "port": conn.port,
-            }
-            if self.private_key:
-                connect_kwargs.update(pkey=self.private_key)
-            if self.key_file:
-                connect_kwargs.update(key_filename=self.key_file)
-
-            paramiko_client.load_host_keys(filename=self.known_hosts)
-            client_host_keys = paramiko_client.get_host_keys()
-            if self.host_key:
-                if conn.port == SSH_PORT:
-                    client_host_keys.add(conn.host, self.host_key.get_name(), self.host_key)
-                else:
-                    client_host_keys.add(
-                        f"[{conn.host}]:{conn.port}", self.host_key.get_name(), self.host_key
-                    )
-                # We need to save the provided host_key back to known_hosts file as the AsyncSSH client we use can read
-                # keys from that file only. If the key is already present, it will be overwritten.
-                client_host_keys.save(self.known_hosts)
-
-            def _log_before_sleep(retry_state: RetryCallState) -> None:
-                return self.log.info(
-                    "Failed to connect. Sleeping before retry attempt %d", retry_state.attempt_number
-                )
-
-            for attempt in Retrying(
-                reraise=True,
-                wait=wait_fixed(3) + wait_random(0, 2),
-                stop=stop_after_attempt(3),
-                before_sleep=_log_before_sleep,
-            ):
-                with attempt:
-                    try:
-                        paramiko_client.connect(**connect_kwargs)
-                    except (BadHostKeyException, SSHException):
-                        # Reraise with less information as the BadHostKeyException includes the expected host key when
-                        # validating host keys.
-                        error_message = ""
-                        if self.host_key:
-                            error_message = (
-                                f"\nGiven host key '{self.host_key.get_name()} {self.host_key.get_base64()}' for "
-                                f"server '{conn.host}' does not match!\n"
-                            )
-                        error_message += (
-                            f"None of the host keys in the 'known_hosts' file '{self.known_hosts}' match!"
-                        )
-                        raise SSHException(error_message)
-
-        self.log.info("Validated host key successfully. Proceeding with further operations...")
 
     async def list_directory(self, path: str = "") -> list[str] | None:
         """Returns a list of files on the SFTP server at the provided path"""

--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -4,7 +4,6 @@ import os.path
 from base64 import decodebytes
 from datetime import datetime
 from fnmatch import fnmatch
-from pathlib import Path
 from typing import Any, Sequence
 
 import asyncssh
@@ -126,16 +125,6 @@ class SFTPHookAsync(BaseHook):
         ssh_client_conn = await asyncssh.connect(**conn_config)
         return ssh_client_conn
 
-    def _ensure_known_hosts_file_exists(self):
-        """
-        Ensure that the known_hosts file exists and create it if it doesn't exist along with creating its parent
-        directories.
-        """
-        known_hosts_file_path = Path(self.known_hosts)
-        if not known_hosts_file_path.exists():
-            known_hosts_file_path.parent.mkdir(parents=True, exist_ok=True)
-            known_hosts_file_path.touch()
-
     async def _get_conn(self) -> asyncssh.SSHClientConnection:
         """
         Asynchronously connect to the SFTP server as an SSH client
@@ -155,7 +144,6 @@ class SFTPHookAsync(BaseHook):
             self.log.warning("No Host Key Verification. This won't protect against Man-In-The-Middle attacks")
             self.known_hosts = "none"
         else:
-            self._ensure_known_hosts_file_exists()
             self._validate_host_key_using_paramiko(conn)
 
         ssh_client_conn = await self._get_asyncssh_client_connection(conn)

--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -221,7 +221,9 @@ class SFTPHookAsync(BaseHook):
         except asyncssh.SFTPNoSuchFile:
             return None
 
-    async def get_files_by_pattern(self, path: str = "", fnmatch_pattern: str = "") -> list[str]:
+    async def get_files_by_pattern(
+        self, path: str = "", fnmatch_pattern: str = ""
+    ) -> Sequence[asyncssh.sftp.SFTPName]:
         """
         Returns the files along with their attributes matching the file pattern at the provided path, if one exists
         Otherwise, raises an AirflowException to be handled upstream for deferring
@@ -229,7 +231,7 @@ class SFTPHookAsync(BaseHook):
         files_list = await self.read_directory(path)
         if files_list is None:
             raise AirflowException(f"No files at path {path} found...")
-        matched_files = [file for file in files_list if fnmatch(file.filename, fnmatch_pattern)]
+        matched_files = [file for file in files_list if fnmatch(str(file.filename), fnmatch_pattern)]
         return matched_files
 
     async def get_mod_time(self, path: str) -> str:

--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -152,9 +152,7 @@ class SFTPHookAsync(BaseHook):
         matched_files = [file for file in files_list if fnmatch(str(file.filename), fnmatch_pattern)]
         return matched_files
 
-    async def get_files_by_pattern(
-        self, path: str = "", fnmatch_pattern: str = ""
-    ) -> Sequence[asyncssh.sftp.SFTPName]:
+    async def get_files_by_pattern(self, path: str = "", fnmatch_pattern: str = "") -> list[str]:
         """
         Returns the name of a file matching the file pattern at the provided path, if one exists
         Otherwise, raises an AirflowException to be handled upstream for deferring

--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -50,7 +50,7 @@ class SFTPHookAsync(BaseHook):
         self.port = port
         self.username = username
         self.password = password
-        self.known_hosts = os.path.expanduser(known_hosts)
+        self.known_hosts: bytes | str = os.path.expanduser(known_hosts)
         self.key_file = key_file
         self.passphrase = passphrase
         self.private_key = private_key

--- a/astronomer/providers/sftp/hooks/sftp.py
+++ b/astronomer/providers/sftp/hooks/sftp.py
@@ -22,7 +22,7 @@ class SFTPHookAsync(BaseHook):
     :param username: username used when authenticating to the SFTP server
     :param password: password used when authenticating to the SFTP server
         Can be left blank if using a key file
-    :param known_hosts: path to the known_hosts file on the local file system. Defaults to ~/.ssh/known_hosts.
+    :param known_hosts: path to the known_hosts file on the local file system. Defaults to ``~/.ssh/known_hosts``.
     :param key_file: path to the client key file used for authentication to SFTP server
     :param passphrase: passphrase used with the key_file for authentication to SFTP server
     """
@@ -60,7 +60,7 @@ class SFTPHookAsync(BaseHook):
         extra_options = conn.extra_dejson
         if "key_file" in extra_options and self.key_file == "":
             self.key_file = extra_options["key_file"]
-        if "known_hosts" in extra_options:
+        if "known_hosts" in extra_options and self.known_hosts != self.default_known_hosts:
             self.known_hosts = extra_options["known_hosts"]
         if ("passphrase" or "private_key_passphrase") in extra_options:
             self.passphrase = extra_options["passphrase"]
@@ -73,7 +73,7 @@ class SFTPHookAsync(BaseHook):
         if no_host_key_check is not None:
             no_host_key_check = str(no_host_key_check).lower() == "true"
             if host_key is not None and no_host_key_check:
-                raise ValueError("Must check host key when provided.")
+                raise ValueError("Host key check was skipped, but `host_key` value was given")
             if no_host_key_check:
                 self.log.warning(
                     "No Host Key Verification. This won't protect against Man-In-The-Middle attacks"
@@ -148,7 +148,7 @@ class SFTPHookAsync(BaseHook):
         """
         files_list = await self.read_directory(path)
         if files_list is None:
-            raise AirflowException(f"No files at path {path} found...")
+            raise FileNotFoundError(f"No files at path {path!r} found...")
         matched_files = [file for file in files_list if fnmatch(str(file.filename), fnmatch_pattern)]
         return matched_files
 

--- a/astronomer/providers/sftp/sensors/sftp.py
+++ b/astronomer/providers/sftp/sensors/sftp.py
@@ -42,6 +42,23 @@ class SFTPSensorAsync(SFTPSensor):
         Logic that the sensor uses to correctly identify which trigger to
         execute, and defer execution as expected.
         """
+        # Unlike other async sensors, we do not follow the pattern of calling the synchronous self.poke() method before
+        # deferring here. This is due to the current limitations we have in the synchronous SFTPHook methods.
+        # The limitations are discovered while being worked upon the ticket
+        # https://github.com/astronomer/astronomer-providers/issues/1021. They are as follows:
+        # 1. For host key types of ecdsa, the hook expects the host key to prefixed with 'ssh-' as per the mapping of
+        #    key types defined in it to get the appropriate key constructor for the ecdsa type keys, whereas
+        #    conventionally such keys are not prefixed with 'ssh-'.
+        # 2. The sync sensor does not support the newer_than field to be passed as a Jinja template value which is of
+        #    string type.
+        # 3. For file_pattern sensing, the hook implements list_directory() method which returns a list of filenames
+        #    only without the attributes like modified time which is required for the file_pattern sensing when
+        #    newer_than is supplied. This leads to intermittent failures potentially due to throttling by the SFTP
+        #    server as the hook makes multiple calls to the server to get the attributes for each of the files in the
+        #    directory.This limitation is resolved here by instead calling the read_directory() method which returns a
+        #    list of files along with their attributes in a single call.
+        # We can add back the call to self.poke() before deferring once the above limitations are resolved in the
+        # sync sensor.
         self.defer(
             timeout=timedelta(seconds=self.timeout),
             trigger=SFTPTrigger(

--- a/astronomer/providers/sftp/sensors/sftp.py
+++ b/astronomer/providers/sftp/sensors/sftp.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Optional
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.providers.sftp.sensors.sftp import SFTPSensor
-from dateutil.parser import parse as parse_date
 
 from astronomer.providers.sftp.hooks.sftp import SFTPHookAsync
 from astronomer.providers.sftp.triggers.sftp import SFTPTrigger
@@ -35,9 +34,6 @@ class SFTPSensorAsync(SFTPSensor):
         self.file_pattern = file_pattern
         if timeout is None:
             timeout = conf.getfloat("sensors", "default_timeout")
-        newer_than = kwargs.get("newer_than")
-        if isinstance(newer_than, str):
-            kwargs["newer_than"] = parse_date(newer_than)
         super().__init__(path=path, file_pattern=file_pattern, timeout=timeout, **kwargs)
         self.hook = SFTPHookAsync(sftp_conn_id=self.sftp_conn_id)  # type: ignore[assignment]
 

--- a/astronomer/providers/sftp/triggers/sftp.py
+++ b/astronomer/providers/sftp/triggers/sftp.py
@@ -71,7 +71,7 @@ class SFTPTrigger(BaseTrigger):
         while True:
             try:
                 if self.file_pattern:
-                    files_returned_by_hook = await hook.get_files_by_pattern(
+                    files_returned_by_hook = await hook.get_files_and_attrs_by_pattern(
                         path=self.path, fnmatch_pattern=self.file_pattern
                     )
                     files_sensed = []

--- a/astronomer/providers/sftp/triggers/sftp.py
+++ b/astronomer/providers/sftp/triggers/sftp.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import asyncio
 from datetime import datetime
-from typing import Any, AsyncIterator, Dict, Optional, Tuple
+from typing import Any, AsyncIterator
 
 from airflow.exceptions import AirflowException
 from airflow.triggers.base import BaseTrigger, TriggerEvent
@@ -29,7 +31,7 @@ class SFTPTrigger(BaseTrigger):
         path: str,
         file_pattern: str = "",
         sftp_conn_id: str = "sftp_default",
-        newer_than: Optional[datetime] = None,
+        newer_than: datetime | str | None = None,
         poke_interval: float = 5,
     ) -> None:
         super().__init__()
@@ -39,7 +41,7 @@ class SFTPTrigger(BaseTrigger):
         self.newer_than = newer_than
         self.poke_interval = poke_interval
 
-    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+    def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serializes SFTPTrigger arguments and classpath"""
         return (
             "astronomer.providers.sftp.triggers.sftp.SFTPTrigger",
@@ -52,7 +54,7 @@ class SFTPTrigger(BaseTrigger):
             },
         )
 
-    async def run(self) -> AsyncIterator["TriggerEvent"]:
+    async def run(self) -> AsyncIterator[TriggerEvent]:
         """
         Makes a series of asynchronous calls to sftp servers via async sftp hook. It yields a Trigger
 

--- a/astronomer/providers/sftp/triggers/sftp.py
+++ b/astronomer/providers/sftp/triggers/sftp.py
@@ -6,6 +6,7 @@ from typing import Any, AsyncIterator, Dict, Optional, Tuple
 from airflow.exceptions import AirflowException
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils.timezone import convert_to_utc
+from dateutil.parser import parse as parse_date
 
 from astronomer.providers.sftp.hooks.sftp import SFTPHookAsync
 
@@ -63,6 +64,8 @@ class SFTPTrigger(BaseTrigger):
         """
         hook = self._get_async_hook()
         exc = None
+        if isinstance(self.newer_than, str):
+            self.newer_than = parse_date(self.newer_than)
         _newer_than = convert_to_utc(self.newer_than) if self.newer_than else None
         while True:
             try:

--- a/astronomer/providers/sftp/triggers/sftp.py
+++ b/astronomer/providers/sftp/triggers/sftp.py
@@ -75,7 +75,11 @@ class SFTPTrigger(BaseTrigger):
                     files_sensed = []
                     for file in files_returned_by_hook:
                         if _newer_than:
-                            mod_time = datetime.fromtimestamp(file.attrs.mtime).strftime("%Y%m%d%H%M%S")
+                            if file.attrs.mtime is None:
+                                continue
+                            mod_time = datetime.fromtimestamp(float(file.attrs.mtime)).strftime(
+                                "%Y%m%d%H%M%S"
+                            )
                             mod_time_utc = convert_to_utc(datetime.strptime(mod_time, "%Y%m%d%H%M%S"))
                             if _newer_than <= mod_time_utc:
                                 files_sensed.append(file.filename)

--- a/tests/sftp/hooks/test_sftp.py
+++ b/tests/sftp/hooks/test_sftp.py
@@ -350,6 +350,19 @@ class TestSFTPHookAsync:
 
     @patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")
     @pytest.mark.asyncio
+    async def test_read_directory_path_does_not_exist(self, mock_hook_get_conn):
+        """
+        Assert that AirflowException is raised when path does not exist on SFTP server
+        """
+        mock_hook_get_conn.return_value = MockSSHClient()
+        hook = SFTPHookAsync()
+
+        expected_files = None
+        files = await hook.read_directory(path="/path/does_not/exist/")
+        assert files == expected_files
+
+    @patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")
+    @pytest.mark.asyncio
     async def test_list_directory_path_has_files(self, mock_hook_get_conn):
         """
         Assert that file list is returned when path exists on SFTP server
@@ -378,6 +391,18 @@ class TestSFTPHookAsync:
     @pytest.mark.asyncio
     @patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")
     async def test_get_file_by_pattern_with_no_match(self, mock_hook_get_conn):
+        """
+        Assert that AirflowException is raised when no files match file pattern on SFTP server
+        """
+        mock_hook_get_conn.return_value = MockSSHClient()
+        hook = SFTPHookAsync()
+        file = await hook.get_files_by_pattern(path="/path/exists/", fnmatch_pattern="file_does_not_exist")
+
+        assert file == []
+
+    @pytest.mark.asyncio
+    @patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync._get_conn")
+    async def test_get_file_by_pattern_path_not_exists(self, mock_hook_get_conn):
         """
         Assert that AirflowException is raised when no files match file pattern on SFTP server
         """

--- a/tests/sftp/hooks/test_sftp.py
+++ b/tests/sftp/hooks/test_sftp.py
@@ -311,7 +311,7 @@ class TestSFTPHookAsync:
         mock_hook_get_conn.return_value = MockSSHClient()
         hook = SFTPHookAsync()
 
-        files = await hook.get_files_by_pattern(path="/path/exists/", fnmatch_pattern="file")
+        files = await hook.get_files_and_attrs_by_pattern(path="/path/exists/", fnmatch_pattern="file")
 
         assert len(files) == 1
         assert files[0].filename == "file"

--- a/tests/sftp/hooks/test_sftp.py
+++ b/tests/sftp/hooks/test_sftp.py
@@ -193,7 +193,7 @@ class TestSFTPHookAsync:
         with pytest.raises(ValueError) as exc:
             await hook._get_conn()
 
-        assert str(exc.value) == "Must check host key when provided."
+        assert str(exc.value) == "Host key check was skipped, but `host_key` value was given"
 
     @patch("paramiko.SSHClient.connect")
     @patch("asyncssh.import_private_key")

--- a/tests/sftp/sensors/test_sftp.py
+++ b/tests/sftp/sensors/test_sftp.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -17,11 +18,15 @@ class TestSFTPSensorAsync:
         when the SFTPSensorAsync is executed.
         """
 
-        task = SFTPSensorAsync(task_id="run_now", path="/test/path/", file_pattern="test_file")
+        task = SFTPSensorAsync(
+            task_id="run_now", path="/test/path/", file_pattern="test_file", newer_than="2020-01-01"
+        )
 
         with pytest.raises(TaskDeferred) as exc:
             task.execute(context)
             assert isinstance(exc.value.trigger, SFTPTrigger), "Trigger is not an SFTPTrigger"
+        assert isinstance(task.newer_than, datetime)
+        assert task.newer_than == datetime(2020, 1, 1)
 
     def test_sftp_execute_complete_success(self, context):
         """

--- a/tests/sftp/sensors/test_sftp.py
+++ b/tests/sftp/sensors/test_sftp.py
@@ -10,14 +10,6 @@ MODULE = "astronomer.providers.sftp.sensors.sftp"
 
 
 class TestSFTPSensorAsync:
-    @mock.patch(f"{MODULE}.SFTPSensorAsync.defer")
-    @mock.patch(f"{MODULE}.SFTPSensorAsync.poke", return_value=True)
-    def test_sftp_sensor_async_finish_before_deferred(self, mock_poke, mock_defer, context):
-        task = SFTPSensorAsync(task_id="run_now", path="/test/path/", file_pattern="test_file")
-        task.execute(context)
-
-        assert not mock_defer.called
-
     @mock.patch(f"{MODULE}.SFTPSensorAsync.poke", return_value=False)
     def test_sftp_run_now_sensor_async(self, context):
         """

--- a/tests/sftp/sensors/test_sftp.py
+++ b/tests/sftp/sensors/test_sftp.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -19,14 +18,14 @@ class TestSFTPSensorAsync:
         """
 
         task = SFTPSensorAsync(
-            task_id="run_now", path="/test/path/", file_pattern="test_file", newer_than="2020-01-01"
+            task_id="run_now",
+            path="/test/path/",
+            file_pattern="test_file",
         )
 
         with pytest.raises(TaskDeferred) as exc:
             task.execute(context)
             assert isinstance(exc.value.trigger, SFTPTrigger), "Trigger is not an SFTPTrigger"
-        assert isinstance(task.newer_than, datetime)
-        assert task.newer_than == datetime(2020, 1, 1)
 
     def test_sftp_execute_complete_success(self, context):
         """

--- a/tests/sftp/triggers/test_sftp.py
+++ b/tests/sftp/triggers/test_sftp.py
@@ -32,7 +32,7 @@ class TestSFTPTrigger:
         "newer_than",
         ["19700101053001", None],
     )
-    @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_files_by_pattern")
+    @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_files_and_attrs_by_pattern")
     async def test_sftp_trigger_run_trigger_success_state(self, mock_get_files_by_pattern, newer_than):
         """
         Assert that a TriggerEvent with a success status is yielded if a file
@@ -100,7 +100,7 @@ class TestSFTPTrigger:
         assert TriggerEvent(expected_event) == actual_event
 
     @pytest.mark.asyncio
-    @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_files_by_pattern")
+    @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_files_and_attrs_by_pattern")
     async def test_sftp_trigger_run_trigger_defer_state(
         self,
         mock_get_files_by_pattern,
@@ -148,7 +148,7 @@ class TestSFTPTrigger:
         asyncio.get_event_loop().stop()
 
     @pytest.mark.asyncio
-    @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_files_by_pattern")
+    @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_files_and_attrs_by_pattern")
     async def test_sftp_trigger_run_trigger_failure_state(self, mock_get_files_by_pattern):
         """
         Mock the hook to raise other than an AirflowException and assert that a TriggerEvent with a failure status
@@ -166,7 +166,7 @@ class TestSFTPTrigger:
             assert TriggerEvent(expected_event) == actual_event
 
     @pytest.mark.asyncio
-    @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_files_by_pattern")
+    @mock.patch("astronomer.providers.sftp.hooks.sftp.SFTPHookAsync.get_files_and_attrs_by_pattern")
     async def test_sftp_trigger_run_airflow_exception(self, mock_get_files_by_pattern):
         """
         Assert that a the task does not complete if the hook raises an AirflowException,

--- a/tests/sftp/triggers/test_sftp.py
+++ b/tests/sftp/triggers/test_sftp.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 from airflow.exceptions import AirflowException
 from airflow.triggers.base import TriggerEvent
+from asyncssh.sftp import SFTPName
 
 from astronomer.providers.sftp.triggers.sftp import SFTPTrigger
 
@@ -34,12 +35,12 @@ class TestSFTPTrigger:
         Assert that a TriggerEvent with a success status is yielded if a file
         matching the pattern is returned by the hook
         """
-        mock_get_files_by_pattern.return_value = ["some_file"]
+        mock_get_files_by_pattern.return_value = [SFTPName("some_file")]
         mock_mod_time.return_value = "19700101053001"
 
         trigger = SFTPTrigger(path="test/path/", sftp_conn_id="sftp_default", file_pattern="my_test_file")
 
-        expected_event = {"status": "success", "message": "Sensed file: test/path/some_file"}
+        expected_event = {"status": "success", "message": "Sensed 1 files: ['some_file']"}
 
         generator = trigger.run()
         actual_event = await generator.asend(None)
@@ -97,7 +98,7 @@ class TestSFTPTrigger:
         Assert that a the task does not complete,
         indicating that the task needs to be deferred
         """
-        mock_get_files_by_pattern.return_value = ["my_test_file.txt"]
+        mock_get_files_by_pattern.return_value = [SFTPName("my_test_file.txt")]
         mock_mod_time.return_value = "19700101053001"
         yesterday = datetime.datetime.now() - datetime.timedelta(days=1)
         trigger = SFTPTrigger(


### PR DESCRIPTION
The PR address the following feature requests mentioned in the issue as per user feedback:
- If the ssh host key and the SSH command line tool outputs are in the format of `ecdsa-sha2-nistp256`, then ideally the SFTP hook should recognise this format without the need for it to be edited (by prepending `ssh-`) just to get it working with Astronomer’s SFTP library
- If no_host_key_check: False on the connection, but doesn’t include a host key, it lets the connection through just fine and effectively doesn’t validate the server. This seems wrong. In fact, the whole need to enable host key checking by default seems wrong. Host key check should be enabled by default (so by default users are then forced to use secure/validated connections), and if it is needed to test locally without ssh host key checking, let the user turn on no_host_key_check: True in the connection details to override the default. It seems a safer approach.
- Users are still having to write out to the docker containers `~/.ssh/config` file as part of their work because one of the servers they connect to is using a much older key exchange algorithm that the ssh libraries don’t check for by default, so they have to tell it which one to use for a specific site. Given they still need to write out this file, it would be convenient for them just to update the `~/.ssh/known_hosts` file too, now they know how to do it as part of the Dockerfile. It would make sense to them for the SFTP provider to default back to using the `known_hosts` file if a host key is not specifically provided on the connection. Developers have the choice then of which approach to take.
- Accept `string` values(fetched from XCOM results of the previous task) to the `newer_than` field that need to be converted to `datetime` values in the implementation as currently the `newer_than` field only accepts `datetime` fields.
- Use `readdir` instead of `listdir` to avoid multiple roundtrip for each file to get the modified timestamp of the file.

Based on code review suggestion by @ashb that we could pass `byte string` `known_hosts` to the `asyncssh` client connection for the given connection extras `host_key`, we do not need an additional `paramiko` based host key validation as the asynchssh client usage can validate host keys by itself. This also removes the need for the presence of `known_hosts` files in case of `host_key` provided via connection extras. Thus, we also clean up the `paramiko` based validation added in the previous PR #963 


closes: #1021 