### PR TITLE
Set version scheme to semver

### DIFF
--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -32,7 +32,7 @@ You will need to update it in:
 * ``docs/conf.py`` - ``release`` variable
 * ``astronomer/providers/package.py`` - ``get_provider_info`` method return value ``versions``
 
-You can also use `commitizen <https://github.com/commitizen-tools/commitizen>`_ to update the version in these files
+You can also use `commitizen <https://github.com/commitizen-tools/commitizen>`_ (version >= 3.4.0 is required) to update the version in these files
 
 Install commitizen on mac
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,4 @@ version_files = [
     "astronomer/providers/package.py",
     "setup.cfg",
 ]
+version_scheme = "semver"


### PR DESCRIPTION
Since version 3.4.0, commitizen introduce [version_schemes](https://github.com/commitizen-tools/commitizen/blob/master/CHANGELOG.md#v340-2023-06-20). By default, python project uses `pep440` instead of `semver` (check [here](https://commitizen-tools.github.io/commitizen/bump/#-version-scheme) for more information). As we use "semver" in this project, I set the version_scheme to "semver" to fix a version bumping error