### PR TITLE
Remove AWS nuke DAG from master DAG & accept DAG schedule param 

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -238,18 +238,6 @@ with DAG(
     dag_run_ids.extend(ids)
     chain(*dbt_trigger_tasks)
 
-    end_test = DummyOperator(
-        task_id="end_test",
-        trigger_rule="all_success",
-    )
-
-    aws_nuke_task_info = [
-        {"aws_nuke_dag": "example_aws_nuke"},
-    ]
-    aws_nuke_trigger_tasks, ids = prepare_dag_dependency(aws_nuke_task_info, "{{ ds }}")
-    dag_run_ids.extend(ids)
-    chain(*aws_nuke_trigger_tasks)
-
     report = PythonOperator(
         task_id="get_report",
         python_callable=get_report,
@@ -303,4 +291,4 @@ with DAG(
         dbt_trigger_tasks[-1],
     ]
 
-    last_task >> end_test >> aws_nuke_trigger_tasks[0] >> report >> end
+    last_task >> report >> end

--- a/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
@@ -23,7 +23,8 @@ SLACK_USERNAME = os.getenv("SLACK_USERNAME", "airflow_app")
 SLACK_WEBHOOK_CONN = os.getenv("SLACK_WEBHOOK_CONN", "http_slack")
 
 
-def generate_task_report(**context):
+def generate_task_report(**context: Any):
+    """Generate a report of the task statuses for the DAG run and send it to configured Slack channel for alerts."""
     dag_run = context["dag_run"]
     run_id = dag_run.run_id
 
@@ -79,7 +80,7 @@ def generate_task_report(**context):
 
 
 def check_dag_status(**kwargs: Any) -> None:
-    """Raises an exception if any of the DAG's tasks failed and as a result marking the DAG failed."""
+    """Raise an exception if any of the DAG's tasks failed and as a result marking the DAG failed."""
     for task_instance in kwargs["dag_run"].get_task_instances():
         if (
             task_instance.current_state() != State.SUCCESS

--- a/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
@@ -1,16 +1,92 @@
 """DAG to nuke AWS resources."""
+import logging
 import os
 from datetime import datetime, timedelta
+from typing import Any
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator
+from airflow.operators.python import PythonOperator
+from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
+from airflow.utils.state import State
+from airflow.utils.trigger_rule import TriggerRule
 
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "**********")
-AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "***********")
-AWS_DEFAULT_REGION = os.getenv("AWS_DEFAULT_REGION", "us-east-2")
 AWS_CONN_ID = os.getenv("ASTRO_AWS_CONN_ID", "aws_default")
+AWS_DEFAULT_REGION = os.getenv("AWS_DEFAULT_REGION", "us-east-2")
+AWS_NUKE_DAG_SCHEDULE = os.getenv("AWS_NUKE_DAG_SCHEDULE", None)
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "***********")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
+SLACK_CHANNEL = os.getenv("SLACK_CHANNEL", "#provider-alert")
+SLACK_USERNAME = os.getenv("SLACK_USERNAME", "airflow_app")
+SLACK_WEBHOOK_CONN = os.getenv("SLACK_WEBHOOK_CONN", "http_slack")
+
+
+def generate_task_report(**context):
+    dag_run = context["dag_run"]
+    run_id = dag_run.run_id
+
+    report = f"*Report for `AWS nuke` DAG run ID: `{run_id}`*\n\n"
+
+    airflow_version = context["ti"].xcom_pull(task_ids="get_airflow_version")
+    report += f"*Airflow version*: `{airflow_version}`\n"
+    airflow_executor = context["ti"].xcom_pull(task_ids="get_airflow_executor")
+    report += f"*Airflow executor*: `{airflow_executor}`\n\n"
+
+    dag = context["dag"]
+    ordered_task_ids = [task.task_id for task in dag.topological_sort()]
+
+    # Retrieve task instances for the DagRun
+    task_instances = dag_run.get_task_instances()
+
+    # Sort the task instances based on the ordered task IDs
+    ordered_task_instances = sorted(task_instances, key=lambda ti: ordered_task_ids.index(ti.task_id))
+
+    # Iterate over each task instance and append its status to the report
+    for task_instance in ordered_task_instances:
+        task_id = task_instance.task_id
+        if task_id in (
+            "start",
+            "get_airflow_version",
+            "get_airflow_executor",
+            "generate_report",
+            "dag_final_status",
+        ):
+            continue
+        task_status = task_instance.current_state()
+        task_status_icon = ":black_circle:"
+        if task_status == State.SUCCESS:
+            task_status_icon = ":large_green_circle:"
+        elif task_status == State.FAILED:
+            task_status_icon = ":red_circle:"
+        elif task_status == State.UPSTREAM_FAILED:
+            task_status_icon = ":large_orange_circle:"
+        report += f"{task_status_icon} {task_id} - {task_status} \n"
+
+    try:
+        # Send the report as a Slack message
+        SlackWebhookOperator(
+            task_id="send_slack_report",
+            http_conn_id=SLACK_WEBHOOK_CONN,
+            message=report,
+            channel=SLACK_CHANNEL,
+            username=SLACK_USERNAME,
+        ).execute(context=None)
+    except Exception as exception:
+        logging.exception("Error occur while sending slack alert.")
+        raise exception
+
+
+def check_dag_status(**kwargs: Any) -> None:
+    """Raises an exception if any of the DAG's tasks failed and as a result marking the DAG failed."""
+    for task_instance in kwargs["dag_run"].get_task_instances():
+        if (
+            task_instance.current_state() != State.SUCCESS
+            and task_instance.task_id != kwargs["task_instance"].task_id
+        ):
+            raise Exception(f"Task {task_instance.task_id} failed. Failing this DAG run")
+
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
@@ -21,13 +97,23 @@ default_args = {
 with DAG(
     dag_id="example_aws_nuke",
     start_date=datetime(2022, 1, 1),
-    schedule=None,
+    schedule=AWS_NUKE_DAG_SCHEDULE,
     catchup=False,
     default_args=default_args,
     tags=["example", "aws-nuke"],
     is_paused_upon_creation=False,
 ) as dag:
     start = DummyOperator(task_id="start")
+
+    get_airflow_version = BashOperator(
+        task_id="get_airflow_version", bash_command="airflow version", do_xcom_push=True
+    )
+
+    get_airflow_executor = BashOperator(
+        task_id="get_airflow_executor",
+        bash_command="airflow config get-value core executor",
+        do_xcom_push=True,
+    )
 
     terminate_running_emr_virtual_clusters = BashOperator(
         task_id="terminate_running_emr_virtual_clusters",
@@ -52,7 +138,27 @@ with DAG(
         trigger_rule="all_done",
     )
 
-    end = DummyOperator(task_id="end")
+    generate_report = PythonOperator(
+        task_id="generate_report",
+        python_callable=generate_task_report,
+        provide_context=True,
+        trigger_rule="all_done",
+    )
 
-    start >> terminate_running_emr_virtual_clusters >> execute_aws_nuke >> delete_stale_emr_vpcs
-    [terminate_running_emr_virtual_clusters, execute_aws_nuke, delete_stale_emr_vpcs] >> end
+    dag_final_status = PythonOperator(
+        task_id="dag_final_status",
+        provide_context=True,
+        python_callable=check_dag_status,
+        trigger_rule=TriggerRule.ALL_DONE,  # Ensures this task runs even if upstream fails
+        retries=0,
+    )
+
+    (
+        start
+        >> [get_airflow_version, get_airflow_executor]
+        >> terminate_running_emr_virtual_clusters
+        >> execute_aws_nuke
+        >> delete_stale_emr_vpcs
+        >> generate_report
+        >> dag_final_status
+    )

--- a/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_aws_nuke.py
@@ -23,7 +23,7 @@ SLACK_USERNAME = os.getenv("SLACK_USERNAME", "airflow_app")
 SLACK_WEBHOOK_CONN = os.getenv("SLACK_WEBHOOK_CONN", "http_slack")
 
 
-def generate_task_report(**context: Any):
+def generate_task_report(**context: Any) -> None:
     """Generate a report of the task statuses for the DAG run and send it to configured Slack channel for alerts."""
     dag_run = context["dag_run"]
     run_id = dag_run.run_id

--- a/dev/Dockerfile.aws
+++ b/dev/Dockerfile.aws
@@ -38,4 +38,5 @@ COPY setup.cfg ${AIRFLOW_HOME}/astronomer_providers/setup.cfg
 COPY pyproject.toml ${AIRFLOW_HOME}/astronomer_providers/pyproject.toml
 
 RUN pip install -e "${AIRFLOW_HOME}/astronomer_providers[all,tests,mypy]"
+RUN pip install apache-airflow-providers-slack
 USER astro

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -20,6 +20,7 @@ x-airflow-common:
     AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "True"
     AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL: "5"
     ASTRONOMER_ENVIRONMENT: local
+    # AWS_NUKE_DAG_SCHEDULE: "28 6 * * *"
     # AIRFLOW__LINEAGE__BACKEND: openlineage.lineage_backend.OpenLineageBackend
     # OPENLINEAGE_URL: http://host.docker.internal:5050/
     # OPENLINEAGE_EXTRACTORS: "astronomer.providers.google.cloud.extractors.bigquery.BigQueryAsyncExtractor;\


### PR DESCRIPTION
It is observed that when 2 deployments are run in parallel, 
their master DAGs trigger the nuke task which cleanup the 
resources and if one master DAG finished running before 
the other one across the deployments, the other deployment's
 master DAG tasks will fail as the resources will no longer be 
available. To mitigate this, we remove the nuke DAG trigger 
from the master DAG and instead plan to schedule the master 
DAG only from one of the provider integration tests 
deployment (e.g. CeleryExecutor) by using the env var 
"AWS_NUKE_DAG_SCHEDULE". We also want to be alerted in
 our Slack channel if one of the nuke tasks fail and hence also 
add a report task for the DAG.