### PR TITLE
ci(integration-tests): fix installation breakline typo

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -16,8 +16,9 @@ RUN apt-add-repository 'deb http://archive.debian.org/debian stretch main' \
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 
 RUN apt-get update -y \
-    && apt-get install -y git \
-    && apt-get install -y unzip \
+    && apt-get install -y \
+        git \
+        unzip \
     && apt-get install -y --no-install-recommends \
         build-essential \
         libsasl2-2 \
@@ -25,13 +26,14 @@ RUN apt-get update -y \
         libsasl2-modules \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && apt-get install -y curl gnupg && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
-    apt-get update -y && \
-    apt-get install google-cloud-sdk -y && \
-    apt-get install google-cloud-sdk-gke-gcloud-auth-plugin -y \
-    apt-get install jq -y \
+    && apt-get install -y curl gnupg \
+    && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - \
+    && apt-get update -y \
+    && apt-get install -y \
+        google-cloud-sdk \
+        google-cloud-sdk-gke-gcloud-auth-plugin \
+        jq
 
 # Set Hive and Hadoop versions.
 ENV HIVE_LIBRARY_VERSION=hive-2.3.9


### PR DESCRIPTION
We introduce an error https://github.com/astronomer/astronomer-providers/pull/1151/files#diff-ffdd07a66f69f4d478483b9856c4b5442796955f3d624738b5b9c981905f204dR33 due to some typos