### PR TITLE
Correct testing module import path as per Pandas 2.0.0 release

### DIFF
--- a/tests/amazon/aws/xcom_backends/test_s3.py
+++ b/tests/amazon/aws/xcom_backends/test_s3.py
@@ -13,7 +13,7 @@ import pytest
 from airflow import settings
 from airflow.configuration import conf
 from airflow.models.xcom import BaseXCom
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 
 from astronomer.providers.amazon.aws.xcom_backends.s3 import (
     S3XComBackend,

--- a/tests/google/cloud/xcom_backends/test_gcs.py
+++ b/tests/google/cloud/xcom_backends/test_gcs.py
@@ -13,7 +13,7 @@ import pytest
 from airflow import settings
 from airflow.configuration import conf
 from airflow.models.xcom import BaseXCom
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 
 from astronomer.providers.google.cloud.xcom_backends.gcs import (
     GCSXComBackend,


### PR DESCRIPTION
Tests have been failing as observed in PR https://github.com/astronomer/astronomer-providers/pull/1252
for the missing import path pandas.util.testing. It is observed
the module was moved one level up in the Pandas 2.0.0 release 
and hence import the module from that path.