### PR TITLE
build(setup.cfg): pin pydanctic to lower than 2.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,10 @@ install_requires =
     asgiref
     typing_extensions; python_version < "3.8"
     markupsafe>=1.1.1
+    # Limit Pydantic to <2.0.0 because it breaks Kubernetes tests and building providers
+    # This limit should be removed after Pydantic 2 incompatibility resolved and
+    # https://github.com/apache/airflow/issues/32311
+    pydantic>=1.10.0,<2.0.0
 zip_safe = false
 
 [options.extras_require]


### PR DESCRIPTION
We need to pin this version as most of our users might not use the airflow on the main branch

related issue: https://github.com/apache/airflow/issues/32311
related PR: https://github.com/apache/airflow/pull/32312