### PR TITLE
Check whether the task finishes before deferring the task for DatabricksSubmitRunOperatorAsync

### DIFF
--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -1,15 +1,47 @@
+from __future__ import annotations
+
 from typing import Any
 
 from airflow.exceptions import AirflowException
+from airflow.providers.databricks.hooks.databricks import DatabricksHook
 from airflow.providers.databricks.operators.databricks import (
     XCOM_RUN_ID_KEY,
     XCOM_RUN_PAGE_URL_KEY,
     DatabricksRunNowOperator,
     DatabricksSubmitRunOperator,
+    RunState,
 )
 
 from astronomer.providers.databricks.triggers.databricks import DatabricksTrigger
 from astronomer.providers.utils.typing_compat import Context
+
+
+def _handle_not_successful_teminated_state(
+    run_state: RunState, run_info: dict[str, Any], hook: DatabricksHook, task_id: str
+) -> None:
+    if run_state.result_state == "FAILED":
+        task_run_id = None
+        if "tasks" in run_info:
+            for task in run_info["tasks"]:
+                if task.get("state", {}).get("result_state", "") == "FAILED":
+                    task_run_id = task["run_id"]
+        if task_run_id is not None:
+            run_output = hook.get_run_output(task_run_id)
+            if "error" in run_output:
+                notebook_error = run_output["error"]
+            else:
+                notebook_error = run_state.state_message
+        else:
+            notebook_error = run_state.state_message
+        error_message = (
+            f"{task_id} failed with terminal state: {run_state} " f"and with the error {notebook_error}"
+        )
+    else:
+        error_message = (
+            f"{task_id} failed with terminal state: {run_state} "
+            f"and with the error {run_state.state_message}"
+        )
+    raise AirflowException(error_message)
 
 
 class DatabricksSubmitRunOperatorAsync(DatabricksSubmitRunOperator):
@@ -153,20 +185,29 @@ class DatabricksSubmitRunOperatorAsync(DatabricksSubmitRunOperator):
 
         self.log.info("View run status, Spark UI, and logs at %s", self.run_page_url)
 
-        self.defer(
-            timeout=self.execution_timeout,
-            trigger=DatabricksTrigger(
-                conn_id=self.databricks_conn_id,
-                task_id=self.task_id,
-                run_id=str(self.run_id),
-                job_id=job_id,
-                run_page_url=self.run_page_url,
-                retry_limit=self.databricks_retry_limit,
-                retry_delay=self.databricks_retry_delay,
-                polling_period_seconds=self.polling_period_seconds,
-            ),
-            method_name="execute_complete",
-        )
+        run_info = hook.get_run(self.run_id)
+        run_state = RunState(**run_info["state"])
+        if not run_state.is_terminal:
+            self.defer(
+                timeout=self.execution_timeout,
+                trigger=DatabricksTrigger(
+                    conn_id=self.databricks_conn_id,
+                    task_id=self.task_id,
+                    run_id=str(self.run_id),
+                    job_id=job_id,
+                    run_page_url=self.run_page_url,
+                    retry_limit=self.databricks_retry_limit,
+                    retry_delay=self.databricks_retry_delay,
+                    polling_period_seconds=self.polling_period_seconds,
+                ),
+                method_name="execute_complete",
+            )
+        else:
+            if run_state.is_successful:
+                self.log.info("%s completed successfully.", self.task_id)
+                return
+            else:
+                _handle_not_successful_teminated_state(run_state, run_info, hook, self.task_id)
 
     def execute_complete(self, context: Context, event: Any = None) -> None:
         """

--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -19,6 +19,7 @@ from astronomer.providers.utils.typing_compat import Context
 def _handle_non_successful_teminal_states(
     run_state: RunState, run_info: dict[str, Any], hook: DatabricksHook, task_id: str
 ) -> None:
+    """Raise AirflowException with detailed error message from run_info"""
     if run_state.result_state == "FAILED":
         task_run_id = None
         if "tasks" in run_info:

--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -16,7 +16,7 @@ from astronomer.providers.databricks.triggers.databricks import DatabricksTrigge
 from astronomer.providers.utils.typing_compat import Context
 
 
-def _handle_not_successful_teminated_state(
+def _handle_non_successful_teminal_states(
     run_state: RunState, run_info: dict[str, Any], hook: DatabricksHook, task_id: str
 ) -> None:
     if run_state.result_state == "FAILED":
@@ -207,7 +207,7 @@ class DatabricksSubmitRunOperatorAsync(DatabricksSubmitRunOperator):
                 self.log.info("%s completed successfully.", self.task_id)
                 return
             else:
-                _handle_not_successful_teminated_state(run_state, run_info, hook, self.task_id)
+                _handle_non_successful_teminal_states(run_state, run_info, hook, self.task_id)
 
     def execute_complete(self, context: Context, event: Any = None) -> None:
         """

--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -15,7 +15,7 @@ from astronomer.providers.databricks.triggers.databricks import DatabricksTrigge
 from astronomer.providers.utils.typing_compat import Context
 
 
-def _handle_non_successful_teminal_states(
+def _handle_non_successful_terminal_states(
     run_state: RunState, run_info: dict[str, Any], hook: DatabricksHook, task_id: str
 ) -> None:
     """Raise AirflowException with detailed error message from run_info
@@ -220,7 +220,7 @@ class DatabricksSubmitRunOperatorAsync(DatabricksSubmitRunOperator):
                 self.log.info("%s completed successfully.", self.task_id)
                 return
             else:
-                _handle_non_successful_teminal_states(run_state, run_info, hook, self.task_id)
+                _handle_non_successful_terminal_states(run_state, run_info, hook, self.task_id)
 
     def execute_complete(self, context: Context, event: Any = None) -> None:
         """


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we try to verify if the submitted job has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. 