### PR TITLE
Use env variable to control GCP nuke DAG schedule

### DIFF
--- a/astronomer/providers/google/cloud/example_dags/example_gcp_nuke.py
+++ b/astronomer/providers/google/cloud/example_dags/example_gcp_nuke.py
@@ -1,3 +1,4 @@
+"""DAG to delete stale GCP resources."""
 import os
 from datetime import timedelta
 
@@ -7,6 +8,7 @@ from airflow.operators.python import PythonOperator
 from airflow.utils.timezone import datetime
 
 REGION = os.getenv("GCP_LOCATION", "us-central1")
+GCP_NUKE_DAG_SCHEDULE = os.getenv("GCP_NUKE_DAG_SCHEDULE", None)
 GCP_PROJECT_NAME = os.getenv("GCP_PROJECT_NAME", "astronomer-airflow-providers")
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
 
@@ -18,7 +20,7 @@ default_args = {
 
 
 def gcloud_nuke_callable() -> None:
-    """Deletes stale GCP resources."""
+    """Delete stale GCP resources."""
     import json
     import logging
     import subprocess
@@ -71,7 +73,7 @@ def gcloud_nuke_callable() -> None:
 with DAG(
     dag_id="example_gcp_nuke",
     start_date=datetime(2022, 1, 1),
-    schedule="30 20 * * *",
+    schedule=GCP_NUKE_DAG_SCHEDULE,
     catchup=False,
     default_args=default_args,
     tags=["example", "gcp", "nuke"],


### PR DESCRIPTION
The current GCP Nuke DAG schedule is colluding with our
night runs and hence we're observing GCP DAG failures
at times. This allows us to set the nuke dag schedule with
an environment variable and we plan to run it at the same
time as AWS nuke DAG which runs twice; once before and once
after our nightly run.