### PR TITLE
Adding only valid DAG state for TriggerDagRunOperator

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -136,7 +136,7 @@ def prepare_dag_dependency(task_info, execution_time):
                 wait_for_completion=True,
                 reset_dag_run=True,
                 execution_date=execution_time,
-                allowed_states=["success", "failed", "queued", "running"],
+                allowed_states=["success", "failed"],
                 trigger_rule="all_done",
             )
         )

--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -136,7 +136,7 @@ def prepare_dag_dependency(task_info, execution_time):
                 wait_for_completion=True,
                 reset_dag_run=True,
                 execution_date=execution_time,
-                allowed_states=["success", "failed", "skipped"],
+                allowed_states=["success", "failed", "queued", "running"],
                 trigger_rule="all_done",
             )
         )

--- a/astronomer/providers/core/example_dags/example_external_task.py
+++ b/astronomer/providers/core/example_dags/example_external_task.py
@@ -71,7 +71,7 @@ with DAG(
         trigger_dag_id="example_external_task_async_waits_for_me",
         wait_for_completion=True,
         reset_dag_run=True,
-        allowed_states=["success", "failed", "queued", "running"],
+        allowed_states=["success", "failed"],
         execution_date="{{execution_date}}",
         poke_interval=1,
     )

--- a/astronomer/providers/core/example_dags/example_external_task.py
+++ b/astronomer/providers/core/example_dags/example_external_task.py
@@ -71,7 +71,7 @@ with DAG(
         trigger_dag_id="example_external_task_async_waits_for_me",
         wait_for_completion=True,
         reset_dag_run=True,
-        allowed_states=["success", "failed", "skipped"],
+        allowed_states=["success", "failed", "queued", "running"],
         execution_date="{{execution_date}}",
         poke_interval=1,
     )


### PR DESCRIPTION
Recently, we have noticed that our Master DAG and example_external_task DAG are throwing parsing errors due to a new [change](https://github.com/apache/airflow/commit/fd2687d0d51fa444f63aac705d843f30e5922319#diff-800088a475d2b93df93b7b497aba69eeb0485005be1d4dd5b414c46ab1c68023). We can only pass valid DAG [states](https://github.com/apache/airflow/blob/145b16caaa43f0c42bffd97344df916c602cddde/airflow/utils/state.py#L67C7-L67C18) in TriggerDagRunOperator. This PR will address this issue