### PR TITLE
Check whether the task finishes before deferring the task for DatabricksRunNowOperatorAsync

### DIFF
--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -15,7 +15,7 @@ from astronomer.providers.databricks.triggers.databricks import DatabricksTrigge
 from astronomer.providers.utils.typing_compat import Context
 
 
-def _handle_non_successful_teminal_states(
+def _handle_non_successful_terminal_states(
     run_state: RunState, run_info: dict[str, Any], hook: DatabricksHook, task_id: str
 ) -> None:
     """Raise AirflowException with detailed error message from run_info
@@ -426,7 +426,7 @@ class DatabricksRunNowOperatorAsync(DatabricksRunNowOperator):
                 self.log.info("%s completed successfully.", self.task_id)
                 return
             else:
-                _handle_non_successful_teminal_states(run_state, run_info, hook, self.task_id)
+                _handle_non_successful_terminal_states(run_state, run_info, hook, self.task_id)
 
     def execute_complete(
         self, context: Context, event: Any = None

--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -19,6 +19,7 @@ from astronomer.providers.utils.typing_compat import Context
 def _handle_non_successful_teminal_states(
     run_state: RunState, run_info: dict[str, Any], hook: DatabricksHook, task_id: str
 ) -> None:
+    """Raise AirflowException with detailed error message from run_info"""
     if run_state.result_state == "FAILED":
         task_run_id = None
         if "tasks" in run_info:

--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -16,7 +16,7 @@ from astronomer.providers.databricks.triggers.databricks import DatabricksTrigge
 from astronomer.providers.utils.typing_compat import Context
 
 
-def _handle_not_successful_teminated_state(
+def _handle_non_successful_teminal_states(
     run_state: RunState, run_info: dict[str, Any], hook: DatabricksHook, task_id: str
 ) -> None:
     if run_state.result_state == "FAILED":
@@ -413,7 +413,7 @@ class DatabricksRunNowOperatorAsync(DatabricksRunNowOperator):
                 self.log.info("%s completed successfully.", self.task_id)
                 return
             else:
-                _handle_not_successful_teminated_state(run_state, run_info, hook, self.task_id)
+                _handle_non_successful_teminal_states(run_state, run_info, hook, self.task_id)
 
     def execute_complete(
         self, context: Context, event: Any = None

--- a/tests/databricks/operators/test_databricks.py
+++ b/tests/databricks/operators/test_databricks.py
@@ -10,6 +10,7 @@ from astronomer.providers.databricks.operators.databricks import (
 from astronomer.providers.databricks.triggers.databricks import DatabricksTrigger
 from tests.utils.airflow_util import create_context
 
+JOB_ID = "42"
 TASK_ID = "databricks_check"
 CONN_ID = "databricks_default"
 RUN_ID = "1"
@@ -19,6 +20,16 @@ RETRY_DELAY = 1.0
 POLLING_PERIOD_SECONDS = 1.0
 XCOM_RUN_ID_KEY = "run_id"
 XCOM_RUN_PAGE_URL_KEY = "run_page_url"
+
+
+def make_run_with_state_mock(lifecycle_state: str, result_state: str, state_message: str = ""):
+    return {
+        "state": {
+            "life_cycle_state": lifecycle_state,
+            "result_state": result_state,
+            "state_message": state_message,
+        },
+    }
 
 
 class TestDatabricksSubmitRunOperatorAsync:
@@ -119,15 +130,113 @@ class TestDatabricksSubmitRunOperatorAsync:
 
 
 class TestDatabricksRunNowOperatorAsync:
+    @mock.patch("astronomer.providers.databricks.operators.databricks.DatabricksRunNowOperatorAsync.defer")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run")
     @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.run_now")
     @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
-    def test_databricks_run_now_operator_async(self, run_now_response, get_run_page_url_response):
+    def test_databricks_run_now_operator_async_succeeded_before_defered(
+        self, run_now_response, get_run_page_url_response, get_run, defer
+    ):
+        run_now_response.return_value = {"run_id": RUN_ID}
+        get_run_page_url_response.return_value = RUN_PAGE_URL
+        get_run.return_value = make_run_with_state_mock("TERMINATED", "SUCCESS")
+
+        operator = DatabricksRunNowOperatorAsync(
+            task_id="run_now",
+            databricks_conn_id=CONN_ID,
+        )
+
+        operator.execute(context=create_context(operator))
+
+        assert not defer.called
+
+    @pytest.mark.parametrize("result_state", ("FAILED", "UNEXPECTED"))
+    @mock.patch("astronomer.providers.databricks.operators.databricks.DatabricksRunNowOperatorAsync.defer")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.run_now")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
+    def test_databricks_run_now_operator_async_failed_before_defered(
+        self, run_now_response, get_run_page_url_response, get_run, defer, result_state
+    ):
+        run_now_response.return_value = {"run_id": RUN_ID}
+        get_run_page_url_response.return_value = RUN_PAGE_URL
+        get_run.return_value = make_run_with_state_mock("TERMINATED", result_state)
+
+        operator = DatabricksRunNowOperatorAsync(
+            task_id="run_now",
+            databricks_conn_id=CONN_ID,
+        )
+        with pytest.raises(AirflowException):
+            operator.execute(context=create_context(operator))
+
+        assert not defer.called
+
+    @mock.patch("astronomer.providers.databricks.operators.databricks.DatabricksRunNowOperatorAsync.defer")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run_output")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.run_now")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
+    def test_databricks_run_now_operator_failed_with_error_in_run_output_before_defered(
+        self,
+        run_now_response,
+        get_run_page_url_response,
+        get_run,
+        get_run_output,
+        defer,
+    ):
+        run_now_response.return_value = {"run_id": RUN_ID}
+        get_run_page_url_response.return_value = RUN_PAGE_URL
+        get_run.return_value = make_run_with_state_mock("TERMINATED", "FAILED")
+        get_run.return_value["tasks"] = [{"state": {"result_state": "FAILED"}, "run_id": RUN_ID}]
+        get_run_output.return_value = {"error": "notebook error"}
+
+        operator = DatabricksRunNowOperatorAsync(
+            task_id="run_now",
+            databricks_conn_id=CONN_ID,
+        )
+        with pytest.raises(AirflowException):
+            operator.execute(context=create_context(operator))
+
+        assert not defer.called
+
+    @mock.patch("astronomer.providers.databricks.operators.databricks.DatabricksRunNowOperatorAsync.defer")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run_output")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.run_now")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
+    def test_databricks_run_now_operator_async_failed_without_error_in_run_output_before_defered(
+        self,
+        run_now_response,
+        get_run_page_url_response,
+        get_run,
+        get_run_output,
+        defer,
+    ):
+        run_now_response.return_value = {"run_id": RUN_ID}
+        get_run_page_url_response.return_value = RUN_PAGE_URL
+        get_run.return_value = make_run_with_state_mock("TERMINATED", "FAILED")
+        get_run.return_value["tasks"] = [{"state": {"result_state": "FAILED"}, "run_id": RUN_ID}]
+
+        operator = DatabricksRunNowOperatorAsync(
+            task_id="run_now",
+            databricks_conn_id=CONN_ID,
+        )
+        with pytest.raises(AirflowException):
+            operator.execute(context=create_context(operator))
+
+        assert not defer.called
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.run_now")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
+    def test_databricks_run_now_operator_async(self, run_now_response, get_run_page_url_response, get_run):
         """
         Asserts that a task is deferred and an DatabricksTrigger will be fired
         when the DatabricksRunNowOperatorAsync is executed.
         """
         run_now_response.return_value = {"run_id": RUN_ID}
         get_run_page_url_response.return_value = RUN_PAGE_URL
+        get_run.return_value = make_run_with_state_mock("RUNNING", "SUCCESS")
 
         operator = DatabricksRunNowOperatorAsync(
             task_id="run_now",


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we try to verify if the submitted job has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. 