### PR TITLE
Enable `do_xcom_push` param in KPO example

### DIFF
--- a/astronomer/providers/cncf/kubernetes/example_dags/example_kubernetes_pod_operator.py
+++ b/astronomer/providers/cncf/kubernetes/example_dags/example_kubernetes_pod_operator.py
@@ -53,6 +53,7 @@ with DAG(
                 'echo \'{"message": "good afternoon!"}\' > /airflow/xcom/return.json'
             ),
         ],
+        do_xcom_push=True,
     )
     # [END howto_operator_kubernetes_pod_async]
 


### PR DESCRIPTION
In our KPO example test, we write some dummy data at path `/airflow/xcom/return.json` 
The intention of doing this would be probably to push this data in xcom 
but it does not push since `do_xcom_push` is false. 
so either we should set `do_xcom_push`  to true or remove `'echo \'{"message": "good afternoon!"}\' > /airflow/xcom/return.json' `