### PR TITLE
Check whether the task finishes before deferring the task for GKEStartPodOperatorAsync

### DIFF
--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -222,7 +222,7 @@ class DatabricksSubmitRunOperatorAsync(DatabricksSubmitRunOperator):
             else:
                 _handle_non_successful_terminal_states(run_state, run_info, hook, self.task_id)
 
-    def execute_complete(self, context: Context, event: Any = None) -> None:
+    def execute_complete(self, context: Context, event: Any = None) -> None:  # type: ignore[override]
         """
         Callback for when the trigger fires - returns immediately.
         Relies on trigger to throw an exception, otherwise it assumes execution was

--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -222,7 +222,7 @@ class DatabricksSubmitRunOperatorAsync(DatabricksSubmitRunOperator):
             else:
                 _handle_non_successful_terminal_states(run_state, run_info, hook, self.task_id)
 
-    def execute_complete(self, context: Context, event: Any = None) -> None:  # type: ignore[override]
+    def execute_complete(self, context: Context, event: Any = None) -> None:
         """
         Callback for when the trigger fires - returns immediately.
         Relies on trigger to throw an exception, otherwise it assumes execution was


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we try to verify if the submitted job has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. 