### PR TITLE
Setting Factory name as ENV Var

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -45,6 +45,7 @@ MODEL_NAME
 REDSHIFT_CLUSTER_IDENTIFIER
 REDSHIFT_TABLE_NAME
 RESOURCE_GROUP_NAME
+ADF_FACTORY_NAME
 
 Additionally, ensure to have unique "cluster_identifier" values for each deployment in the below Airflow connections:
 aws_default

--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -25,6 +25,7 @@ IS_RUNTIME_RELEASE = bool(os.getenv("IS_RUNTIME_RELEASE", False))
 To run this master dag across multiple deployments simultaneously, set unique values for the below environment
 variables; otherwise same resources will be used by all the deployments and will cause conflicts at runtime.
 
+ADF_FACTORY_NAME
 AZURE_DATA_STORAGE_BLOB_NAME
 AZURE_DATA_STORAGE_CONTAINER_NAME
 BATCH_JOB_COMPUTE_ENV
@@ -45,7 +46,7 @@ MODEL_NAME
 REDSHIFT_CLUSTER_IDENTIFIER
 REDSHIFT_TABLE_NAME
 RESOURCE_GROUP_NAME
-ADF_FACTORY_NAME
+
 
 Additionally, ensure to have unique "cluster_identifier" values for each deployment in the below Airflow connections:
 aws_default

--- a/astronomer/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
+++ b/astronomer/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
@@ -23,8 +23,7 @@ CLIENT_SECRET = os.getenv("CLIENT_SECRET", "")
 TENANT_ID = os.getenv("TENANT_ID", "")
 SUBSCRIPTION_ID = os.getenv("SUBSCRIPTION_ID", "")
 RESOURCE_GROUP_NAME = os.getenv("RESOURCE_GROUP_NAME", "team_provider_resource_group_test_1")
-ADF_FACTORY_NAME = os.getenv("ADF_FACTORY_NAME", "ADFProvidersTeamDataFactoryTest")
-DATAFACTORY_NAME = os.getenv("DATAFACTORY_NAME", "")
+DATAFACTORY_NAME = os.getenv("DATAFACTORY_NAME", "ADFProvidersTeamDataFactoryTest")
 LOCATION = os.getenv("LOCATION", "eastus")
 CONNECTION_STRING = os.getenv("CONNECTION_STRING", "")
 PIPELINE_NAME = os.getenv("PIPELINE_NAME", "pipeline1")
@@ -41,7 +40,7 @@ df_params = {"location": LOCATION}
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
     "azure_data_factory_conn_id": "azure_data_factory_default",
-    "factory_name": ADF_FACTORY_NAME,  # This can also be specified in the ADF connection.
+    "factory_name": DATAFACTORY_NAME,  # This can also be specified in the ADF connection.
     "resource_group_name": RESOURCE_GROUP_NAME,  # This can also be specified in the ADF connection.
     "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
     "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),

--- a/astronomer/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
+++ b/astronomer/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
@@ -23,6 +23,7 @@ CLIENT_SECRET = os.getenv("CLIENT_SECRET", "")
 TENANT_ID = os.getenv("TENANT_ID", "")
 SUBSCRIPTION_ID = os.getenv("SUBSCRIPTION_ID", "")
 RESOURCE_GROUP_NAME = os.getenv("RESOURCE_GROUP_NAME", "team_provider_resource_group_test_1")
+ADF_FACTORY_NAME = os.getenv("ADF_FACTORY_NAME", "ADFProvidersTeamDataFactoryTest")
 DATAFACTORY_NAME = os.getenv("DATAFACTORY_NAME", "")
 LOCATION = os.getenv("LOCATION", "eastus")
 CONNECTION_STRING = os.getenv("CONNECTION_STRING", "")
@@ -40,7 +41,7 @@ df_params = {"location": LOCATION}
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
     "azure_data_factory_conn_id": "azure_data_factory_default",
-    "factory_name": "ADFProvidersTeamDataFactoryTest",  # This can also be specified in the ADF connection.
+    "factory_name": ADF_FACTORY_NAME,  # This can also be specified in the ADF connection.
     "resource_group_name": RESOURCE_GROUP_NAME,  # This can also be specified in the ADF connection.
     "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
     "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),


### PR DESCRIPTION
We have recently observed that the current usage of the "factory_name" as a static value. Taking it from an environment variable will help us run the DAG in parallel.