### PR TITLE
Use `self.job_id` to describe Batch job

### DIFF
--- a/astronomer/providers/amazon/aws/operators/batch.py
+++ b/astronomer/providers/amazon/aws/operators/batch.py
@@ -61,6 +61,8 @@ class BatchOperatorAsync(BatchOperator):
         Submit the job and get the job_id using which we defer and poll in trigger
         """
         self.submit_job(context)
+        if not self.job_id:
+            raise AirflowException("AWS Batch job - job_id was not found")
         job = self.hook.get_job_description(self.job_id)
         job_status = job.get("status")
 

--- a/astronomer/providers/amazon/aws/operators/batch.py
+++ b/astronomer/providers/amazon/aws/operators/batch.py
@@ -60,16 +60,16 @@ class BatchOperatorAsync(BatchOperator):
         Airflow runs this method on the worker and defers using the trigger.
         Submit the job and get the job_id using which we defer and poll in trigger
         """
-        job_id = self.submit_job(context)
-        job = self.hook.get_job_description(job_id)
+        self.submit_job(context)
+        job = self.hook.get_job_description(self.job_id)
         job_status = job.get("status")
 
         if job_status == self.hook.SUCCESS_STATE:
-            self.log.info(f"{job_id} was completed successfully")
+            self.log.info(f"{self.job_id} was completed successfully")
             return
 
         if job_status == self.hook.FAILURE_STATE:
-            raise AirflowException(f"{job_id} failed")
+            raise AirflowException(f"{self.job_id} failed")
 
         if job_status in self.hook.INTERMEDIATE_STATES:
             self.defer(


### PR DESCRIPTION
With the change in PR https://github.com/astronomer/astronomer-providers/pull/1087, we called `submit_job` and assigned its output to a local variable `job_id` and then used this local variable `job_id` to describe on the job subsequently by passing it as parameter to the describe method. But, the `submit_job` method implicitly assigns the `job_id` as an instance attribute and it returns `None`. Hence, `self.job_id` actually contains the `job_id` and the local variable `job_id` which was capturing the output of `submit_job` was assigned `None` value and hence the subsequent method to describe job was failing as it was calling the describe on a `None` (job_id) type value.

The commit fixes this issue by referencing `self.job_id` instead of using the `None` valued local variable `job_id`

closes: #1097.