### PR TITLE
Add test rc GitHub workflow

### DIFF
--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -5,20 +5,18 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
       rc_testing_branch_name:
+        # If a branch is given, the workflow will use it for deployment and testing.
+        # If no branch is provided, the workflow will create a new rc testing branch
+        # for deployment and testing.
         description: |
-          If a branch is given, the workflow will use it for deployment and testing.
-          If no branch is provided, the workflow will create a new rc testing branch
-          for deployment and testing.
-
-          * One and only one of rc_testing_branch_name and issue_url is required.
+          rc_testing_branch_name: existing testing branch
+          (One and only one of rc_testing_branch_name and issue_url is required.)
         required: false
         default: ''
       issue_url:
         description: |
-          The URL of the github issue that announce provider testing
-          (e.g., https://github.com/apache/airflow/issues/31322)
-
-          * One and only one of rc_testing_branch_name and issue_url is required.
+          issue_url: the URL of the github issue that announce provider testing
+          (One and only one of rc_testing_branch_name and issue_url is required.)
         required: false
       base_git_rev:
         description: 'The base git revision to test rc release'

--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -8,31 +8,91 @@ on:  # yamllint disable-line rule:truthy
         description: 'The rc provider packages (separate by ,) (e.g., apache-airflow-providers-amazon==8.0.0rc1,apache-airflow-providers-databricks==4.1.0rc1)'
         required: true
         default: ''
+      git_rev:
+        description: 'The base git revision to test rc release'
+        required: false
+        type: string
+        default: 'main'
 
 jobs:
-  test-rc-release:
+  create-branch-for-testing-rc-release:
     runs-on: 'ubuntu-20.04'
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
           ref: ${{ inputs.git_rev }}
+
+      - name: Install dev dependency
+        run: |
+          python3 -m pip install -U pip
+
+      - name: Create RC branch
+        id: create_rc_branch
+        run: |
+          $(eval current_timestamp := $(shell date +%Y-%m-%dT%H-%M-%S%Z))
+          echo "Current timestamp is" $(current_timestamp)
+          $(eval branch_name := "rc-test-$(current_timestamp)")
+          git checkout -b $(branch_name)
+          echo "rc_testing_branch_name=$(branch_name)" >> $GITHUB_OUTPUT
+
+      - name: Update project dependencies to use RC providers
+        run: |
+          echo "Updating setup.cfg with RC provider packages"
+          python3 dev/scripts/replace_dependencies.py ${{ input.rc_provider_packages }}
 
       - name: Setup Github Actions git user
         run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Actions"
 
-      - name: Test RC providers
+      - name: Commit changes and create a pull request
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          python3 -m pip install pip==23.1.2
-          make test-rc-deps \
-            RC_PROVIDER_PACKAGES="${{ inputs.rc_provider_packages }}" \
-            DOCKER_REGISTRY="${{ secrets.DOCKER_REGISTRY }}" \
-            ORGANIZATION_ID="${{ secrets.ORGANIZATION_ID }}" \
-            DEPLOYMENT_ID="${{ secrets.PROVIDER_INTEGRATION_TESTS_DEPLOYMENT_ID }}" \
-            ASTRONOMER_KEY_ID="${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_ID }}" \
-            ASTRONOMER_KEY_SECRET="${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_SECRET }}"
+          git add setup.cfg
+          git commit -m "Update setup.cfg to use RC provider packages"
+          git push origin ${{ steps.create_rc_branch.outputs.rc_testing_branch_name }}
+          gh pr create --base "main" --title "[DO NOT MERGE] Test RC provider packages" --fill
+          echo "git_rev=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+    outputs:
+      rc_testing_branch_name: ${{ steps.create_rc_branch.outputs.rc_testing_branch_name }}
+
+
+  deploy-rc-testing-branch-to-astro-cloud:
+    needs: create-branch-for-testing-rc-release
+    uses: ./.github/workflows/deploy-to-astro-cloud-reuse-wf.yaml
+    with:
+      git_rev: ${{ needs.create-branch-for-testing-rc-release.outpus.rc_testing_branch_name }}
+      environment_to_deploy: 'providers-integration-tests'
+    secrets:
+      docker_registry: ${{ secrets.DOCKER_REGISTRY }}
+      organization_id: ${{ secrets.ORGANIZATION_ID }}
+      deployment_id: ${{ secrets.PROVIDER_INTEGRATION_TESTS_DEPLOYMENT_ID }}
+      astronomer_key_id: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_ID }}
+      astronomer_key_secret: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_SECRET }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  wait-for-deployment-to-be-ready:
+    needs: deploy-rc-testing-branch-to-astro-cloud
+    runs-on: 'ubuntu-20.04'
+    steps:
+      - name: Sleep for 30 minutes
+        run: |
+          $(eval current_timestamp := $(shell date))
+          echo "Current timestamp is" $(current_timestamp)
+          echo "Sleeping for 1800 seconds (30 minutes) allowing the deployed image to be updated across all Airflow components.."
+          sleep 1800
+
+  trigger-master-dag:
+    runs-on: 'ubuntu-20.04'
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.create-branch-for-testing-rc-release.outpus.rc_testing_branch_name }}
+
+      - name: Sleep for 30 minutes
+        run: |
+          python3 dev/scripts/trigger_master_dag.py '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' ' $(ASTRONOMER_KEY_SECRET)'

--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -4,25 +4,47 @@ name: test-rc-release
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
+      rc_testing_branch_name:
+        description: |
+          If a branch is given, the workflow will use it for deployment and testing.
+          If no branch is provided, the workflow will create a new rc testing branch
+          for deployment and testing.
+
+          * One and only one of rc_testing_branch_name and issue_url is required.
+        required: false
+        default: ''
       issue_url:
         description: |
           The URL of the github issue that announce provider testing
           (e.g., https://github.com/apache/airflow/issues/31322)
-        required: true
-      git_rev:
+
+          * One and only one of rc_testing_branch_name and issue_url is required.
+        required: false
+      base_git_rev:
         description: 'The base git revision to test rc release'
         required: false
         type: string
         default: 'main'
 
 jobs:
-  create-branch-for-testing-rc-release:
+  validate-manual-input:
     runs-on: 'ubuntu-20.04'
+    steps:
+      - name: Validate user input
+        if: ${{ (inputs.rc_testing_branch_name != '') == (inputs.issue_url != '') }}
+        run: |
+          echo "One and only one of rc_testing_branch_name and issue_url is required."
+          exit 1
+
+  create-branch-for-testing-rc-release:
+    needs: validate-manual-input
+    runs-on: 'ubuntu-20.04'
+    if: ${{ inputs.issue_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.git_rev }}
+          ref: ${{ inputs.base_git_rev }}
 
       - name: Install dev dependency
         run: |
@@ -54,17 +76,41 @@ jobs:
           git add setup.cfg
           git commit -m "Update setup.cfg to use RC provider packages"
           git push origin ${{ steps.create_rc_branch.outputs.rc_testing_branch_name }}
-          gh pr create --base ${{ inputs.git_rev }} --title "[DO NOT MERGE] Test RC provider packages" --fill
+          gh pr create --base ${{ inputs.base_git_rev }} \
+                       --title "[DO NOT MERGE] Test RC provider packages" \
+                       --body "${{ inputs.issue_url }}" --fill
           echo "git_rev=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
     outputs:
       rc_testing_branch_name: ${{ steps.create_rc_branch.outputs.rc_testing_branch_name }}
 
+  export-rc-testing-branch-name:
+    needs: [validate-manual-input, create-branch-for-testing-rc-release]
+    if: |
+      always() &&
+      needs.create-branch-for-testing-rc-release.result == 'success' ||
+      (needs.validate-manual-input.result == 'success' && inputs.rc_testing_branch_name )
+    runs-on: 'ubuntu-20.04'
+    steps:
+      - name: export rc_testing_branch_name
+        id: export-rc-testing-branch-name-step
+        run: |
+          if [ "${{ inputs.rc_testing_branch_name }}" == "" ]; then
+            rc_testing_branch_name=${{ needs.create-branch-for-testing-rc-release.outputs.rc_testing_branch_name }}
+          else
+            rc_testing_branch_name=${{ inputs.rc_testing_branch_name }}
+          fi
+          echo "rc_testing_branch_name=$rc_testing_branch_name" >> $GITHUB_OUTPUT
+    outputs:
+      rc_testing_branch_name: ${{ steps.export-rc-testing-branch-name-step.outputs.rc_testing_branch_name }}
+
   deploy-rc-testing-branch-to-astro-cloud:
-    needs: create-branch-for-testing-rc-release
+    needs: export-rc-testing-branch-name
+    if: |
+      always() &&
+      needs.export-rc-testing-branch-name.result == 'success'
     uses: ./.github/workflows/deploy-to-astro-cloud-reuse-wf.yaml
     with:
-      git_rev: ${{ needs.create-branch-for-testing-rc-release.outputs.rc_testing_branch_name }}
+      git_rev: ${{ needs.export-rc-testing-branch-name.outputs.rc_testing_branch_name }}
       environment_to_deploy: 'providers-integration-tests'
     secrets:
       docker_registry: ${{ secrets.DOCKER_REGISTRY }}
@@ -76,17 +122,23 @@ jobs:
 
   wait-for-deployment-to-be-ready:
     needs: deploy-rc-testing-branch-to-astro-cloud
+    if: |
+      always() &&
+      needs.deploy-rc-testing-branch-to-astro-cloud.result == 'success'
     runs-on: 'ubuntu-20.04'
     steps:
       - name: Sleep for 30 minutes
         run: |
           echo "Current timestamp is" `date`
-          echo "Sleeping for 1800 seconds (30 minutes)
+          echo "Sleeping for 1800 seconds (30 minutes)"
           echo "allowing the deployed image to be updated across all Airflow components.."
           sleep 1800
 
   trigger-master-dag:
     needs: wait-for-deployment-to-be-ready
+    if: |
+      always() &&
+      needs.wait-for-deployment-to-be-ready.result == 'success'
     runs-on: 'ubuntu-20.04'
     steps:
       - name: checkout
@@ -95,12 +147,8 @@ jobs:
           ref: ${{ needs.create-branch-for-testing-rc-release.outputs.rc_testing_branch_name }}
 
       - name: Trigger master dag
-        env:
-          deployment_id: ${{ secrets.PROVIDER_INTEGRATION_TESTS_DEPLOYMENT_ID }}
-          astronomer_key_id: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_ID }}
-          astronomer_key_secret: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_SECRET }}
         run: |
           python3 dev/providers_rc_test_scripts/trigger_master_dag.py \
-            '$deployment_id' \
-            '$astronomer_key_id' \
-            '$astronomer_key_secret'
+            ${{ secrets.PROVIDER_INTEGRATION_TESTS_DEPLOYMENT_ID }} \
+            ${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_ID }} \
+            ${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_SECRET }}

--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -4,19 +4,19 @@ name: test-rc-release
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
-      rc_testing_branch_name:
+      rc_testing_branch:
         # If a branch is given, the workflow will use it for deployment and testing.
         # If no branch is provided, the workflow will create a new rc testing branch
         # for deployment and testing.
         description: |
-          rc_testing_branch_name: existing testing branch
-          (One and only one of rc_testing_branch_name and issue_url is required.)
+          rc_testing_branch: existing testing branch
+          (One and only one of rc_testing_branch and issue_url is required.)
         required: false
         default: ''
       issue_url:
         description: |
           issue_url: the URL of the github issue that announce provider testing
-          (One and only one of rc_testing_branch_name and issue_url is required.)
+          (One and only one of rc_testing_branch and issue_url is required.)
         required: false
       base_git_rev:
         description: 'The base git revision to test rc release'
@@ -29,9 +29,9 @@ jobs:
     runs-on: 'ubuntu-20.04'
     steps:
       - name: Validate user input
-        if: ${{ (inputs.rc_testing_branch_name != '') == (inputs.issue_url != '') }}
+        if: ${{ (inputs.rc_testing_branch != '') == (inputs.issue_url != '') }}
         run: |
-          echo "One and only one of rc_testing_branch_name and issue_url is required."
+          echo "One and only one of rc_testing_branch and issue_url is required."
           exit 1
 
   create-branch-for-testing-rc-release:
@@ -55,7 +55,7 @@ jobs:
           echo "Current timestamp is" $current_timestamp
           branch_name="rc-test-$current_timestamp"
           git checkout -b $branch_name
-          echo "rc_testing_branch_name=$branch_name" >> $GITHUB_OUTPUT
+          echo "rc_testing_branch=$branch_name" >> $GITHUB_OUTPUT
 
       - name: Update project dependencies to use RC providers
         run: |
@@ -73,33 +73,33 @@ jobs:
         run: |
           git add setup.cfg
           git commit -m "Update setup.cfg to use RC provider packages"
-          git push origin ${{ steps.create_rc_branch.outputs.rc_testing_branch_name }}
+          git push origin ${{ steps.create_rc_branch.outputs.rc_testing_branch }}
           gh pr create --base ${{ inputs.base_git_rev }} \
                        --title "[DO NOT MERGE] Test RC provider packages" \
                        --body "${{ inputs.issue_url }}" --fill
           echo "git_rev=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
     outputs:
-      rc_testing_branch_name: ${{ steps.create_rc_branch.outputs.rc_testing_branch_name }}
+      rc_testing_branch: ${{ steps.create_rc_branch.outputs.rc_testing_branch }}
 
   export-rc-testing-branch-name:
     needs: [validate-manual-input, create-branch-for-testing-rc-release]
     if: |
       always() &&
       needs.create-branch-for-testing-rc-release.result == 'success' ||
-      (needs.validate-manual-input.result == 'success' && inputs.rc_testing_branch_name )
+      (needs.validate-manual-input.result == 'success' && inputs.rc_testing_branch )
     runs-on: 'ubuntu-20.04'
     steps:
-      - name: export rc_testing_branch_name
+      - name: export rc_testing_branch
         id: export-rc-testing-branch-name-step
         run: |
-          if [ "${{ inputs.rc_testing_branch_name }}" == "" ]; then
-            rc_testing_branch_name=${{ needs.create-branch-for-testing-rc-release.outputs.rc_testing_branch_name }}
+          if [ "${{ inputs.rc_testing_branch }}" == "" ]; then
+            rc_testing_branch=${{ needs.create-branch-for-testing-rc-release.outputs.rc_testing_branch }}
           else
-            rc_testing_branch_name=${{ inputs.rc_testing_branch_name }}
+            rc_testing_branch=${{ inputs.rc_testing_branch }}
           fi
-          echo "rc_testing_branch_name=$rc_testing_branch_name" >> $GITHUB_OUTPUT
+          echo "rc_testing_branch=$rc_testing_branch" >> $GITHUB_OUTPUT
     outputs:
-      rc_testing_branch_name: ${{ steps.export-rc-testing-branch-name-step.outputs.rc_testing_branch_name }}
+      rc_testing_branch: ${{ steps.export-rc-testing-branch-name-step.outputs.rc_testing_branch }}
 
   deploy-rc-testing-branch-to-astro-cloud:
     needs: export-rc-testing-branch-name
@@ -108,7 +108,7 @@ jobs:
       needs.export-rc-testing-branch-name.result == 'success'
     uses: ./.github/workflows/deploy-to-astro-cloud-reuse-wf.yaml
     with:
-      git_rev: ${{ needs.export-rc-testing-branch-name.outputs.rc_testing_branch_name }}
+      git_rev: ${{ needs.export-rc-testing-branch-name.outputs.rc_testing_branch }}
       environment_to_deploy: 'providers-integration-tests'
     secrets:
       docker_registry: ${{ secrets.DOCKER_REGISTRY }}
@@ -142,7 +142,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ needs.create-branch-for-testing-rc-release.outputs.rc_testing_branch_name }}
+          ref: ${{ needs.create-branch-for-testing-rc-release.outputs.rc_testing_branch }}
 
       - name: Trigger master dag
         run: |

--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -4,10 +4,11 @@ name: test-rc-release
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
-      rc_provider_packages:
-        description: 'The rc provider packages (separate by ,) (e.g., apache-airflow-providers-amazon==8.0.0rc1,apache-airflow-providers-databricks==4.1.0rc1)'
+      issue_url:
+        description: |
+          The URL of the github issue that announce provider testing
+          (e.g., https://github.com/apache/airflow/issues/31322)
         required: true
-        default: ''
       git_rev:
         description: 'The base git revision to test rc release'
         required: false
@@ -25,21 +26,21 @@ jobs:
 
       - name: Install dev dependency
         run: |
-          python3 -m pip install -U pip
+          python3 -m pip install -r dev/providers_rc_test_scripts/requirements.txt
 
       - name: Create RC branch
         id: create_rc_branch
         run: |
-          $(eval current_timestamp := $(shell date +%Y-%m-%dT%H-%M-%S%Z))
-          echo "Current timestamp is" $(current_timestamp)
-          $(eval branch_name := "rc-test-$(current_timestamp)")
-          git checkout -b $(branch_name)
-          echo "rc_testing_branch_name=$(branch_name)" >> $GITHUB_OUTPUT
+          current_timestamp=`date +%Y-%m-%dT%H-%M-%S%Z`
+          echo "Current timestamp is" $current_timestamp
+          branch_name="rc-test-$current_timestamp"
+          git checkout -b $branch_name
+          echo "rc_testing_branch_name=$branch_name" >> $GITHUB_OUTPUT
 
       - name: Update project dependencies to use RC providers
         run: |
           echo "Updating setup.cfg with RC provider packages"
-          python3 dev/scripts/replace_dependencies.py ${{ input.rc_provider_packages }}
+          python3 dev/providers_rc_test_scripts/replace_dependencies.py --issue-url ${{ inputs.issue_url }}
 
       - name: Setup Github Actions git user
         run: |
@@ -53,18 +54,17 @@ jobs:
           git add setup.cfg
           git commit -m "Update setup.cfg to use RC provider packages"
           git push origin ${{ steps.create_rc_branch.outputs.rc_testing_branch_name }}
-          gh pr create --base "main" --title "[DO NOT MERGE] Test RC provider packages" --fill
+          gh pr create --base ${{ inputs.git_rev }} --title "[DO NOT MERGE] Test RC provider packages" --fill
           echo "git_rev=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
     outputs:
       rc_testing_branch_name: ${{ steps.create_rc_branch.outputs.rc_testing_branch_name }}
 
-
   deploy-rc-testing-branch-to-astro-cloud:
     needs: create-branch-for-testing-rc-release
     uses: ./.github/workflows/deploy-to-astro-cloud-reuse-wf.yaml
     with:
-      git_rev: ${{ needs.create-branch-for-testing-rc-release.outpus.rc_testing_branch_name }}
+      git_rev: ${{ needs.create-branch-for-testing-rc-release.outputs.rc_testing_branch_name }}
       environment_to_deploy: 'providers-integration-tests'
     secrets:
       docker_registry: ${{ secrets.DOCKER_REGISTRY }}
@@ -80,19 +80,27 @@ jobs:
     steps:
       - name: Sleep for 30 minutes
         run: |
-          $(eval current_timestamp := $(shell date))
-          echo "Current timestamp is" $(current_timestamp)
-          echo "Sleeping for 1800 seconds (30 minutes) allowing the deployed image to be updated across all Airflow components.."
+          echo "Current timestamp is" `date`
+          echo "Sleeping for 1800 seconds (30 minutes)
+          echo "allowing the deployed image to be updated across all Airflow components.."
           sleep 1800
 
   trigger-master-dag:
+    needs: wait-for-deployment-to-be-ready
     runs-on: 'ubuntu-20.04'
     steps:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ needs.create-branch-for-testing-rc-release.outpus.rc_testing_branch_name }}
+          ref: ${{ needs.create-branch-for-testing-rc-release.outputs.rc_testing_branch_name }}
 
-      - name: Sleep for 30 minutes
+      - name: Trigger master dag
+        env:
+          deployment_id: ${{ secrets.PROVIDER_INTEGRATION_TESTS_DEPLOYMENT_ID }}
+          astronomer_key_id: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_ID }}
+          astronomer_key_secret: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_SECRET }}
         run: |
-          python3 dev/scripts/trigger_master_dag.py '$(DEPLOYMENT_ID)' '$(ASTRONOMER_KEY_ID)' ' $(ASTRONOMER_KEY_SECRET)'
+          python3 dev/providers_rc_test_scripts/trigger_master_dag.py \
+            '$deployment_id' \
+            '$astronomer_key_id' \
+            '$astronomer_key_secret'

--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -1,0 +1,38 @@
+---
+name: test-rc-release
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      rc_provider_packages:
+        description: 'The rc provider packages (separate by ,) (e.g., apache-airflow-providers-amazon==8.0.0rc1,apache-airflow-providers-databricks==4.1.0rc1)'
+        required: true
+        default: ''
+
+jobs:
+  test-rc-release:
+    runs-on: 'ubuntu-20.04'
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_rev }}
+
+      - name: Setup Github Actions git user
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Actions"
+
+      - name: Test RC providers
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 -m pip install pip==23.1.2
+          make test-rc-deps \
+            RC_PROVIDER_PACKAGES="${{ inputs.rc_provider_packages }}" \
+            DOCKER_REGISTRY="${{ secrets.DOCKER_REGISTRY }}" \
+            ORGANIZATION_ID="${{ secrets.ORGANIZATION_ID }}" \
+            DEPLOYMENT_ID="${{ secrets.PROVIDER_INTEGRATION_TESTS_DEPLOYMENT_ID }}" \
+            ASTRONOMER_KEY_ID="${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_ID }}" \
+            ASTRONOMER_KEY_SECRET="${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_SECRET }}"


### PR DESCRIPTION
Automate the RC testing process through the GitHub Actions workflow.

## Input
It can accept one of the following two arguments.

* rc_testing_branch: existing rc testing branch (e.g., `rc-test-2023-05-20T05-10-46UTC`)
* issue_url: the URL to the airflow issue that announces rc testing

![image](https://github.com/astronomer/astronomer-providers/assets/5144808/cfa321f9-adef-47f3-9634-a8892e245908)

## Workflow steps

![image](https://github.com/astronomer/astronomer-providers/assets/5144808/a4558806-4397-414b-a193-82dc424a23e9)
