### PR TITLE
ci(github-actions): increate the frequency of airflow rc testing issue check

### DIFF
--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -3,7 +3,7 @@ name: Test providers RC releases
 
 on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0,12 * * *"
   workflow_dispatch:
     inputs:
       rc_testing_branch:


### PR DESCRIPTION
Today's announcement happen to be a bit later than our regular check. thus, @phanikumv suggests we can increase the check frequency