### PR TITLE
Terminate running virtual clusters launched for EMR containers

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -30,7 +30,8 @@ RUN apt-get update -y \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
     apt-get update -y && \
     apt-get install google-cloud-sdk -y && \
-    apt-get install google-cloud-sdk-gke-gcloud-auth-plugin -y
+    apt-get install google-cloud-sdk-gke-gcloud-auth-plugin -y \
+    apt-get install jq -y \
 
 # Set Hive and Hadoop versions.
 ENV HIVE_LIBRARY_VERSION=hive-2.3.9

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get install -y --no-install-recommends \
         build-essential \
         libsasl2-2 \
         libsasl2-dev \
-        libsasl2-modules
+        libsasl2-modules \
+        jq
 
 COPY setup.cfg ${AIRFLOW_HOME}/astronomer_providers/setup.cfg
 COPY pyproject.toml ${AIRFLOW_HOME}/astronomer_providers/pyproject.toml


### PR DESCRIPTION
It has been observed that sometimes the virtual clusters launched 
by EMR containers are not cleaned up. It is not possible to nuke 
them using AWS nuke as this resource type is not exposed, 
additionally, it has not been exposed to delete them in the 
AWS console too. The only way to delete them is using AWS CLI 
and hence we're adding a task in the nuke DAG to delete those 
using AWS CLI.