### PR TITLE
Include apache-airflow-providers-slack in dev image

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -14,4 +14,5 @@ COPY pyproject.toml ${AIRFLOW_HOME}/astronomer_providers/pyproject.toml
 
 
 RUN pip install -e "${AIRFLOW_HOME}/astronomer_providers[all,tests,mypy]"
+RUN pip install apache-airflow-providers-slack
 USER astro


### PR DESCRIPTION
Currently, the master DAG does not load locally as it complains about importing the slack provider which is not installed in the image; this provider is needed by the report generation task in the master DAG. The commit installs the apache-airflow-providers-slack in the local dev image so that we could also run the master_dag locally.