### PR TITLE
Mark Async Redshift sql DAG failed if any of the tasks fail

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_sql.py
@@ -2,11 +2,13 @@ import logging
 import os
 import time
 from datetime import datetime, timedelta
+from typing import Any
 
 from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import PythonOperator
+from airflow.utils.state import State
+from airflow.utils.trigger_rule import TriggerRule
 
 from astronomer.providers.amazon.aws.operators.redshift_sql import (
     RedshiftSQLOperatorAsync,
@@ -30,6 +32,16 @@ default_args = {
     "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
     "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
+
+
+def check_dag_status(**kwargs: Any) -> None:
+    """Raises an exception if any of the DAG's tasks failed and as a result marking the DAG failed."""
+    for task_instance in kwargs["dag_run"].get_task_instances():
+        if (
+            task_instance.current_state() != State.SUCCESS
+            and task_instance.task_id != kwargs["task_instance"].task_id
+        ):
+            raise Exception(f"Task {task_instance.task_id} failed. Failing this DAG run")
 
 
 def get_cluster_status() -> str:
@@ -195,7 +207,13 @@ with DAG(
         trigger_rule="all_done",
     )
 
-    end = DummyOperator(task_id="end")
+    dag_final_status = PythonOperator(
+        task_id="dag_final_status",
+        provide_context=True,
+        python_callable=check_dag_status,
+        trigger_rule=TriggerRule.ALL_DONE,  # Ensures this task runs even if upstream fails
+        retries=0,
+    )
 
     (
         config
@@ -208,6 +226,5 @@ with DAG(
         >> task_get_data_with_filter
         >> task_delete_table
         >> delete_redshift_cluster
+        >> dag_final_status
     )
-
-    [task_delete_table, delete_redshift_cluster] >> end


### PR DESCRIPTION
Master DAG does show the status of the DAG as
successful even though its intermediate tasks fail. This does not reflect
the correct top-level view of the statuses of the DAGs triggered from the master DAG.
The commit adds a PythonOperator task at the end of the DAG to check the
statuses of all of the DAG's tasks and marks the DAG as failed if any of its tasks
fail.

Tested DAG locally after the update
<img width="1489" alt="image" src="https://github.com/astronomer/astronomer-providers/assets/43964496/a3d0f3ba-5464-4a9f-8009-3125aebd5ca2">
