### PR TITLE
Check whether the task finishes before deferring the task for SageMakerTrainingOperatorAsync

### DIFF
--- a/astronomer/providers/amazon/aws/operators/sagemaker.py
+++ b/astronomer/providers/amazon/aws/operators/sagemaker.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import json
 import time
-from typing import Any, Dict, Optional
+from typing import Any
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sagemaker import (
+    LogState,
     secondary_training_status_message,
 )
 from airflow.providers.amazon.aws.operators.sagemaker import (
@@ -21,7 +24,7 @@ from astronomer.providers.amazon.aws.triggers.sagemaker import (
 from astronomer.providers.utils.typing_compat import Context
 
 
-def serialize(result: Dict[str, Any]) -> str:
+def serialize(result: dict[str, Any]) -> str:
     """Serialize any objects coming from Sagemaker API response to json string"""
     return json.loads(json.dumps(result, cls=AirflowJsonEncoder))  # type: ignore[no-any-return]
 
@@ -81,7 +84,7 @@ class SageMakerProcessingOperatorAsync(SageMakerProcessingOperator):
         if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
             raise AirflowException(f"Sagemaker Processing Job creation failed: {response}")
         else:
-            end_time: Optional[float] = None
+            end_time: float | None = None
             if self.max_ingestion_time is not None:
                 end_time = time.time() + self.max_ingestion_time
             self.defer(
@@ -95,7 +98,7 @@ class SageMakerProcessingOperatorAsync(SageMakerProcessingOperator):
                 method_name="execute_complete",
             )
 
-    def execute_complete(self, context: Context, event: Any = None) -> Dict[str, Any]:
+    def execute_complete(self, context: Context, event: Any = None) -> dict[str, Any]:
         """
         Callback for when the trigger fires - returns immediately.
         Relies on trigger to throw an exception, otherwise it assumes execution was
@@ -180,7 +183,7 @@ class SageMakerTransformOperatorAsync(SageMakerTransformOperator):
         if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
             raise AirflowException(f"Sagemaker transform Job creation failed: {response}")
         else:
-            end_time: Optional[float] = None
+            end_time: float | None = None
             if self.max_ingestion_time is not None:
                 end_time = time.time() + self.max_ingestion_time
             self.defer(
@@ -196,7 +199,7 @@ class SageMakerTransformOperatorAsync(SageMakerTransformOperator):
                 method_name="execute_complete",
             )
 
-    def execute_complete(self, context: "Context", event: Dict[str, Any]) -> Dict[str, Any]:
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> dict[str, Any]:
         """
         Callback for when the trigger fires - returns immediately.
         Relies on trigger to throw an exception, otherwise it assumes execution was
@@ -240,7 +243,7 @@ class SageMakerTrainingOperatorAsync(SageMakerTrainingOperator):
         This is only relevant if check_if_job_exists is True.
     """
 
-    def execute(self, context: Context) -> None:  # type: ignore[override]
+    def execute(self, context: Context) -> dict[str, Any] | None:  # type: ignore[override]
         """
         Creates SageMaker training job via sync hook `create_training_job` and pass the
         control to trigger and polls for the status of the training job in async
@@ -267,42 +270,78 @@ class SageMakerTrainingOperatorAsync(SageMakerTrainingOperator):
         )
         if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
             raise AirflowException(f"Sagemaker Training Job creation failed: {response}")
-        else:
-            end_time: Optional[float] = None
-            if self.max_ingestion_time is not None:
-                end_time = time.time() + self.max_ingestion_time
-            if self.print_log:
-                description = self.hook.describe_training_job(self.config["TrainingJobName"])
-                self.log.info(secondary_training_status_message(description, None))
-                instance_count = description["ResourceConfig"]["InstanceCount"]
-                status = description["TrainingJobStatus"]
-                self.defer(
-                    timeout=self.execution_timeout,
-                    trigger=SagemakerTrainingWithLogTrigger(
-                        poke_interval=self.check_interval,
-                        end_time=end_time,
-                        aws_conn_id=self.aws_conn_id,
-                        job_name=self.config["TrainingJobName"],
-                        instance_count=int(instance_count),
-                        status=status,
-                    ),
-                    method_name="execute_complete",
-                )
-            else:
-                self.defer(
-                    timeout=self.execution_timeout,
-                    trigger=SagemakerTrigger(
-                        poke_interval=self.check_interval,
-                        end_time=end_time,
-                        aws_conn_id=self.aws_conn_id,
-                        job_name=self.config["TrainingJobName"],
-                        job_type="Training",
-                        response_key="TrainingJobStatus",
-                    ),
-                    method_name="execute_complete",
-                )
 
-    def execute_complete(self, context: "Context", event: Dict[str, Any]) -> Dict[str, Any]:
+        end_time: float | None = None
+        if self.max_ingestion_time is not None:
+            end_time = time.time() + self.max_ingestion_time
+
+        description = self.hook.describe_training_job(self.config["TrainingJobName"])
+        status = description["TrainingJobStatus"]
+        if self.print_log:
+            instance_count = description["ResourceConfig"]["InstanceCount"]
+            last_describe_job_call = time.monotonic()
+            job_already_completed = status not in self.hook.non_terminal_states
+            _, last_description, last_describe_job_call = self.hook.describe_training_job_with_log(
+                self.config["TrainingJobName"],
+                {},
+                [],
+                instance_count,
+                LogState.TAILING if job_already_completed else LogState.COMPLETE,
+                description,
+                last_describe_job_call,
+            )
+
+            self.log.info(secondary_training_status_message(description, None))
+
+            if status in self.hook.failed_states:
+                reason = last_description.get("FailureReason", "(No reason provided)")
+                raise AirflowException(f"SageMaker job failed because {reason}")
+            elif status == "Completed":
+                billable_time = (
+                    last_description["TrainingEndTime"] - last_description["TrainingStartTime"]
+                ) * instance_count
+                self.log.info(
+                    f"Billable seconds: {int(billable_time.total_seconds()) + 1}\n"
+                    f"{self.task_id} completed successfully."
+                )
+                return {"Training": serialize(description)}
+
+            self.defer(
+                timeout=self.execution_timeout,
+                trigger=SagemakerTrainingWithLogTrigger(
+                    poke_interval=self.check_interval,
+                    end_time=end_time,
+                    aws_conn_id=self.aws_conn_id,
+                    job_name=self.config["TrainingJobName"],
+                    instance_count=int(instance_count),
+                    status=status,
+                ),
+                method_name="execute_complete",
+            )
+        else:
+            if status in self.hook.failed_states:
+                raise AirflowException(f"SageMaker job failed because {description['FailureReason']}")
+            elif status == "Completed":
+                self.log.info(f"{self.task_id} completed successfully.")
+                return {"Training": serialize(description)}
+
+            self.defer(
+                timeout=self.execution_timeout,
+                trigger=SagemakerTrigger(
+                    poke_interval=self.check_interval,
+                    end_time=end_time,
+                    aws_conn_id=self.aws_conn_id,
+                    job_name=self.config["TrainingJobName"],
+                    job_type="Training",
+                    response_key="TrainingJobStatus",
+                ),
+                method_name="execute_complete",
+            )
+
+        # for bypassing mypy missing return error
+        return None  # pragma: no cover
+
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> dict[str, Any]:
         """
         Callback for when the trigger fires - returns immediately.
         Relies on trigger to throw an exception, otherwise it assumes execution was

--- a/tests/amazon/aws/operators/test_sagemaker.py
+++ b/tests/amazon/aws/operators/test_sagemaker.py
@@ -4,6 +4,7 @@ import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
 from airflow.providers.amazon.aws.operators import sagemaker
+from airflow.utils.timezone import datetime
 
 from astronomer.providers.amazon.aws.operators.sagemaker import (
     SageMakerProcessingOperatorAsync,
@@ -301,16 +302,165 @@ class TestSagemakerTrainingOperatorAsync:
             (False, SagemakerTrigger, "SagemakerTrigger"),
         ],
     )
+    @mock.patch("astronomer.providers.amazon.aws.operators.sagemaker.SageMakerTrainingOperatorAsync.defer")
+    @mock.patch.object(
+        SageMakerHook,
+        "describe_training_job_with_log",
+        return_value=(
+            ...,
+            {
+                "TrainingJobStatus": "Completed",
+                "ResourceConfig": {"InstanceCount": 1},
+                "TrainingEndTime": datetime(2023, 5, 15),
+                "TrainingStartTime": datetime(2023, 5, 16),
+            },
+            datetime(2023, 5, 16),
+        ),
+    )
+    @mock.patch.object(
+        SageMakerHook,
+        "describe_training_job",
+        return_value={
+            "TrainingJobStatus": "Completed",
+            "ResourceConfig": {"InstanceCount": 1},
+        },
+    )
+    @mock.patch.object(SageMakerHook, "get_conn")
+    @mock.patch.object(SageMakerHook, "create_training_job")
+    @mock.patch.object(sagemaker, "serialize", return_value="")
+    @mock.patch.object(SageMakerHook, "list_training_jobs", return_value=[])
+    def test_sagemaker_training_op_async_complete_before_defer(
+        self,
+        mock_list_training_job,
+        mock_serialize,
+        mock_create_training_job,
+        mock_get_conn,
+        mock_describe_training_job,
+        mock_describe_training_job_with_log,
+        mock_defer,
+        mock_print_log_attr,
+        mock_trigger_class,
+        mock_trigger_name,
+    ):
+        mock_create_training_job.return_value = {
+            "TrainingJobArn": "test_arn",
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+        }
+        task = SageMakerTrainingOperatorAsync(
+            config=TRAINING_CONFIG,
+            task_id=self.TASK_ID,
+            check_if_job_exists=False,
+            print_log=mock_print_log_attr,
+            check_interval=self.CHECK_INTERVAL,
+            max_ingestion_time=self.MAX_INGESTION_TIME,
+        )
+        task.execute(None)
+
+        assert not mock_defer.called
+
+    @pytest.mark.parametrize(
+        "mock_print_log_attr,mock_trigger_class, mock_trigger_name",
+        [
+            (True, SagemakerTrainingWithLogTrigger, "SagemakerTrainingWithLogTrigger"),
+            (False, SagemakerTrigger, "SagemakerTrigger"),
+        ],
+    )
+    @mock.patch("astronomer.providers.amazon.aws.operators.sagemaker.SageMakerTrainingOperatorAsync.defer")
+    @mock.patch.object(
+        SageMakerHook,
+        "describe_training_job_with_log",
+        return_value=(
+            ...,
+            {
+                "TrainingJobStatus": "Failed",
+                "ResourceConfig": {"InstanceCount": 1},
+                "FailureReason": "it just failed",
+            },
+            datetime(2023, 5, 16),
+        ),
+    )
+    @mock.patch.object(
+        SageMakerHook,
+        "describe_training_job",
+        return_value={
+            "TrainingJobStatus": "Failed",
+            "ResourceConfig": {"InstanceCount": 1},
+            "FailureReason": "it just failed",
+        },
+    )
+    @mock.patch.object(SageMakerHook, "get_conn")
+    @mock.patch.object(SageMakerHook, "create_training_job")
+    @mock.patch.object(sagemaker, "serialize", return_value="")
+    @mock.patch.object(SageMakerHook, "list_training_jobs", return_value=[])
+    def test_sagemaker_training_op_async_failed_before_defer(
+        self,
+        mock_list_training_job,
+        mock_serialize,
+        mock_create_training_job,
+        mock_get_conn,
+        mock_describe_training_job,
+        mock_describe_training_job_with_log,
+        mock_defer,
+        mock_print_log_attr,
+        mock_trigger_class,
+        mock_trigger_name,
+    ):
+        mock_create_training_job.return_value = {
+            "TrainingJobArn": "test_arn",
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+        }
+        task = SageMakerTrainingOperatorAsync(
+            config=TRAINING_CONFIG,
+            task_id=self.TASK_ID,
+            check_if_job_exists=False,
+            print_log=mock_print_log_attr,
+            check_interval=self.CHECK_INTERVAL,
+            max_ingestion_time=self.MAX_INGESTION_TIME,
+        )
+        with pytest.raises(AirflowException):
+            task.execute(None)
+
+        assert not mock_defer.called
+
+    @pytest.mark.parametrize(
+        "mock_print_log_attr,mock_trigger_class, mock_trigger_name",
+        [
+            (True, SagemakerTrainingWithLogTrigger, "SagemakerTrainingWithLogTrigger"),
+            (False, SagemakerTrigger, "SagemakerTrigger"),
+        ],
+    )
+    @mock.patch.object(
+        SageMakerHook,
+        "describe_training_job_with_log",
+        return_value=(
+            ...,
+            {
+                "TrainingJobStatus": "InProgress",
+                "ResourceConfig": {"InstanceCount": 1},
+            },
+            datetime(2023, 5, 16),
+        ),
+    )
+    @mock.patch.object(
+        SageMakerHook,
+        "describe_training_job",
+        return_value={
+            "TrainingJobStatus": "InProgress",
+            "ResourceConfig": {"InstanceCount": 1},
+        },
+    )
     @mock.patch.object(SageMakerHook, "get_conn")
     @mock.patch.object(SageMakerHook, "create_training_job")
     @mock.patch.object(sagemaker, "serialize", return_value="")
     @mock.patch.object(SageMakerHook, "list_training_jobs", return_value=[])
     def test_sagemaker_training_op_async(
         self,
-        mock_training_job,
+        mock_list_training_job,
         mock_serialize,
         mock_create_training_job,
-        mock_client,
+        mock_get_conn,
+        mock_describe_training_job,
+        mock_describe_training_job_with_log,
         mock_print_log_attr,
         mock_trigger_class,
         mock_trigger_name,


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we try to verify if the submitted job has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. 