### PR TITLE
Check whether the task finishes before deferring the task for RedshiftSQLOperatorAsync

### DIFF
--- a/astronomer/providers/amazon/aws/operators/redshift_sql.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_sql.py
@@ -59,6 +59,7 @@ class RedshiftSQLOperatorAsync(RedshiftSQLOperator):
         context["ti"].xcom_push(key="return_value", value=query_ids)
 
         still_running = False
+        completed_query_ids = []
         for qid in query_ids:
             resp = redshift_data_hook.conn.describe_statement(Id=qid)
             status = resp["Status"]
@@ -73,8 +74,10 @@ class RedshiftSQLOperatorAsync(RedshiftSQLOperator):
             elif status in ("SUBMITTED", "PICKED", "STARTED"):
                 still_running = True
                 break
+            elif status == "FINISHED":
+                completed_query_ids.append(qid)
 
-        if not still_running:
+        if not still_running and len(completed_query_ids) == len(query_ids):
             self.log.info("%s completed successfully.", self.task_id)
             return
 

--- a/tests/amazon/aws/operators/test_redshift_sql.py
+++ b/tests/amazon/aws/operators/test_redshift_sql.py
@@ -18,9 +18,48 @@ class TestRedshiftSQLOperatorAsync:
         params={},
     )
 
+    @mock.patch("astronomer.providers.amazon.aws.operators.redshift_sql.RedshiftSQLOperatorAsync.defer")
+    @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.conn")
     @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.execute_query")
-    def test_redshiftsql_op_async(self, mock_execute):
-        mock_execute.return_value = [], {}
+    def test_redshiftsql_op_async_finished_before_deferred(self, mock_execute, mock_conn, mock_defer):
+        mock_execute.return_value = ["test_query_id"], {}
+        mock_conn.describe_statement.return_value = {"Status": "FINISHED"}
+
+        self.TASK.execute(create_context(self.TASK))
+        assert not mock_defer.called
+
+    @mock.patch("astronomer.providers.amazon.aws.operators.redshift_sql.RedshiftSQLOperatorAsync.defer")
+    @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.conn")
+    @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.execute_query")
+    def test_redshiftsql_op_async_aborted_before_deferred(self, mock_execute, mock_conn, mock_defer):
+        mock_execute.return_value = ["test_query_id"], {}
+        mock_conn.describe_statement.return_value = {"Status": "ABORTED"}
+
+        with pytest.raises(AirflowException):
+            self.TASK.execute(create_context(self.TASK))
+        assert not mock_defer.called
+
+    @mock.patch("astronomer.providers.amazon.aws.operators.redshift_sql.RedshiftSQLOperatorAsync.defer")
+    @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.conn")
+    @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.execute_query")
+    def test_redshiftsql_op_async_failed_before_deferred(self, mock_execute, mock_conn, mock_defer):
+        mock_execute.return_value = ["test_query_id"], {}
+        mock_conn.describe_statement.return_value = {
+            "Status": "FAILED",
+            "QueryString": "test query",
+            "Error": "test error",
+        }
+
+        with pytest.raises(AirflowException):
+            self.TASK.execute(create_context(self.TASK))
+        assert not mock_defer.called
+
+    @pytest.mark.parametrize("status", ("SUBMITTED", "PICKED", "STARTED"))
+    @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.conn")
+    @mock.patch("astronomer.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.execute_query")
+    def test_redshiftsql_op_async(self, mock_execute, mock_conn, status):
+        mock_execute.return_value = ["test_query_id"], {}
+        mock_conn.describe_statement.return_value = {"Status": status}
 
         with pytest.raises(TaskDeferred) as exc:
             self.TASK.execute(create_context(self.TASK))


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we try to verify if the submitted job has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. 