### PR TITLE
Update the dev AWS Dockerfile to support all AWS example DAGs

### DIFF
--- a/dev/Dockerfile.aws
+++ b/dev/Dockerfile.aws
@@ -1,6 +1,8 @@
 ARG IMAGE_NAME
 FROM ${IMAGE_NAME}
 
+ENV AWS_NUKE_VERSION=v2.17.0
+
 USER root
 RUN apt-get update -y && apt-get install -y git
 RUN apt-get install -y --no-install-recommends \
@@ -8,12 +10,29 @@ RUN apt-get install -y --no-install-recommends \
         libsasl2-2 \
         libsasl2-dev \
         libsasl2-modules \
-        unzip
+        unzip \
+        wget \
+        jq
 
 # install AWS CLI
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \
     && ./aws/install;
+
+# install AWS nuke
+RUN wget --quiet  \
+    "https://github.com/rebuy-de/aws-nuke/releases/download/${AWS_NUKE_VERSION}/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz" \
+    && tar -xzvf aws-nuke-${AWS_NUKE_VERSION}-linux-amd64.tar.gz -C /usr/local/bin \
+    && mv /usr/local/bin/aws-nuke-${AWS_NUKE_VERSION}-linux-amd64 /usr/local/bin/aws-nuke
+
+# install eksctl
+RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp \
+    && mv /tmp/eksctl /usr/local/bin
+
+# install kubectl
+RUN curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03-09/bin/linux/amd64/kubectl \
+    && chmod +x ./kubectl \
+    && mv ./kubectl /usr/local/bin
 
 COPY setup.cfg ${AIRFLOW_HOME}/astronomer_providers/setup.cfg
 COPY pyproject.toml ${AIRFLOW_HOME}/astronomer_providers/pyproject.toml


### PR DESCRIPTION
We use the dev/Dockerfile.aws to build images locally for testing 
AWS example DAGs. Images built using this file currently does not 
support running example DAGs like the nuke dag, emr_eks_pi_job_dag 
due to missing dependencies. The commit adds the missing dependencies. 
Additionally, since most of the developers are on ARM64 architectures, 
it makes sense to update the AWS CLI installation to refer to the aarch64 binary 
instead of the amd64; so we're also changing that in the commit.