### PR TITLE
ci(github-actions): fix missing needed in test rc release

### DIFF
--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -1,5 +1,5 @@
 ---
-name: test-rc-release
+name: Test providers RC releases
 
 on:  # yamllint disable-line rule:truthy
   schedule:
@@ -215,7 +215,7 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   wait-for-deployment-to-be-ready-and-trigger-master-dag:
-    needs: deploy-rc-testing-branch-to-astro-cloud
+    needs: [deploy-rc-testing-branch-to-astro-cloud, export-rc-testing-branch-name]
     if: |
       always() &&
       needs.deploy-rc-testing-branch-to-astro-cloud.result == 'success'


### PR DESCRIPTION
In step `wait-for-deployment-to-be-ready-and-trigger-master-dag`, we use the output of `export-rc-testing-branch` but we did not specify it as needs of `wait-for-deployment-to-be-ready-and-trigger-master-dag`