### PR TITLE
Correct KE creds passed while triggering master DAG

### DIFF
--- a/.github/workflows/deploy-integration-tests.yaml
+++ b/.github/workflows/deploy-integration-tests.yaml
@@ -85,6 +85,6 @@ jobs:
       dags_to_trigger_after_deployment: ${{ inputs.dags_to_trigger_after_deployment }}
     secrets:
       astro_subdomain: ${{ secrets.ASTRO_SUBDOMAIN }}
-      deployment_id: ${{ secrets.PROVIDER_INTEGRATION_TESTS_DEPLOYMENT_ID }}
+      deployment_id: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ON_KE_DEPLOYMENT_ID }}
       astronomer_key_id: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_ID }}
       astronomer_key_secret: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_SECRET }}

--- a/.github/workflows/deploy-integration-tests.yaml
+++ b/.github/workflows/deploy-integration-tests.yaml
@@ -86,5 +86,5 @@ jobs:
     secrets:
       astro_subdomain: ${{ secrets.ASTRO_SUBDOMAIN }}
       deployment_id: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ON_KE_DEPLOYMENT_ID }}
-      astronomer_key_id: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_ID }}
-      astronomer_key_secret: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ASTRONOMER_KEY_SECRET }}
+      astronomer_key_id: ${{ secrets.PROVIDER_INTEGRATION_TESTS_ON_KE_ASTRONOMER_KEY_ID }}
+      astronomer_key_secret: ${{ secrets. PROVIDER_INTEGRATION_TESTS_ON_KE_ASTRONOMER_KEY_SECRET }}


### PR DESCRIPTION
With PR #1222, we made few change but also started passing
the same CE deployment secrets to KE deployment master DAG
trigger. As a result the KE DAG was not getting triggered. This
PR corrects the usage of needed creds to trigger KE DAG.