### PR TITLE
Automate part of the release process

### DIFF
--- a/.github/scripts/validate_release_commit.py
+++ b/.github/scripts/validate_release_commit.py
@@ -1,0 +1,14 @@
+import re
+import sys
+
+if __name__ == "__main__":
+    pattern = r"^Release \d{1,}\.\d{1,}\.\d{1,}$"
+    if len(sys.argv) == 2:
+        commit_message = sys.argv[1]
+        if not re.fullmatch(pattern, commit_message):
+            print(f"{commit_message} does not match '{pattern}'")
+            sys.exit(1)
+        else:
+            print(f"{commit_message} matches '{pattern}'")
+    else:
+        raise ValueError("One positional argument 'commit message' is required")

--- a/.github/workflows/deploy-integration-tests.yaml
+++ b/.github/workflows/deploy-integration-tests.yaml
@@ -1,5 +1,5 @@
 ---
-name: deploy-integration-tests-to-astro-cloud
+name: Deploy integration tests to astro cloud
 
 on:  # yamllint disable-line rule:truthy
   schedule:

--- a/.github/workflows/deploy-to-astro-cloud-reuse-wf.yaml
+++ b/.github/workflows/deploy-to-astro-cloud-reuse-wf.yaml
@@ -1,5 +1,5 @@
 ---
-name: deploy-to-astro-cloud
+name: Deploy to astro cloud
 
 on:  # yamllint disable-line rule:truthy
   workflow_call:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,37 @@
+---
+name: Trigger release and bump version
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  trigger-release-process:
+    if: github.event.pull_request.merged == true && startswith(github.event.head_commit.message, 'Release ')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install commitizen
+        run: |
+          pip3 install commitizen
+
+      - name: Setup Github Actions git user
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Actions"
+
+      - name: Tag and push tag for triggering release
+        run: |
+          git tag `cz version -p`
+          git push origin `cz version -p`
+
+      - name: Bump version for new development
+        run: |
+          make ASTRO_PROVIDER_VERSION=dev bump-version
+          git add .
+          git push origin main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check head commit message
+        env:
+          head_commit_title: ${{ github.event.head_commit.message }}
+        run: |
+          python ./.github/scripts/validate_release_commit.py "$head_commit_title"
+
       - name: Install commitizen
         run: |
           pip3 install commitizen

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Setup Github Actions git user
         run: |
-          git config --global user.email "action@github.com"
-          git config --global user.name "GitHub Actions"
+          git config --global user.email "airflow-oss-bot@astronomer.io"
+          git config --global user.name "airflow-oss-bot"
 
       - name: Tag and push tag for triggering release
         run: |

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -77,7 +77,7 @@ Tag and push the commit
 -----------------------
 
 Once the release branch has been approved and merged to ``main``, checkout to the ``main`` branch.
-Tag that commit with a tag that matches the version number (``git tag 1.2.1 <latest commit sha>``),
+It will trigger the GitHub Actions to tag that commit with a tag that matches the version number (``git tag 1.2.1 <latest commit sha>``),
 and then push the tag (``git push origin 1.2.1``).
 
 CircleCI will handle the rest - building, testing, and pushing the resulting


### PR DESCRIPTION
* add `release` workflow for automating tagging process
* fix missing `needs` in the test rc release workflow
* rename workflows

closes: #1201 


We'll need to allow `action@github.com` to push tag and commit to main
