### PR TITLE
Adding region option in eksctl commands

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_create_eks_kube_namespace_with_role.sh
+++ b/astronomer/providers/amazon/aws/example_dags/example_create_eks_kube_namespace_with_role.sh
@@ -26,7 +26,7 @@ eksctl create iamidentitymapping \
 
 aws eks describe-cluster --name $EKS_CLUSTER_NAME --query "cluster.identity.oidc.issuer" --region $AWS_DEFAULT_REGION
 
-eksctl utils associate-iam-oidc-provider --cluster $EKS_CLUSTER_NAME --approve
+eksctl utils associate-iam-oidc-provider --cluster $EKS_CLUSTER_NAME --approve --region $AWS_DEFAULT_REGION
 
 aws iam create-role --role-name $JOB_EXECUTION_ROLE --assume-role-policy-document '{"Version": "2012-10-17","Statement":
 [{"Effect": "Allow","Principal": {"AWS": "arn:aws:iam::'$AWS_ACCOUNT_ID':root"},"Action":

--- a/astronomer/providers/amazon/aws/example_dags/example_create_eks_kube_namespace_with_role.sh
+++ b/astronomer/providers/amazon/aws/example_dags/example_create_eks_kube_namespace_with_role.sh
@@ -24,7 +24,7 @@ eksctl create iamidentitymapping \
     --region $AWS_DEFAULT_REGION
 
 
-aws eks describe-cluster --name $EKS_CLUSTER_NAME --query "cluster.identity.oidc.issuer" --region $AWS_DEFAULT_REGION
+aws eks describe-cluster --name $EKS_CLUSTER_NAME --query "cluster.identity.oidc.issuer"
 
 eksctl utils associate-iam-oidc-provider --cluster $EKS_CLUSTER_NAME --approve --region $AWS_DEFAULT_REGION
 

--- a/astronomer/providers/amazon/aws/example_dags/example_create_eks_kube_namespace_with_role.sh
+++ b/astronomer/providers/amazon/aws/example_dags/example_create_eks_kube_namespace_with_role.sh
@@ -22,7 +22,7 @@ eksctl create iamidentitymapping \
     --namespace $EKS_NAMESPACE \
     --service-name "emr-containers"
 
-aws eks describe-cluster --name $EKS_CLUSTER_NAME --query "cluster.identity.oidc.issuer"
+aws eks describe-cluster --name $EKS_CLUSTER_NAME --query "cluster.identity.oidc.issuer" --region $AWS_DEFAULT_REGION
 
 eksctl utils associate-iam-oidc-provider --cluster $EKS_CLUSTER_NAME --approve
 

--- a/astronomer/providers/amazon/aws/example_dags/example_create_eks_kube_namespace_with_role.sh
+++ b/astronomer/providers/amazon/aws/example_dags/example_create_eks_kube_namespace_with_role.sh
@@ -22,6 +22,8 @@ eksctl create iamidentitymapping \
     --namespace $EKS_NAMESPACE \
     --service-name "emr-containers"
 
+# Sleeping for 60s before describing cluster
+sleep 60
 aws eks describe-cluster --name $EKS_CLUSTER_NAME --query "cluster.identity.oidc.issuer" --region $AWS_DEFAULT_REGION
 
 eksctl utils associate-iam-oidc-provider --cluster $EKS_CLUSTER_NAME --approve

--- a/astronomer/providers/amazon/aws/example_dags/example_create_eks_kube_namespace_with_role.sh
+++ b/astronomer/providers/amazon/aws/example_dags/example_create_eks_kube_namespace_with_role.sh
@@ -20,10 +20,10 @@ kubectl create namespace $EKS_NAMESPACE
 eksctl create iamidentitymapping \
     --cluster $EKS_CLUSTER_NAME \
     --namespace $EKS_NAMESPACE \
-    --service-name "emr-containers"
+    --service-name "emr-containers" \
+    --region $AWS_DEFAULT_REGION
 
-# Sleeping for 60s before describing cluster
-sleep 60
+
 aws eks describe-cluster --name $EKS_CLUSTER_NAME --query "cluster.identity.oidc.issuer" --region $AWS_DEFAULT_REGION
 
 eksctl utils associate-iam-oidc-provider --cluster $EKS_CLUSTER_NAME --approve

--- a/astronomer/providers/amazon/aws/example_dags/example_delete_eks_cluster_and_role_policies.sh
+++ b/astronomer/providers/amazon/aws/example_dags/example_delete_eks_cluster_and_role_policies.sh
@@ -77,5 +77,5 @@ fi
 
 # Command to delete the EKS cluster and node group attached with it. Make sure to wait for the cluster to be deleted so
 # that the task reports for any potential failures.
-eksctl delete cluster $EKS_CLUSTER_NAME --wait --force --timeout 60m0s
+eksctl delete cluster $EKS_CLUSTER_NAME --wait --force --timeout 60m0s --region $AWS_DEFAULT_REGION
 echo "EKS cluster '$EKS_CLUSTER_NAME' deleted."


### PR DESCRIPTION
It appears that the default region support in the latest release of eksctl (v0.148.0) is broken. A defect has already been raised for this issue, which you can find [here](https://github.com/weaveworks/eksctl/issues/6774). As a result of this problem, all of our eksctl commands were failing because we didn't have the "--region" command line option included. To work around this issue, I have temporarily added the "--region" option explicitly