### PR TITLE
Use upstream aws base hook session implementation 

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_batch.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_batch.py
@@ -288,8 +288,8 @@ with DAG(
     )
     # [END howto_operator_batch_async]
 
-    submit_batch_job_assume_cred = BatchOperatorAsync(
-        task_id="assume_role_cred",
+    submit_job_with_assume_role = BatchOperatorAsync(
+        task_id="submit_job_with_assume_role",
         job_name=JOB_NAME,
         job_queue=JOB_QUEUE,
         job_definition=JOB_DEFINITION,
@@ -347,7 +347,7 @@ with DAG(
         >> submit_batch_job
         >> list_jobs
         >> batch_job_sensor
-        >> submit_batch_job_assume_cred
+        >> submit_job_with_assume_role
         >> disable_compute_environment
         >> disable_job_queue
         >> delete_job_queue

--- a/astronomer/providers/amazon/aws/example_dags/example_batch.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_batch.py
@@ -18,6 +18,7 @@ from astronomer.providers.amazon.aws.sensors.batch import BatchSensorAsync
 
 AWS_DEFAULT_REGION = os.getenv("AWS_DEFAULT_REGION", "us-east-2")
 AWS_CONN_ID = os.getenv("ASTRO_AWS_CONN_ID", "aws_default")
+AWS_CONN_ID_ASSUME_ROLE = os.getenv("ASTRO_AWS_ASSUME_ROLE_CONN_ID", "aws_assume_role_conn")
 AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "xxxxxxx")
 AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "xxxxxxxx")
 
@@ -287,6 +288,16 @@ with DAG(
     )
     # [END howto_operator_batch_async]
 
+    submit_batch_job_assume_cred = BatchOperatorAsync(
+        task_id="assume_role_cred",
+        job_name=JOB_NAME,
+        job_queue=JOB_QUEUE,
+        job_definition=JOB_DEFINITION,
+        overrides=JOB_OVERRIDES,
+        aws_conn_id=AWS_CONN_ID_ASSUME_ROLE,
+        region_name=AWS_DEFAULT_REGION,
+    )
+
     # Task to List jobs in AWS batch
     list_jobs = PythonOperator(
         task_id="list_jobs",
@@ -336,6 +347,7 @@ with DAG(
         >> submit_batch_job
         >> list_jobs
         >> batch_job_sensor
+        >> submit_batch_job_assume_cred
         >> disable_compute_environment
         >> disable_job_queue
         >> delete_job_queue

--- a/astronomer/providers/amazon/aws/hooks/base_aws.py
+++ b/astronomer/providers/amazon/aws/hooks/base_aws.py
@@ -161,7 +161,7 @@ class AwsBaseHookAsync(AwsBaseHook):
 
     def _get_aioclient(self) -> AioBaseClient:
         session = self.get_session(region_name=self.region_name, deferrable=True)
-        return session.client(
+        return session.create_client(
             self.client_type,
             endpoint_url=self.conn_config.endpoint_url,
             config=self._get_config(),

--- a/astronomer/providers/amazon/aws/hooks/base_aws.py
+++ b/astronomer/providers/amazon/aws/hooks/base_aws.py
@@ -40,7 +40,7 @@ class AwsBaseHookAsync(AwsBaseHook):
         """Create an Async Client object to communicate with AWS services."""
         # Try to use airflow provider client implementation
         try:
-            return self.get_aioclient()
+            return self._get_aioclient()
         except Exception as e:
             self.log.info(f"An error occur while using upstream provider implementation \n {e}")
 
@@ -159,7 +159,7 @@ class AwsBaseHookAsync(AwsBaseHook):
                 return_response = response["Credentials"]
             return return_response
 
-    def get_aioclient(self):
+    def _get_aioclient(self):
         session = self.get_session(region_name=self.region_name, deferrable=True)
         return session.client(
             self.client_type,

--- a/astronomer/providers/amazon/aws/hooks/base_aws.py
+++ b/astronomer/providers/amazon/aws/hooks/base_aws.py
@@ -41,8 +41,8 @@ class AwsBaseHookAsync(AwsBaseHook):
         # Try to use airflow provider client implementation
         try:
             return self.get_aioclient()
-        except Exception:
-            pass
+        except Exception as e:
+            self.log.info(f"An error occur while using upstream provider implementation \n {e}")
 
         # Fetch the Airflow connection object
         connection_object = await sync_to_async(self.get_connection)(self.aws_conn_id)  # type: ignore[arg-type]

--- a/astronomer/providers/amazon/aws/hooks/base_aws.py
+++ b/astronomer/providers/amazon/aws/hooks/base_aws.py
@@ -159,7 +159,7 @@ class AwsBaseHookAsync(AwsBaseHook):
                 return_response = response["Credentials"]
             return return_response
 
-    def _get_aioclient(self):
+    def _get_aioclient(self) -> AioBaseClient:
         session = self.get_session(region_name=self.region_name, deferrable=True)
         return session.client(
             self.client_type,

--- a/astronomer/providers/amazon/aws/hooks/base_aws.py
+++ b/astronomer/providers/amazon/aws/hooks/base_aws.py
@@ -38,6 +38,12 @@ class AwsBaseHookAsync(AwsBaseHook):
 
     async def get_client_async(self) -> AioBaseClient:
         """Create an Async Client object to communicate with AWS services."""
+        # Try to use airflow provider client implementation
+        try:
+            return self.get_aioclient()
+        except Exception:
+            pass
+
         # Fetch the Airflow connection object
         connection_object = await sync_to_async(self.get_connection)(self.aws_conn_id)  # type: ignore[arg-type]
 
@@ -152,3 +158,12 @@ class AwsBaseHookAsync(AwsBaseHook):
                 )
                 return_response = response["Credentials"]
             return return_response
+
+    def get_aioclient(self):
+        session = self.get_session(region_name=self.region_name, deferrable=True)
+        return session.client(
+            self.client_type,
+            endpoint_url=self.conn_config.endpoint_url,
+            config=self._get_config(),
+            verify=self.verify,
+        )


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-providers/issues/1227

We have missing implementation for some auth type so I was thinking if it makes sense to use upstream provider base hook implementation. 

<img width="1471" alt="Screenshot 2023-07-05 at 12 40 33 AM" src="https://github.com/astronomer/astronomer-providers/assets/98807258/65ac1187-8cf9-42fd-b690-7cdbb9173859">
