### PR TITLE
Revert "feat(kubernetes): check state before deferring KubernetesPodOperatorAsync (#1104)"

### DIFF
--- a/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -5,10 +5,6 @@ from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
     KubernetesPodOperator,
 )
-from airflow.providers.cncf.kubernetes.utils.pod_manager import (
-    PodPhase,
-    container_is_running,
-)
 from kubernetes.client import models as k8s
 from pendulum import DateTime
 
@@ -80,20 +76,9 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
             method_name=self.trigger_reentry.__name__,
         )
 
-    def execute(self, context: Context) -> Any:  # noqa: D102
+    def execute(self, context: Context) -> None:  # noqa: D102
         self.pod_request_obj = self.build_pod_request_obj(context)
         self.pod: k8s.V1Pod = self.get_or_create_pod(self.pod_request_obj, context)
-        pod_status = self.pod.status.phase
-        if pod_status in PodPhase.terminal_states or not container_is_running(
-            pod=self.pod, container_name=self.BASE_CONTAINER_NAME
-        ):
-            event = {
-                "status": "done",
-                "namespace": self.pod.metadata.namespace,
-                "pod_name": self.pod.metadata.name,
-            }
-            return self.trigger_reentry(context=context, event=event)
-
         self.defer()
 
     def execute_complete(self, context: Context, event: Dict[str, Any]) -> Any:  # type: ignore[override]

--- a/astronomer/providers/cncf/kubernetes/triggers/wait_container.py
+++ b/astronomer/providers/cncf/kubernetes/triggers/wait_container.py
@@ -1,9 +1,7 @@
-from __future__ import annotations
-
 import asyncio
 import traceback
 from datetime import timedelta
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Dict, Optional, Tuple
 
 from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.utils.pod_manager import (
@@ -45,12 +43,12 @@ class WaitContainerTrigger(BaseTrigger):
         container_name: str,
         pod_name: str,
         pod_namespace: str,
-        kubernetes_conn_id: str | None = None,
-        hook_params: dict[str, Any] | None = None,
+        kubernetes_conn_id: Optional[str] = None,
+        hook_params: Optional[Dict[str, Any]] = None,
         pending_phase_timeout: float = 120,
         poll_interval: float = 5,
-        logging_interval: int | None = None,
-        last_log_time: DateTime | None = None,
+        logging_interval: Optional[int] = None,
+        last_log_time: Optional[DateTime] = None,
     ):
         super().__init__()
         self.kubernetes_conn_id = kubernetes_conn_id
@@ -63,7 +61,7 @@ class WaitContainerTrigger(BaseTrigger):
         self.logging_interval = logging_interval
         self.last_log_time = last_log_time
 
-    def serialize(self) -> tuple[str, dict[str, Any]]:  # noqa: D102
+    def serialize(self) -> Tuple[str, Dict[str, Any]]:  # noqa: D102
         return (
             "astronomer.providers.cncf.kubernetes.triggers.wait_container.WaitContainerTrigger",
             {
@@ -96,7 +94,7 @@ class WaitContainerTrigger(BaseTrigger):
             await asyncio.sleep(self.poll_interval)
         raise PodLaunchTimeoutException("Pod did not leave 'Pending' phase within specified timeout")
 
-    async def wait_for_container_completion(self, v1_api: CoreV1Api) -> TriggerEvent:
+    async def wait_for_container_completion(self, v1_api: CoreV1Api) -> "TriggerEvent":
         """
         Waits until container ``self.container_name`` is no longer in running state.
         If trigger is configured with a logging period, then will emit an event to
@@ -116,7 +114,7 @@ class WaitContainerTrigger(BaseTrigger):
                 return TriggerEvent({"status": "running", "last_log_time": self.last_log_time})
             await asyncio.sleep(self.poll_interval)
 
-    async def run(self) -> AsyncIterator[TriggerEvent]:  # noqa: D102
+    async def run(self) -> AsyncIterator["TriggerEvent"]:  # noqa: D102
         self.log.debug("Checking pod %r in namespace %r.", self.pod_name, self.pod_namespace)
         try:
             hook = await self.get_hook()

--- a/tests/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -3,11 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from airflow.exceptions import TaskDeferred
-from airflow.providers.cncf.kubernetes.utils.pod_manager import (
-    PodLoggingStatus,
-    PodPhase,
-)
-from kubernetes.client import models as k8s
+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodLoggingStatus
 
 from astronomer.providers.cncf.kubernetes.operators.kubernetes_pod import (
     KubernetesPodOperatorAsync,
@@ -19,24 +15,6 @@ from astronomer.providers.cncf.kubernetes.triggers.wait_container import (
 from tests.utils.airflow_util import create_context
 
 KUBE_POD_MOD = "astronomer.providers.cncf.kubernetes.operators.kubernetes_pod"
-
-
-def _build_mock_pod(state: k8s.V1ContainerState) -> k8s.V1Pod:
-    return k8s.V1Pod(
-        metadata=k8s.V1ObjectMeta(name="base", namespace="default"),
-        status=k8s.V1PodStatus(
-            container_statuses=[
-                k8s.V1ContainerStatus(
-                    name="base",
-                    image="alpine",
-                    image_id="1",
-                    ready=True,
-                    restart_count=1,
-                    state=state,
-                )
-            ]
-        ),
-    )
 
 
 class TestKubernetesPodOperatorAsync:
@@ -174,37 +152,12 @@ class TestKubernetesPodOperatorAsync:
         with pytest.raises(ValueError):
             op.defer(kwargs={"timeout": 10})
 
-    @pytest.mark.parametrize("pod_phase", PodPhase.terminal_states)
-    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.trigger_reentry")
     @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.build_pod_request_obj")
     @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.get_or_create_pod")
     @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.defer")
-    def test_execute_done_before_defer(
-        self, mock_defer, mock_get_or_create_pod, mock_build_pod_request_obj, mock_trigger_reentry, pod_phase
-    ):
-        mock_get_or_create_pod.return_value.status.phase = pod_phase
-        mock_build_pod_request_obj.return_value = {}
-        mock_defer.return_value = {}
-        op = KubernetesPodOperatorAsync(task_id="test_task", name="test-pod", get_logs=True)
-        assert op.execute(context=create_context(op))
-        assert mock_trigger_reentry.called
-        assert not mock_defer.called
-
-    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.build_pod_request_obj")
-    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.get_or_create_pod")
-    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodOperatorAsync.defer")
-    def test_execute(
-        self,
-        mock_defer,
-        mock_get_or_create_pod,
-        mock_build_pod_request_obj,
-    ):
+    def test_execute(self, mock_defer, mock_get_or_create_pod, mock_build_pod_request_obj):
         """Assert that execute succeeded"""
-        mock_get_or_create_pod.return_value = _build_mock_pod(
-            k8s.V1ContainerState(
-                {"running": k8s.V1ContainerStateRunning(), "terminated": None, "waiting": None}
-            )
-        )
+        mock_get_or_create_pod.return_value = {}
         mock_build_pod_request_obj.return_value = {}
         mock_defer.return_value = {}
         op = KubernetesPodOperatorAsync(task_id="test_task", name="test-pod", get_logs=True)


### PR DESCRIPTION
This reverts commit 89ccc7ec1ad5c38a1665b50f649e9153d3ca2f37.

PR #1104 adds logic to poke for Pod status before putting the status 
check on deferral. However, it is observed that our DAG fails always 
when we go on checking the status.phase on pods as Pod.status is None 
before the pod gets scheduled on a node. So, in most scenarios it does 
not make sense to check for the pod status immediately to verify that the 
pod has completed its desired execution and hence, we revert this poke 
in case of Kubernetes Pod operator.

closes: #1208 