### PR TITLE
Test rc branch workflow quick fix

### DIFF
--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -10,13 +10,13 @@ on:  # yamllint disable-line rule:truthy
         # for deployment and testing.
         description: |
           rc_testing_branch: existing testing branch
-          (Either rc_testing_branch or issue_url is required. You cannot give both.)
+          (Either rc_testing_branch or issue_url is required, and you cannot give both.)
         required: false
         default: ''
       issue_url:
         description: |
           issue_url: the GitHub issue URL that tracks the status of Providers release
-          (Either rc_testing_branch or issue_url is required. You cannot give both.)
+          (Either rc_testing_branch or issue_url is required, and you cannot give both.)
         required: false
       base_git_rev:
         description: 'The base git revision to test Providers RCs'
@@ -31,7 +31,7 @@ jobs:
       - name: Validate user input
         if: ${{ (inputs.rc_testing_branch != '') == (inputs.issue_url != '') }}
         run: |
-          echo "Either rc_testing_branch or issue_url is required. You cannot give both."
+          echo "Either rc_testing_branch or issue_url is required, and you cannot give both."
           exit 1
 
   create-branch-for-testing-rc-release:

--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -10,16 +10,16 @@ on:  # yamllint disable-line rule:truthy
         # for deployment and testing.
         description: |
           rc_testing_branch: existing testing branch
-          (One and only one of rc_testing_branch and issue_url is required.)
+          (Either rc_testing_branch or issue_url is required. You cannot give both.)
         required: false
         default: ''
       issue_url:
         description: |
-          issue_url: the URL of the github issue that announce provider testing
-          (One and only one of rc_testing_branch and issue_url is required.)
+          issue_url: the GitHub issue URL that tracks the status of Providers release
+          (Either rc_testing_branch or issue_url is required. You cannot give both.)
         required: false
       base_git_rev:
-        description: 'The base git revision to test rc release'
+        description: 'The base git revision to test Providers RCs'
         required: false
         type: string
         default: 'main'
@@ -31,7 +31,7 @@ jobs:
       - name: Validate user input
         if: ${{ (inputs.rc_testing_branch != '') == (inputs.issue_url != '') }}
         run: |
-          echo "One and only one of rc_testing_branch and issue_url is required."
+          echo "Either rc_testing_branch or issue_url is required. You cannot give both."
           exit 1
 
   create-branch-for-testing-rc-release:

--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -142,7 +142,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ needs.create-branch-for-testing-rc-release.outputs.rc_testing_branch }}
+          ref: ${{ needs.export-rc-testing-branch-name.outputs.rc_testing_branch }}
 
       - name: Trigger master dag
         run: |

--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -29,7 +29,9 @@ jobs:
     runs-on: 'ubuntu-20.04'
     steps:
       - name: Validate user input
-        if: ${{ (inputs.rc_testing_branch != '') == (inputs.issue_url != '') }}
+        if: |
+           (inputs.rc_testing_branch == '' && inputs.issue_url == '') ||
+           (inputs.rc_testing_branch != '' && inputs.issue_url != '')
         run: |
           echo "Either rc_testing_branch or issue_url is required, and you cannot give both."
           exit 1


### PR DESCRIPTION
Address comments on https://github.com/astronomer/astronomer-providers/pull/1107

* reword test-rc-branch workflow descriptions
* use export-rc-testing-branch-name output to checkout in trigger-master-dag