### PR TITLE
add loguri to EmrCreateJobFlowOperator for bypassing https://github.com/apache/airflow/issues/31480

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
@@ -54,7 +54,7 @@ JOB_FLOW_OVERRIDES = {
     },
     "JobFlowRole": JOB_FLOW_ROLE,
     "ServiceRole": SERVICE_ROLE,
-    "LogUri": "s3://example_emr_sensor_cluster/"
+    "LogUri": "s3://example_emr_sensor_cluster/",
 }
 
 DEFAULT_ARGS = {

--- a/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_sensor.py
@@ -54,6 +54,7 @@ JOB_FLOW_OVERRIDES = {
     },
     "JobFlowRole": JOB_FLOW_ROLE,
     "ServiceRole": SERVICE_ROLE,
+    "LogUri": "s3://example_emr_sensor_cluster/"
 }
 
 DEFAULT_ARGS = {

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -80,7 +80,7 @@ JOB_FLOW_OVERRIDES = {
     "Steps": [],
     "JobFlowRole": JOB_FLOW_ROLE,
     "ServiceRole": SERVICE_ROLE,
-    "LogUri": "s3://example_emr_sensor_cluster/"
+    "LogUri": "s3://example_emr_sensor_cluster/",
 }
 
 

--- a/astronomer/providers/apache/hive/example_dags/example_hive.py
+++ b/astronomer/providers/apache/hive/example_dags/example_hive.py
@@ -80,6 +80,7 @@ JOB_FLOW_OVERRIDES = {
     "Steps": [],
     "JobFlowRole": JOB_FLOW_ROLE,
     "ServiceRole": SERVICE_ROLE,
+    "LogUri": "s3://example_emr_sensor_cluster/"
 }
 
 

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -77,6 +77,7 @@ JOB_FLOW_OVERRIDES = {
     "Steps": [],
     "JobFlowRole": JOB_FLOW_ROLE,
     "ServiceRole": SERVICE_ROLE,
+    "LogUri": "s3://example_emr_sensor_cluster/"
 }
 
 

--- a/astronomer/providers/apache/livy/example_dags/example_livy.py
+++ b/astronomer/providers/apache/livy/example_dags/example_livy.py
@@ -77,7 +77,7 @@ JOB_FLOW_OVERRIDES = {
     "Steps": [],
     "JobFlowRole": JOB_FLOW_ROLE,
     "ServiceRole": SERVICE_ROLE,
-    "LogUri": "s3://example_emr_sensor_cluster/"
+    "LogUri": "s3://example_emr_sensor_cluster/",
 }
 
 


### PR DESCRIPTION
Note that this loguri is a fake s3 bucket which doesn't not exist and used only for bypassing this issue

Closes: #1120, #1121, #1123