### PR TITLE
ci(dev/scripts): use pip internal to parse RC_PROVIDER_PACKAGES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ run-local-lineage-server: ## Run flask based local Lineage server
 
 test-rc-deps: ## Test providers RC by building an image with given dependencies and running the master DAG
 	@which gh > /dev/null || (echo "ERROR: Github CLI is required. Refer https://github.com/cli/cli for installation."; exit 1)
+	python3 -m pip install -U pip
 	git checkout main && git pull origin main
 	$(eval current_timestamp := $(shell date +%Y-%m-%dT%H-%M-%S%Z))
 	echo "Current timestamp is" $(current_timestamp)


### PR DESCRIPTION
According to the discussion with @pankajkoti yesterday, when testing [apache-airflow-providers-cncf-kubernetes](https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/), we cannot use the pinned version but need to use the [source distribution](https://files.pythonhosted.org/packages/a9/59/fcd15c3d3b9b26bab4df980f59b1e86769bf7b18edbd18afca5db973b746/apache-airflow-providers-cncf-kubernetes-6.1.0.tar.gz) instead. However, our current script does not support parsing this kind of string. This PR replace the original string manipulation and uses pip internal to parse the package string instead