### PR TITLE
Automate deletion of RC testing branch once PR is closed

### DIFF
--- a/.github/workflows/delete-branch-on-pr-close.yaml
+++ b/.github/workflows/delete-branch-on-pr-close.yaml
@@ -1,0 +1,27 @@
+---
+name: Delete RC testing branch upon PR closure
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Verify and Delete RC testing branch
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "action@github.com"
+          git fetch --prune --all
+
+          if [[ "${{ github.event.pull_request.head.ref }}" == rc-test-* ]]; then
+            git push origin --delete ${{ github.event.pull_request.head.ref }}
+          else
+            echo "Branch does not have the required RC testing prefix. Skipping branch deletion."
+          fi


### PR DESCRIPTION
Our current GitHub configuration automatically deletes the branches
when PRs are merged. But for closed PRs, the branches are not deleted
and they remain stale. We have cases like testing the RCs, where we do
not want to merge the PR but only close it after verifying that our RCs
do not cause static check or tests failure. For such RC testing branches, 
this action will delete the branches upon closing the PR. 

In case, we want to reopen the PR, we need to click the button to 
restore the branch first and only then the reopen PR option will be
enabled by GitHub. I made an attempt to restore the branch if the event
is of type PR reopen, but that event cannot happen when the branch
no longer exists. Hence, we will have to manually click on the restore
button first if we want to reopen the PR.