### PR TITLE
Check whether the task finishes before deferring the task for RedshiftDataOperatorAsync

### DIFF
--- a/astronomer/providers/amazon/aws/operators/redshift_sql.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_sql.py
@@ -58,26 +58,7 @@ class RedshiftSQLOperatorAsync(RedshiftSQLOperator):
             return
         context["ti"].xcom_push(key="return_value", value=query_ids)
 
-        still_running = False
-        completed_query_ids = []
-        for qid in query_ids:
-            resp = redshift_data_hook.conn.describe_statement(Id=qid)
-            status = resp["Status"]
-            if status == "FAILED":
-                err_msg = f"Error: {resp['QueryString']} query Failed due to {resp['Error']}"
-                msg = f"context: {context}, error message: {err_msg}"
-                raise AirflowException(msg)
-            elif status == "ABORTED":
-                err_msg = "The query run was stopped by the user."
-                msg = f"context: {context}, error message: {err_msg}"
-                raise AirflowException(msg)
-            elif status in ("SUBMITTED", "PICKED", "STARTED"):
-                still_running = True
-                break
-            elif status == "FINISHED":
-                completed_query_ids.append(qid)
-
-        if not still_running and len(completed_query_ids) == len(query_ids):
+        if redshift_data_hook.queries_are_completed(query_ids, context):
             self.log.info("%s completed successfully.", self.task_id)
             return
 


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we try to verify if the submitted job has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. 