### PR TITLE
Verify automation of deletion of RC test branches works

### DIFF
--- a/.github/workflows/delete-branch-on-pr-close.yaml
+++ b/.github/workflows/delete-branch-on-pr-close.yaml
@@ -1,0 +1,27 @@
+---
+name: Delete RC testing branch upon PR closure
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete-branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Verify and Delete RC testing branch
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "action@github.com"
+          git fetch --prune --all
+
+          if [[ "${{ github.event.pull_request.head.ref }}" == rc-test-* ]]; then
+            git push origin --delete ${{ github.event.pull_request.head.ref }}
+          else
+            echo "Branch does not have the required RC testing prefix. Skipping branch deletion."
+          fi


### PR DESCRIPTION
WRT to GitHub action in PR #1196 , we are creating this verification
PR with the branch name having `rc-test-` prefix to test that
such branches are deleted upon PR closure.

I cherrypicked the commit for the action from the PR #1196 
to test the action's behaviour.