### PR TITLE
Test constraints are generated on release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,14 @@ version_tag_only: &version_tag_only
     branches:
       ignore: /.*/
 
+# Run jobs only for main branch and release branches
+main_and_release_branches: &main_and_release_branches
+  filters:
+    branches:
+      only:
+        - main
+        - /^release\b.*$/
+
 workflows:
   test:
     jobs:
@@ -31,7 +39,7 @@ workflows:
             parameters:
               python_version: ["3.8", "3.9", "3.10"]
               airflow_version: ["2.3.4", "2.4.2", "2.5.3"]
-          <<: *all_branches_and_version_tag
+          <<: *main_and_release_branches
       - build-docs:
           <<: *all_branches_and_version_tag
       - test:

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -1,6 +1,15 @@
 How to release?
 ===============
 
+Create a new release branch from main
+-------------------------------------
+
+Create a new release branch from ``main`` branch with the name ``release-<version>``.
+e.g. If you want to release version ``1.17.6``, you can create a new branch called ``release-1-17-6`` cut from ``main`` branch.
+
+Note: It is important to prefix your release branch name with ``release-``. This is because we run a CircleCI job to
+generate the constraints files only on such branches and the ``main`` branch.
+
 Decide on the new version number
 --------------------------------
 
@@ -38,6 +47,15 @@ make ASTRO_PROVIDER_VERSION=<RELEASE_VERSION> bump-version
 ```
 
 Note: ```RELEASE_VERSION``` is the software version you want to release.
+
+Compare the commits introduced since the last release to aid building the CHANGELOG
+-----------------------------------------------------------------------------------
+
+You can use the following link to compare the commits introduced since the last release (e.g. 1.15.4)
+
+```https://github.com/astronomer/astronomer-providers/compare/1.15.4...main```
+
+Note: Make sure to replace the last release version in the above URL
 
 Write the changelog
 -------------------


### PR DESCRIPTION
This PR uses the branch `release-dummy-version` which was cut
from the branch `selective-constraints-generation` used for PR #1129 
to verify that the `generate-constraints` job is run on release branches having
names starting with the `release` prefix