### PR TITLE
Fix dag trigger script

### DIFF
--- a/dev/integration_test_scripts/trigger_dag.py
+++ b/dev/integration_test_scripts/trigger_dag.py
@@ -51,9 +51,9 @@ def trigger_dag_runs(dag_ids: list[str], deployment_id: str, bearer_token: str) 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("deployment_id", help="ID of the deployment in Astro Cloud")
-    parser.add_argument("astronomer_key_id", help="Key ID of the Astro Cloud deployment")
-    parser.add_argument("astronomer_key_secret", help="Key secret of the Astro Cloud deployment")
+    parser.add_argument("deployment_id", help="ID of the deployment in Astro Cloud", type=str)
+    parser.add_argument("astronomer_key_id", help="Key ID of the Astro Cloud deployment", type=str)
+    parser.add_argument("astronomer_key_secret", help="Key secret of the Astro Cloud deployment", type=str)
     parser.add_argument(
         "--dag-ids",
         help=(
@@ -61,6 +61,8 @@ if __name__ == "__main__":
             " e.g. 'example_async_adf_run_pipeline, example_async_batch'"
         ),
         default="example_master_dag",
+        # fallback to "example_master_dag" if empty string "" is provided
+        type=lambda dag_ids: dag_ids if dag_ids else "example_master_dag",
     )
 
     args = parser.parse_args()

--- a/dev/integration_test_scripts/trigger_dag.py
+++ b/dev/integration_test_scripts/trigger_dag.py
@@ -43,10 +43,20 @@ def trigger_dag_runs(dag_ids: list[str], deployment_id: str, bearer_token: str) 
         "Cache-Control": "no-cache",
         "Authorization": f"Bearer {bearer_token}",
     }
+    failed_dag_ids: list[str] = []
     for dag_id in dag_ids:
         dag_trigger_url = f"{integration_tests_deployment_url}/api/v1/dags/{dag_id}/dagRuns"
         response = requests.post(dag_trigger_url, headers=headers, json={})
+
+        if response.status_code != 200:
+            failed_dag_ids.append(dag_id)
+
         logging.info(f"Response for {dag_id} DAG trigger is %s", response.json())
+
+    if failed_dag_ids:
+        for dag_id in failed_dag_ids:
+            logging.error(f"Failed to run DAG {dag_id}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What's failed?

`dev/integration_test_scripts/trigger_dag.py` trigger DAG with empty id "" through "POST /diornlqe/api/v1/dags//dagRuns" in [ deploy-integration-tests-to-astro-cloud #217 ](https://github.com/astronomer/astronomer-providers/actions/runs/5125297245/jobs/9223476855#step:4:13). This is due to https://github.com/astronomer/astronomer-providers/blob/f05c7ceaea7a5f076e202d3e086d7dc2a5534846/dev/integration_test_scripts/trigger_dag.py#L63 does not handle empty string and take it as a valid value. 

We get error message `INFO:root:Response for  DAG trigger is {'detail': 'The method is not allowed for the requested URL.', 'status': 405, 'title': 'Method Not Allowed', 'type': 'about:blank'}` without failing.

## What's the issue
Thus, we have 2 issue that needs to fix.

1. `dev/integration_test_scripts/trigger_dag.py` should take "" as invalid input and fallback to the default value
2. If some DAG trigger requests do not come with a 200 status code, we should return a failure notification.

Regarding point 1, the reason why I want to keep the command as `python3 dev/integration_test_scripts/trigger_dag.py ... --dag-id ""` instead of `python3 dev/integration_test_scripts/trigger_dag.py ...` is because it can simplify our workflow implementation. With it, we don't need to compare whether input is "" to decide whether to add `--dag-id` in the workflow

https://github.com/astronomer/astronomer-providers/blob/f05c7ceaea7a5f076e202d3e086d7dc2a5534846/.github/workflows/deploy-integration-tests.yaml#L123

## What's changed
* fallback to example_master_dag for --dag-ids when empty string is provided
* raise an error if some dags are not triggered successfully
