### PR TITLE
docs(example_dag): set trigger_rule to all_done for the following DAG of EmrCreateJobFlowOperator

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
@@ -96,6 +96,7 @@ with DAG(
         job_flow_id=create_job_flow.output,  # type: ignore[arg-type]
         steps=SPARK_STEPS,
         aws_conn_id=AWS_CONN_ID,
+        trigger_rule="all_done",
     )
     # [END howto_operator_emr_add_steps]
 

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -312,7 +312,9 @@ with DAG(
 
     # [START describe_created_cluster]
     describe_created_cluster = PythonOperator(
-        task_id="describe_created_cluster", python_callable=get_cluster_details
+        task_id="describe_created_cluster",
+        python_callable=get_cluster_details,
+        trigger_rule="all_done",
     )
     # [END describe_created_cluster]
 

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -278,7 +278,9 @@ with DAG(
 
     # [START describe_created_cluster]
     describe_created_cluster = PythonOperator(
-        task_id="describe_created_cluster", python_callable=get_cluster_details
+        task_id="describe_created_cluster",
+        python_callable=get_cluster_details,
+        trigger_rule="all_done",
     )
     # [END describe_created_cluster]
 


### PR DESCRIPTION
EmrCreateJobFlowOperator now fails due to https://github.com/apache/airflow/issues/31480 and https://github.com/apache/airflow/issues/31322, but the cluster seems to work fine.

Closes: #1120, #1121, #1123