### PR TITLE
Check whether the task finishes before deferring the task for EmrContainerOperatorAsync

### DIFF
--- a/astronomer/providers/amazon/aws/sensors/emr.py
+++ b/astronomer/providers/amazon/aws/sensors/emr.py
@@ -33,17 +33,18 @@ class EmrContainerSensorAsync(EmrContainerSensor):
 
     def execute(self, context: Context) -> None:
         """Defers trigger class to poll for state of the job run until it reaches a failure state or success state"""
-        self.defer(
-            timeout=timedelta(seconds=self.timeout),
-            trigger=EmrContainerSensorTrigger(
-                virtual_cluster_id=self.virtual_cluster_id,
-                job_id=self.job_id,
-                max_tries=self.max_retries,
-                aws_conn_id=self.aws_conn_id,
-                poll_interval=self.poll_interval,
-            ),
-            method_name="execute_complete",
-        )
+        if not self.poke(context):
+            self.defer(
+                timeout=timedelta(seconds=self.timeout),
+                trigger=EmrContainerSensorTrigger(
+                    virtual_cluster_id=self.virtual_cluster_id,
+                    job_id=self.job_id,
+                    max_tries=self.max_retries,
+                    aws_conn_id=self.aws_conn_id,
+                    poll_interval=self.poll_interval,
+                ),
+                method_name="execute_complete",
+            )
 
     def execute_complete(self, context: Context, event: Dict[str, str]) -> None:
         """

--- a/tests/amazon/aws/sensors/test_emr_sensors.py
+++ b/tests/amazon/aws/sensors/test_emr_sensors.py
@@ -20,6 +20,8 @@ JOB_ID = "j-T0CT8Z0C20NT"
 AWS_CONN_ID = "aws_default"
 STEP_ID = "s-34RJO0CKERRPL"
 
+MODULE = "astronomer.providers.amazon.aws.sensors.emr"
+
 
 class TestEmrContainerSensorAsync:
     TASK = EmrContainerSensorAsync(
@@ -31,7 +33,15 @@ class TestEmrContainerSensorAsync:
         aws_conn_id=AWS_CONN_ID,
     )
 
-    def test_emr_container_sensor_async(self, context):
+    @mock.patch(f"{MODULE}.EmrContainerSensorAsync.defer")
+    @mock.patch(f"{MODULE}.EmrContainerSensorAsync.poke", return_value=True)
+    def test_emr_container_sensor_async_finish_before_deferred(self, mock_poke, mock_defer, context):
+        """Assert task is not deferred when it receives a finish status before deferring"""
+        self.TASK.execute(context)
+        assert not mock_defer.called
+
+    @mock.patch(f"{MODULE}.EmrContainerSensorAsync.poke", return_value=False)
+    def test_emr_container_sensor_async(self, mock_poke, context):
         """
         Asserts that a task is deferred and a EmrContainerSensorTrigger will be fired
         when the EmrContainerSensorAsync is executed.


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we try to verify if the submitted job has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. 