### PR TITLE
Fix automate process

### DIFF
--- a/.github/scripts/validate_release_commit.py
+++ b/.github/scripts/validate_release_commit.py
@@ -2,7 +2,7 @@ import re
 import sys
 
 if __name__ == "__main__":
-    pattern = r"^Release \d{1,}\.\d{1,}\.\d{1,}$"
+    pattern = r"^Release \d{1,}\.\d{1,}\.\d{1,}( \(#\d+\)){0,1}$"
     if len(sys.argv) == 2:
         commit_message = sys.argv[1]
         if not re.fullmatch(pattern, commit_message):

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
 
       - name: Check head commit message
         id: check_head_commit_message

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
         continue-on-error: true
         run: |
           head_commit_message=`git log --format=%s -1`
-          python ./.github/scripts/validate_release_commit.py $head_commit_message
+          python ./.github/scripts/validate_release_commit.py "$head_commit_message"
           if [ $? -eq 1 ]
           then
             echo "valid_release_message=False" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,11 +45,3 @@ jobs:
         run: |
           git tag `cz version -p`
           git push origin `cz version -p`
-
-      - name: Bump version for new development
-        if: ${{ steps.check_head_commit_message.outputs.valid_release_message == 'True' }}
-        run: |
-          make ASTRO_PROVIDER_VERSION=dev bump-version
-          git add .
-          git commit -m "Bump version to `cz version -p`"
-          git push origin main


### PR DESCRIPTION
* fix release commit validation step failure
    * we'll need to quote the commit message when running the bash script
* change the regex to check the release commit to include the PR number
    * Our release message format is something like "Release 1.0.0 (#123)" instead of "Release 1.0.0" 
* use BOT_ACCESS_TOKEN to push the git tag
* remove bump dev version step for now as it will fail due to commitizen behavior