### PR TITLE
Adding kubernetes provider upgrade statement in Dockerfile

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -76,7 +76,7 @@ COPY astronomer-providers /tmp/astronomer-providers
 RUN  python3 -m pip install --upgrade pip
 # Ideally we should install using constraints file
 RUN pip install  --upgrade --force-reinstall  --no-cache-dir /tmp/astronomer-providers[all]
-pip install --upgrade apache-airflow-providers-cncf-kubernetes
+RUN pip install --upgrade apache-airflow-providers-cncf-kubernetes
 RUN pip install apache-airflow[slack]
 
 # Install astronomer-starship-provider needed for the astronomer_migration_dag to transfer Airflow metadata between deployments

--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -76,6 +76,7 @@ COPY astronomer-providers /tmp/astronomer-providers
 RUN  python3 -m pip install --upgrade pip
 # Ideally we should install using constraints file
 RUN pip install  --upgrade --force-reinstall  --no-cache-dir /tmp/astronomer-providers[all]
+pip install --upgrade apache-airflow-providers-cncf-kubernetes
 RUN pip install apache-airflow[slack]
 
 # Install astronomer-starship-provider needed for the astronomer_migration_dag to transfer Airflow metadata between deployments


### PR DESCRIPTION
We have recently observed that after the latest Airflow Provider Release, our deployment does not have the latest Kubernetes providers. However, for other providers like the Google provider, we have the latest version. As a result, our `example_google_kubernetes_engine` DAG is experiencing parsing issues, as per discuss we decided to upgrade k8s provider explicitly in out docker file

More context [here](https://astronomer.slack.com/archives/C037VQ1HCHZ/p1688963040664369?thread_ts=1688953741.833109&cid=C037VQ1HCHZ)