### PR TITLE
fix release github workflow failure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   trigger-release-process:
-    if: github.event.pull_request.merged == true && startswith(github.event.head_commit.message, 'Release ')
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Check out
@@ -17,10 +17,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check head commit message
-        env:
-          head_commit_title: ${{ github.event.head_commit.message }}
         run: |
-          python ./.github/scripts/validate_release_commit.py "$head_commit_title"
+          head_commit_message=`git log --format=%s -1`
+          python ./.github/scripts/validate_release_commit.py $head_commit_message
 
       - name: Install commitizen
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,4 +51,5 @@ jobs:
         run: |
           make ASTRO_PROVIDER_VERSION=dev bump-version
           git add .
+          git commit -m "Bump version to `cz version -p`"
           git push origin main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,25 +17,37 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check head commit message
+        id: check_head_commit_message
+        continue-on-error: true
         run: |
           head_commit_message=`git log --format=%s -1`
           python ./.github/scripts/validate_release_commit.py $head_commit_message
+          if [ $? -eq 1 ]
+          then
+            echo "valid_release_message=False" >> $GITHUB_OUTPUT
+          else
+            echo "valid_release_message=True" >> $GITHUB_OUTPUT
+          fi
 
       - name: Install commitizen
+        if: ${{ steps.check_head_commit_message.outputs.valid_release_message == 'True' }}
         run: |
           pip3 install commitizen
 
       - name: Setup Github Actions git user
+        if: ${{ steps.check_head_commit_message.outputs.valid_release_message == 'True' }}
         run: |
           git config --global user.email "airflow-oss-bot@astronomer.io"
           git config --global user.name "airflow-oss-bot"
 
       - name: Tag and push tag for triggering release
+        if: ${{ steps.check_head_commit_message.outputs.valid_release_message == 'True' }}
         run: |
           git tag `cz version -p`
           git push origin `cz version -p`
 
       - name: Bump version for new development
+        if: ${{ steps.check_head_commit_message.outputs.valid_release_message == 'True' }}
         run: |
           make ASTRO_PROVIDER_VERSION=dev bump-version
           git add .


### PR DESCRIPTION
* ci(github-actions):
    * postpone the commit message check to python script as `github.event.pull_request` does not have commit message
    * skip if the head message is not "Release \d+\.\d+\.\d+"
 

