### PR TITLE
Remove retries from KPO Async DAG

### DIFF
--- a/astronomer/providers/cncf/kubernetes/example_dags/example_kubernetes_pod_operator.py
+++ b/astronomer/providers/cncf/kubernetes/example_dags/example_kubernetes_pod_operator.py
@@ -1,3 +1,4 @@
+"""Example DAG demonstrating the usage of the KubernetesPodOperatorAsync."""
 import os
 from datetime import datetime, timedelta
 
@@ -20,8 +21,6 @@ else:
 
 default_args = {
     "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
-    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
-    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
 }
 
 with DAG(


### PR DESCRIPTION
Remove retries from the example DAG to uncover potential issues.