### PR TITLE
Increase sts token life for segmaker

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_sagemaker.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_sagemaker.py
@@ -264,7 +264,7 @@ def get_aws_sagemaker_session(task_instance: TaskInstance) -> None:
 
     client = boto3.client("sts", **AWS_SAGEMAKER_CREDS)
     try:
-        response = client.get_session_token(DurationSeconds=1800)
+        response = client.get_session_token(DurationSeconds=7200)
         task_instance.xcom_push(
             key="sagemaker_credentials",
             value=json.loads(json.dumps(response["Credentials"], cls=AirflowJsonEncoder)),


### PR DESCRIPTION
the current token life is 30min but dag take sometime more than 30min recently we got error that token expire so increasing the token lifetime

https://org-airflow-team-org.astronomer.run/dfi0rona/dags/example_async_sagemaker/grid?dag_run_id=sagemaker_dag_example_async_sagemaker_2023-07-26&task_id=test_model&tab=logs