### PR TITLE
build(setup.cfg): remove protobuf constraint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,6 @@ google =
     apache-airflow-providers-google>=8.1.0
     gcloud-aio-storage
     gcloud-aio-bigquery
-    protobuf<=3.20.0  # Bigquery provider isn't compatible with it. Details in https://github.com/apache/airflow/commit/25a9ae3b2eec85dfd500b0a921045fc95ab8ffd6
 http =
     apache-airflow-providers-http
 microsoft.azure =
@@ -137,7 +136,6 @@ all =
     impyla
     openlineage-airflow>=0.12.0
     paramiko
-    protobuf<=3.20.0  # Bigquery provider isn't compatible with it. Details in https://github.com/apache/airflow/commit/25a9ae3b2eec85dfd500b0a921045fc95ab8ffd6
     snowflake-sqlalchemy>=1.4.4  # Temporary solution for https://github.com/astronomer/astronomer-providers/issues/958, we should pin apache-airflow-providers-snowflake version after it pins this package to great than or equal to 1.4.4.
 
 [options.packages.find]


### PR DESCRIPTION
dependency conflict between `protobuf<=3.20.0` and `google-ads>=20.0.0` after we upgrade google provider to [10.1.0rc2](https://pypi.org/project/apache-airflow-providers-google/10.1.0rc2)

Close: #1119