### PR TITLE
fix(databricks): get jod_id from job_name for DatabricksRunNowOperatorAsync

### DIFF
--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -10,7 +10,6 @@ from airflow.providers.databricks.operators.databricks import (
     DatabricksRunNowOperator,
     DatabricksSubmitRunOperator,
 )
-
 from astronomer.providers.databricks.triggers.databricks import DatabricksTrigger
 from astronomer.providers.utils.typing_compat import Context
 
@@ -403,6 +402,13 @@ class DatabricksRunNowOperatorAsync(DatabricksRunNowOperator):
         except TypeError:
             # for apache-airflow-providers-databricks>=3.2.0
             hook = self._get_hook(caller="DatabricksRunNowOperatorAsync")
+
+        if "job_name" in self.json:
+            job_id = hook.find_job_id_by_name(self.json["job_name"])
+            if job_id is None:
+                raise AirflowException(f"Job ID for job name {self.json['job_name']} can not be found")
+            self.json["job_id"] = job_id
+            del self.json["job_name"]
         self.run_id = hook.run_now(self.json)
 
         if self.do_xcom_push:

--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -10,6 +10,7 @@ from airflow.providers.databricks.operators.databricks import (
     DatabricksRunNowOperator,
     DatabricksSubmitRunOperator,
 )
+
 from astronomer.providers.databricks.triggers.databricks import DatabricksTrigger
 from astronomer.providers.utils.typing_compat import Context
 

--- a/tests/databricks/operators/test_databricks.py
+++ b/tests/databricks/operators/test_databricks.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
+
 from astronomer.providers.databricks.operators.databricks import (
     DatabricksRunNowOperatorAsync,
     DatabricksSubmitRunOperatorAsync,

--- a/tests/databricks/operators/test_databricks.py
+++ b/tests/databricks/operators/test_databricks.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
-
 from astronomer.providers.databricks.operators.databricks import (
     DatabricksRunNowOperatorAsync,
     DatabricksSubmitRunOperatorAsync,
@@ -357,6 +356,31 @@ class TestDatabricksRunNowOperatorAsync:
         operator = DatabricksRunNowOperatorAsync(
             task_id="run_now",
             databricks_conn_id=CONN_ID,
+        )
+
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute(context=create_context(operator))
+
+        assert isinstance(exc.value.trigger, DatabricksTrigger), "Trigger is not a DatabricksTrigger"
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.find_job_id_by_name")
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook.get_run")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.run_now")
+    @mock.patch("astronomer.providers.databricks.hooks.databricks.DatabricksHook.get_run_page_url")
+    def test_databricks_run_now_operator_async(
+        self, run_now_response, get_run_page_url_response, get_run, find_job_id_by_name
+    ):
+        """
+        Asserts that a task is deferred and an DatabricksTrigger will be fired
+        when the DatabricksRunNowOperatorAsync is executed.
+        """
+        run_now_response.return_value = {"run_id": RUN_ID}
+        get_run_page_url_response.return_value = RUN_PAGE_URL
+        get_run.return_value = make_run_with_state_mock("RUNNING", "SUCCESS")
+        find_job_id_by_name.return_value = 1
+
+        operator = DatabricksRunNowOperatorAsync(
+            task_id="run_now", databricks_conn_id=CONN_ID, job_name="mock_name"
         )
 
         with pytest.raises(TaskDeferred) as exc:


### PR DESCRIPTION
This fixes the issue that `job_name` is passed without `job_id` and gets `{"error_code":"INVALID_PARAMETER_VALUE","message":"Job 0 does not exist."}` error