### PR TITLE
Mark DBT cloud job run failed if cancelled by raising AirflowFailException

### DIFF
--- a/astronomer/providers/dbt/cloud/operators/dbt.py
+++ b/astronomer/providers/dbt/cloud/operators/dbt.py
@@ -4,6 +4,7 @@ import time
 from typing import Any
 
 from airflow import AirflowException
+from airflow.exceptions import AirflowFailException
 from airflow.providers.dbt.cloud.hooks.dbt import (
     DbtCloudHook,
     DbtCloudJobRunException,
@@ -89,9 +90,8 @@ class DbtCloudRunJobOperatorAsync(DbtCloudRunJobOperator):
         """
         if event["status"] == "cancelled":
             self.log.info("Job run %s has been cancelled.", str(event["run_id"]))
-            self.log.info("Setting task retries to 0")
-            context["task"].retries = 0
-            raise AirflowException(event["message"])
+            self.log.info("Task will not be retried.")
+            raise AirflowFailException(event["message"])
         elif event["status"] == "error":
             raise AirflowException(event["message"])
         self.log.info(event["message"])

--- a/astronomer/providers/dbt/cloud/operators/dbt.py
+++ b/astronomer/providers/dbt/cloud/operators/dbt.py
@@ -87,7 +87,12 @@ class DbtCloudRunJobOperatorAsync(DbtCloudRunJobOperator):
         Relies on trigger to throw an exception, otherwise it assumes execution was
         successful.
         """
-        if event["status"] == "error":
+        if event["status"] == "cancelled":
+            self.log.info("Job run %s has been cancelled.", str(event["run_id"]))
+            self.log.info("Setting task retries to 0")
+            context["task"].retries = 0
+            raise AirflowException(event["message"])
+        elif event["status"] == "error":
             raise AirflowException(event["message"])
         self.log.info(event["message"])
         return int(event["run_id"])

--- a/tests/dbt/cloud/operators/test_dbt.py
+++ b/tests/dbt/cloud/operators/test_dbt.py
@@ -135,6 +135,26 @@ class TestDbtCloudRunJobOperatorAsync:
                 context=None, event={"status": "error", "message": "test failure message"}
             )
 
+    def test_dbt_run_job_cancelled_exception(self):
+        """Test DbtCloudRunJobOperatorAsync to raise exception when job is cancelled"""
+        dbt_op = DbtCloudRunJobOperatorAsync(
+            dbt_cloud_conn_id=self.CONN_ID,
+            task_id=self.TASK_ID,
+            job_id=self.DBT_RUN_ID,
+            check_interval=self.CHECK_INTERVAL,
+            timeout=self.TIMEOUT,
+        )
+        with pytest.raises(AirflowException):
+            dbt_op.execute_complete(
+                context={"task": dbt_op},
+                event={
+                    "status": "cancelled",
+                    "message": f"Job run {self.DBT_RUN_ID} has been cancelled.",
+                    "run_id": self.DBT_RUN_ID,
+                },
+            )
+        assert dbt_op.retries == 0
+
     @pytest.mark.parametrize(
         "mock_event",
         [

--- a/tests/dbt/cloud/operators/test_dbt.py
+++ b/tests/dbt/cloud/operators/test_dbt.py
@@ -144,7 +144,7 @@ class TestDbtCloudRunJobOperatorAsync:
             check_interval=self.CHECK_INTERVAL,
             timeout=self.TIMEOUT,
         )
-        with pytest.raises(AirflowException):
+        with pytest.raises(AirflowException) as exc:
             dbt_op.execute_complete(
                 context={"task": dbt_op},
                 event={
@@ -154,6 +154,7 @@ class TestDbtCloudRunJobOperatorAsync:
                 },
             )
         assert dbt_op.retries == 0
+        assert f"Job run {self.DBT_RUN_ID} has been cancelled." in str(exc.value)
 
     @pytest.mark.parametrize(
         "mock_event",


### PR DESCRIPTION
Currently, if DBT Cloud job run is cancelled our async operator just logs 
a message in the task logs that the job is cancelled and marks the task
status as success.
The PR now raises an AirflowFailException to mark the task as failed 
and that it is not retried by Airflow as the user may not pay attention to 
re-cancel the job or may not have set retries to 0 for the task in their DAG.

closes: #1081 