### PR TITLE
Use min airflow version 2.4 for astronomer-providers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ workflows:
             parameters:
               python_version: ["3.8", "3.9", "3.10"]
               airflow_version: ["2.4.2", "2.5.3", "2.6.1"]
-          <<: *main_and_release_branches
+          <<: *all_branches_and_version_tag  # TODO: Set this back to *main_and_release_branches
       - build-docs:
           <<: *all_branches_and_version_tag
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ workflows:
             parameters:
               python_version: ["3.8", "3.9", "3.10"]
               airflow_version: ["2.4.2", "2.5.3", "2.6.1"]
-          <<: *all_branches_and_version_tag  # TODO: Set this back to *main_and_release_branches
+          <<: *main_and_release_branches
       - build-docs:
           <<: *all_branches_and_version_tag
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ workflows:
           matrix:
             parameters:
               python_version: ["3.8", "3.9", "3.10"]
-              airflow_version: ["2.3.4", "2.4.2", "2.5.3"]
+              airflow_version: ["2.4.2", "2.5.3", "2.6.1"]
           <<: *main_and_release_branches
       - build-docs:
           <<: *all_branches_and_version_tag

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages = find_namespace:
 include_package_data = true
 namespace_packages = astronomer,astronomer.providers
 install_requires =
-    apache-airflow>=2.2.0
+    apache-airflow>=2.4.0
     aiohttp
     aiofiles
     asgiref


### PR DESCRIPTION
With the addition of PR #1169, we set the dependency 
`apache-airflow-providers-amazon>=8.1.0` which requires
min airflow version as `2.4.0`. Hence, we are setting the min 
airflow version to `2.4.0` for `astronomer-providers` too so that 
we're able to generate constraints successfully which failed generation 
for the PR upon merge to the `main`.