### PR TITLE
Call S3 sensor check_fn only with file size attribute

### DIFF
--- a/astronomer/providers/amazon/aws/triggers/s3.py
+++ b/astronomer/providers/amazon/aws/triggers/s3.py
@@ -80,7 +80,8 @@ class S3KeyTrigger(BaseTrigger):
                                 client, self.bucket_name, self.bucket_key, self.wildcard_match
                             )
                             await asyncio.sleep(self.poke_interval)
-                            yield TriggerEvent({"status": "running", "files": s3_objects})
+                            files = [{"Size", s3_object["Size"]} for s3_object in s3_objects]
+                            yield TriggerEvent({"status": "running", "files": files})
                         else:
                             yield TriggerEvent({"status": "success"})
                     await asyncio.sleep(self.poke_interval)

--- a/astronomer/providers/amazon/aws/triggers/s3.py
+++ b/astronomer/providers/amazon/aws/triggers/s3.py
@@ -80,7 +80,7 @@ class S3KeyTrigger(BaseTrigger):
                                 client, self.bucket_name, self.bucket_key, self.wildcard_match
                             )
                             await asyncio.sleep(self.poke_interval)
-                            files = [{"Size", s3_object["Size"]} for s3_object in s3_objects]
+                            files = [{"Size": s3_object["Size"]} for s3_object in s3_objects]
                             yield TriggerEvent({"status": "running", "files": files})
                         else:
                             yield TriggerEvent({"status": "success"})

--- a/tests/amazon/aws/triggers/test_s3_triggers.py
+++ b/tests/amazon/aws/triggers/test_s3_triggers.py
@@ -90,7 +90,7 @@ class TestS3KeyTrigger:
     async def test_run_check_fn_success(self, mock_get_files, mock_client):
         """Test if the task is run is in trigger with check_fn."""
 
-        mock_get_files.return_value = ["test"]
+        mock_get_files.return_value = [{"Size": 123, "Key": "test.csv"}]
         mock_client.return_value.check_key.return_value = True
         trigger = S3KeyTrigger(
             bucket_key="s3://test_bucket/file",
@@ -100,7 +100,7 @@ class TestS3KeyTrigger:
         )
         generator = trigger.run()
         actual = await generator.asend(None)
-        assert TriggerEvent({"status": "running", "files": ["test"]}) == actual
+        assert TriggerEvent({"status": "running", "files": [{"Size": 123}]}) == actual
 
 
 class TestS3KeysUnchangedTrigger:


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-providers/issues/1213

Airflow S3Sensor and astronomer-provider S3SensorAsync call check_fn param with different param. This PR restrict S3SensorAsync to call check_fn with the same param as in the Airflow sensor