### PR TITLE
Update CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ workflows:
           matrix:
             parameters:
               python_version: ["3.8", "3.9", "3.10", "3.11"]
-              airflow_version: ["2.4.2", "2.5.3", "2.6.3"]
+              airflow_version: ["2.4.3", "2.5.3", "2.6.3"]
           <<: *main_and_release_branches
       - build-docs:
           <<: *all_branches_and_version_tag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,8 @@ workflows:
           name: constraints-<< matrix.python_version >>-<< matrix.airflow_version >>
           matrix:
             parameters:
-              python_version: ["3.8", "3.9", "3.10"]
-              airflow_version: ["2.3.4", "2.4.2", "2.5.3"]
+              python_version: ["3.8", "3.9", "3.10", "3.11"]
+              airflow_version: ["2.4.2", "2.5.3", "2.6.3"]
           <<: *main_and_release_branches
       - build-docs:
           <<: *all_branches_and_version_tag
@@ -76,7 +76,7 @@ executors:
     parameters:
       python_version:
         type: string
-        default: "3.8"
+        default: "3.10"
     docker:
       - image: cimg/python:<<parameters.python_version>>
 
@@ -108,7 +108,7 @@ jobs:
     description: "Mypy"
     executor:
       name: docker-executor
-      python_version: "3.9"
+      python_version: "3.10"
     steps:
       - checkout
       - restore_cache:
@@ -140,7 +140,7 @@ jobs:
     description: "Build docs"
     executor:
       name: docker-executor
-      python_version: "3.9"
+      python_version: "3.10"
     steps:
       - checkout
       - restore_cache:
@@ -282,7 +282,7 @@ jobs:
   build-and-verify:
     executor:
       name: docker-executor
-      python_version: "3.9"
+      python_version: "3.10"
     steps:
       - checkout
       - run:
@@ -304,7 +304,7 @@ jobs:
   publish:
     executor:
       name: docker-executor
-      python_version: "3.9"
+      python_version: "3.10"
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ workflows:
           <<: *all_branches_and_version_tag
           requires:
             - test
+            - test-python3-11
             - build-docs
             - mypy
       - hold:


### PR DESCRIPTION
- set the default Python version to 3.10 since the runtime default Python version is 3.10
- generate constraint for Airflow-2.6.3