### PR TITLE
Check whether the task finishes before deferring the task for KubernetesPodOperatorAsync

### DIFF
--- a/astronomer/providers/cncf/kubernetes/triggers/wait_container.py
+++ b/astronomer/providers/cncf/kubernetes/triggers/wait_container.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import asyncio
 import traceback
 from datetime import timedelta
-from typing import Any, AsyncIterator, Dict, Optional, Tuple
+from typing import Any, AsyncIterator
 
 from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.utils.pod_manager import (
@@ -43,12 +45,12 @@ class WaitContainerTrigger(BaseTrigger):
         container_name: str,
         pod_name: str,
         pod_namespace: str,
-        kubernetes_conn_id: Optional[str] = None,
-        hook_params: Optional[Dict[str, Any]] = None,
+        kubernetes_conn_id: str | None = None,
+        hook_params: dict[str, Any] | None = None,
         pending_phase_timeout: float = 120,
         poll_interval: float = 5,
-        logging_interval: Optional[int] = None,
-        last_log_time: Optional[DateTime] = None,
+        logging_interval: int | None = None,
+        last_log_time: DateTime | None = None,
     ):
         super().__init__()
         self.kubernetes_conn_id = kubernetes_conn_id
@@ -61,7 +63,7 @@ class WaitContainerTrigger(BaseTrigger):
         self.logging_interval = logging_interval
         self.last_log_time = last_log_time
 
-    def serialize(self) -> Tuple[str, Dict[str, Any]]:  # noqa: D102
+    def serialize(self) -> tuple[str, dict[str, Any]]:  # noqa: D102
         return (
             "astronomer.providers.cncf.kubernetes.triggers.wait_container.WaitContainerTrigger",
             {
@@ -94,7 +96,7 @@ class WaitContainerTrigger(BaseTrigger):
             await asyncio.sleep(self.poll_interval)
         raise PodLaunchTimeoutException("Pod did not leave 'Pending' phase within specified timeout")
 
-    async def wait_for_container_completion(self, v1_api: CoreV1Api) -> "TriggerEvent":
+    async def wait_for_container_completion(self, v1_api: CoreV1Api) -> TriggerEvent:
         """
         Waits until container ``self.container_name`` is no longer in running state.
         If trigger is configured with a logging period, then will emit an event to
@@ -114,7 +116,7 @@ class WaitContainerTrigger(BaseTrigger):
                 return TriggerEvent({"status": "running", "last_log_time": self.last_log_time})
             await asyncio.sleep(self.poll_interval)
 
-    async def run(self) -> AsyncIterator["TriggerEvent"]:  # noqa: D102
+    async def run(self) -> AsyncIterator[TriggerEvent]:  # noqa: D102
         self.log.debug("Checking pod %r in namespace %r.", self.pod_name, self.pod_namespace)
         try:
             hook = await self.get_hook()

--- a/tests/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -3,8 +3,10 @@ from unittest.mock import MagicMock
 
 import pytest
 from airflow.exceptions import TaskDeferred
-from airflow.providers.cncf.kubernetes.triggers.kubernetes_pod import ContainerState
-from airflow.providers.cncf.kubernetes.utils.pod_manager import PodLoggingStatus
+from airflow.providers.cncf.kubernetes.utils.pod_manager import (
+    PodLoggingStatus,
+    PodPhase,
+)
 from kubernetes.client import models as k8s
 
 from astronomer.providers.cncf.kubernetes.operators.kubernetes_pod import (
@@ -172,52 +174,15 @@ class TestKubernetesPodOperatorAsync:
         with pytest.raises(ValueError):
             op.defer(kwargs={"timeout": 10})
 
+    @pytest.mark.parametrize("pod_phase", PodPhase.terminal_states)
     @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.trigger_reentry")
-    @mock.patch(
-        f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.define_container_state",
-        return_value=ContainerState.FAILED,
-    )
     @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.build_pod_request_obj")
     @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.get_or_create_pod")
     @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.defer")
-    def test_execute_failed_before_defer(
-        self,
-        mock_defer,
-        mock_get_or_create_pod,
-        mock_build_pod_request_obj,
-        mock_define_container_state,
-        mock_trigger_reentry,
+    def test_execute_done_before_defer(
+        self, mock_defer, mock_get_or_create_pod, mock_build_pod_request_obj, mock_trigger_reentry, pod_phase
     ):
-        mock_get_or_create_pod.return_value = _build_mock_pod(
-            k8s.V1ContainerState({"running": k8s.V1ContainerStateTerminated(exit_code=1), "waiting": None})
-        )
-        mock_build_pod_request_obj.return_value = {}
-        mock_defer.return_value = {}
-        op = KubernetesPodOperatorAsync(task_id="test_task", name="test-pod", get_logs=True)
-
-        op.execute(context=create_context(op))
-        assert mock_trigger_reentry.called
-        assert not mock_defer.called
-
-    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.trigger_reentry")
-    @mock.patch(
-        f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.define_container_state",
-        return_value=ContainerState.TERMINATED,
-    )
-    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.build_pod_request_obj")
-    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.get_or_create_pod")
-    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.defer")
-    def test_execute_succeeded_before_defer(
-        self,
-        mock_defer,
-        mock_get_or_create_pod,
-        mock_build_pod_request_obj,
-        mock_define_container_state,
-        mock_trigger_reentry,
-    ):
-        mock_get_or_create_pod.return_value = _build_mock_pod(
-            k8s.V1ContainerState({"running": k8s.V1ContainerStateTerminated(exit_code=0), "waiting": None})
-        )
+        mock_get_or_create_pod.return_value.status.phase = pod_phase
         mock_build_pod_request_obj.return_value = {}
         mock_defer.return_value = {}
         op = KubernetesPodOperatorAsync(task_id="test_task", name="test-pod", get_logs=True)
@@ -225,10 +190,6 @@ class TestKubernetesPodOperatorAsync:
         assert mock_trigger_reentry.called
         assert not mock_defer.called
 
-    @mock.patch(
-        "astronomer.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperatorAsync.define_container_state",
-        return_value=ContainerState.RUNNING,
-    )
     @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.build_pod_request_obj")
     @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.get_or_create_pod")
     @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.defer")
@@ -237,7 +198,6 @@ class TestKubernetesPodOperatorAsync:
         mock_defer,
         mock_get_or_create_pod,
         mock_build_pod_request_obj,
-        mock_define_container_state,
     ):
         """Assert that execute succeeded"""
         mock_get_or_create_pod.return_value = _build_mock_pod(
@@ -256,40 +216,3 @@ class TestKubernetesPodOperatorAsync:
         mock_trigger_reentry.return_value = {}
         op = KubernetesPodOperatorAsync(task_id="test_task", name="test-pod", get_logs=True)
         assert op.execute_complete(context=create_context(op), event={}) is None
-
-    @pytest.mark.parametrize(
-        "container_state, expected_state",
-        [
-            (
-                {"running": k8s.V1ContainerStateRunning(), "terminated": None, "waiting": None},
-                ContainerState.RUNNING,
-            ),
-            (
-                {"running": None, "terminated": k8s.V1ContainerStateTerminated(exit_code=0), "waiting": None},
-                ContainerState.TERMINATED,
-            ),
-            (
-                {"running": None, "terminated": None, "waiting": k8s.V1ContainerStateWaiting()},
-                ContainerState.WAITING,
-            ),
-        ],
-    )
-    def test_define_container_state_should_execute_successfully(self, container_state, expected_state):
-        op = KubernetesPodOperatorAsync(task_id="test_task", name="test-pod", get_logs=True)
-        op.pod = _build_mock_pod(k8s.V1ContainerState(**container_state))
-        assert expected_state == op.define_container_state()
-
-    @pytest.mark.parametrize(
-        "pod",
-        (
-            _build_mock_pod(k8s.V1ContainerState(running=None, terminated=None, waiting=None)),
-            k8s.V1Pod(
-                metadata=k8s.V1ObjectMeta(name="base", namespace="default"),
-                status=k8s.V1PodStatus(container_statuses=[]),
-            ),
-        ),
-    )
-    def test_define_container_state_with_undefined_state(self, pod):
-        op = KubernetesPodOperatorAsync(task_id="test_task", name="test-pod", get_logs=True)
-        op.pod = pod
-        assert op.define_container_state() == ContainerState.UNDEFINED


### PR DESCRIPTION
Like the [SnowflakeOperatorAsync](https://github.com/astronomer/astronomer-providers/blob/b2dade827ad8425952b2f5313b6a2863cb0c3e5e/astronomer/providers/snowflake/operators/snowflake.py#L217), we try to verify if the submitted job has already completed before deferring it to prevent unnecessary deferring. This way, we can skip deferring the task if it has already been finished. 