### PR TITLE
ci(github-actions): fix wrong base branch used when creating pull request

### DIFF
--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -170,7 +170,7 @@ jobs:
           git add setup.cfg
           git commit -m "Updating setup.cfg with RC provider packages on $rc_issue_url"
           git push origin ${{ steps.create_rc_branch.outputs.rc_testing_branch }}
-          gh pr create --base ${{ steps.create_rc_branch.outputs.rc_testing_branch }} \
+          gh pr create --base main \
                        --title "[DO NOT MERGE] Test RC provider packages for $rc_issue_url" \
                        --fill
 

--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -170,8 +170,7 @@ jobs:
           git add setup.cfg
           git commit -m "Updating setup.cfg with RC provider packages on $rc_issue_url"
           git push origin ${{ steps.create_rc_branch.outputs.rc_testing_branch }}
-          gh pr create --base main \
-                       --title "[DO NOT MERGE] Test RC provider packages for $rc_issue_url" \
+          gh pr create --title "[DO NOT MERGE] Test RC provider packages for $rc_issue_url" \
                        --fill
 
           echo "git_rev=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
we should set the main branch as base instead of the changed branch