### PR TITLE
Mark EMR EKS Container DAG failed if any of the tasks fail

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_emr_eks_containers_job.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_emr_eks_containers_job.py
@@ -5,13 +5,12 @@ from typing import Any
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
+from airflow.providers.amazon.aws.operators.emr import EmrEksCreateClusterOperator
 from airflow.utils.state import State
 from airflow.utils.trigger_rule import TriggerRule
-from airflow.providers.amazon.aws.operators.emr import EmrEksCreateClusterOperator
 
 from astronomer.providers.amazon.aws.operators.emr import EmrContainerOperatorAsync
 from astronomer.providers.amazon.aws.sensors.emr import EmrContainerSensorAsync
-
 
 # [START howto_operator_emr_eks_env_variables]
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "xxxxxxx")
@@ -69,6 +68,7 @@ CONFIGURATION_OVERRIDES_ARG = {
 }
 # [END howto_operator_emr_eks_config]
 
+
 def check_dag_status(**kwargs: Any) -> None:
     """Raises an exception if any of the DAG's tasks failed and as a result marking the DAG failed."""
     for task_instance in kwargs["dag_run"].get_task_instances():
@@ -77,7 +77,6 @@ def check_dag_status(**kwargs: Any) -> None:
             and task_instance.task_id != kwargs["task_instance"].task_id
         ):
             raise Exception(f"Task {task_instance.task_id} failed. Failing this DAG run")
-
 
 
 with DAG(


### PR DESCRIPTION
Master DAG does show the status of the DAG as
successful even though its intermediate tasks fail. This does not reflect
the correct top-level view of the statuses of the DAGs triggered from the master DAG.
The commit adds a PythonOperator task at the end of the DAG to check the
statuses of all of the DAG's tasks and marks the DAG as failed if any of its tasks
fail.


Tested DAG locally after update
![image](https://github.com/astronomer/astronomer-providers/assets/43964496/3f6c52b3-d6c8-4ba1-86d9-666adeed3b7a)

