### PR TITLE
Optimize deployment workflow

### DIFF
--- a/.github/workflows/deploy-integration-tests.yaml
+++ b/.github/workflows/deploy-integration-tests.yaml
@@ -86,12 +86,21 @@ jobs:
     needs: deploy-to-providers-integration-tests-on-KE
     runs-on: 'ubuntu-20.04'
     steps:
-      - name: Sleep for 2 hours 30 minutes
+      - name: Sleep and wait for the deployment to be ready
         run: |
+          if [ "${{ inputs.environment_to_deploy }}" == "providers-integration-tests-on-KE" ]; then
+            # This means that only KE deployment was triggered
+            # and hence we do not need to wait for CE deployment's master DAG to complete.
+            # We just need to wait for 30 minutes for the deployment to be reflected.
+            sleep_time=1800
+          else
+            # 3 hours
+            sleep_time=10800
+          fi
           echo "Current timestamp is" `date`
-          echo "Sleeping for 9000 seconds (2 hours 30 minutes)"
+          echo "Sleeping for $sleep_time seconds"
           echo "allowing the deployed image to be updated across all Airflow components.."
-          sleep 9000
+          sleep $sleep_time
 
   trigger-providers-integration-tests-on-KE-master-dag:
     if: github.event_name == 'schedule'

--- a/.github/workflows/deploy-integration-tests.yaml
+++ b/.github/workflows/deploy-integration-tests.yaml
@@ -36,7 +36,7 @@ jobs:
       astronomer_key_secret: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_SECRET }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  wait-for-providers-integration-tests-to-be-ready:
+  wait-for-deployment-to-be-ready-and-trigger-master-dag-for-providers-integration-tests:
     if: github.event_name == 'schedule'
     needs: deploy-to-providers-integration-tests
     runs-on: 'ubuntu-20.04'
@@ -48,11 +48,6 @@ jobs:
           echo "allowing the deployed image to be updated across all Airflow components.."
           sleep 1800
 
-  trigger-providers-integration-tests-master-dag:
-    if: github.event_name == 'schedule'
-    needs: wait-for-providers-integration-tests-to-be-ready
-    runs-on: 'ubuntu-20.04'
-    steps:
       - name: checkout
         uses: actions/checkout@v3
         with:
@@ -81,7 +76,7 @@ jobs:
       astronomer_key_secret: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ON_KE_ASTRONOMER_KEY_SECRET }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  wait-for-providers-integration-tests-on-KE-to-be-ready:
+  wait-for-deployment-to-be-ready-and-trigger-master-dag-for-providers-integration-tests-on-KE:
     if: github.event_name == 'schedule'
     needs: deploy-to-providers-integration-tests-on-KE
     runs-on: 'ubuntu-20.04'
@@ -102,11 +97,6 @@ jobs:
           echo "allowing the deployed image to be updated across all Airflow components.."
           sleep $sleep_time
 
-  trigger-providers-integration-tests-on-KE-master-dag:
-    if: github.event_name == 'schedule'
-    needs: wait-for-providers-integration-tests-on-KE-to-be-ready
-    runs-on: 'ubuntu-20.04'
-    steps:
       - name: checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -120,7 +120,7 @@ jobs:
       astronomer_key_secret: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_SECRET }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  wait-for-deployment-to-be-ready:
+  wait-for-deployment-to-be-ready-and-trigger-master-dag:
     needs: deploy-rc-testing-branch-to-astro-cloud
     if: |
       always() &&
@@ -134,13 +134,6 @@ jobs:
           echo "allowing the deployed image to be updated across all Airflow components.."
           sleep 1800
 
-  trigger-master-dag:
-    needs: wait-for-deployment-to-be-ready
-    if: |
-      always() &&
-      needs.wait-for-deployment-to-be-ready.result == 'success'
-    runs-on: 'ubuntu-20.04'
-    steps:
       - name: checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
* reduce the wait time to 30 minutes for providers-integration-tests-on-KE if providers-integration-tests is not deployed
* merge wait for deployment and trigger master dag job into the same job but different step


Closes: #1136 