### PR TITLE
Check whether the task finishes before deferring the task for DataprocSubmitJobOperatorAsync

### DIFF
--- a/astronomer/providers/google/cloud/operators/dataproc.py
+++ b/astronomer/providers/google/cloud/operators/dataproc.py
@@ -276,7 +276,6 @@ class DataprocSubmitJobOperatorAsync(DataprocSubmitJobOperator):
         )
         job_id = job_object.reference.job_id
         self.log.info("Job %s submitted successfully.", job_id)
-        self.job_id = job_id
         # Save data required for extra links no matter what the job status will be
         DataprocLink.persist(context=context, task_instance=self, url=DATAPROC_JOB_LOG_LINK, resource=job_id)
 


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we need to verify if the task has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished.