### PR TITLE
Mark External Task DAG failed if any of the tasks fail

### DIFF
--- a/astronomer/providers/core/example_dags/example_external_task.py
+++ b/astronomer/providers/core/example_dags/example_external_task.py
@@ -1,12 +1,15 @@
 import os
 import time
 from datetime import timedelta
+from typing import Any
 
 from airflow import DAG
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import PythonOperator
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+from airflow.utils.state import State
 from airflow.utils.timezone import datetime
+from airflow.utils.trigger_rule import TriggerRule
 
 from astronomer.providers.core.sensors.external_task import ExternalTaskSensorAsync
 
@@ -17,6 +20,17 @@ default_args = {
     "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
     "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
+
+
+def check_dag_status(**kwargs: Any) -> None:
+    """Raises an exception if any of the DAG's tasks failed and as a result marking the DAG failed."""
+    for task_instance in kwargs["dag_run"].get_task_instances():
+        if (
+            task_instance.current_state() != State.SUCCESS
+            and task_instance.task_id != kwargs["task_instance"].task_id
+        ):
+            raise Exception(f"Task {task_instance.task_id} failed. Failing this DAG run")
+
 
 with DAG(
     dag_id="example_external_task",
@@ -62,9 +76,15 @@ with DAG(
         poke_interval=1,
     )
 
-    end = DummyOperator(task_id="end")
+    dag_final_status = PythonOperator(
+        task_id="dag_final_status",
+        provide_context=True,
+        python_callable=check_dag_status,
+        trigger_rule=TriggerRule.ALL_DONE,  # Ensures this task runs even if upstream fails
+        retries=0,
+    )
 
-    start >> [waiting_for_task, wait_for_me] >> end
+    start >> [waiting_for_task, wait_for_me] >> dag_final_status
 
-    start >> wait_for_dag >> end
-    start >> wait_to_defer >> external >> end
+    start >> wait_for_dag >> dag_final_status
+    start >> wait_to_defer >> external >> dag_final_status


### PR DESCRIPTION
Master DAG does show the status of the DAG as
successful even though its intermediate tasks fail. This does not reflect
the correct top-level view of the statuses of the DAGs triggered from the master DAG.
The commit adds a PythonOperator task at the end of the DAG to check the
statuses of all of the DAG's tasks and marks the DAG as failed if any of its tasks
fail.

Tested DAG locally after the update
<img width="1332" alt="image" src="https://github.com/astronomer/astronomer-providers/assets/43964496/2be4da33-fa35-47f3-b652-6ce02ef46c8c">
