### PR TITLE
Simplify release steps through "make prepare-release" make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,5 +108,12 @@ bump-version:  ## Bump versions in files locally. By default bump to DEV. set en
 		cz bump $(ASTRO_PROVIDER_VERSION) --files-only;\
     fi
 
+prepare-release:  ## Create a release branch, bump version and draft changelog. set env ASTRO_PROVIDER_VERSION to change default version. see docs https://github.com/astronomer/astronomer-providers/blob/main/RELEASING.rst#update-the-version-number
+	$(eval branch_name := "release-$(subst .,-,$(ASTRO_PROVIDER_VERSION))")
+	git checkout -b $(branch_name)
+	cz bump $(ASTRO_PROVIDER_VERSION) --files-only
+	python dev/prepare_release_scripts/changelog_drafter.py $(ASTRO_PROVIDER_VERSION)
+	echo "We still need to update the CHANGELOG.rst manually."
+
 help: ## Prints this message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-41s\033[0m %s\n", $$1, $$2}'

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -1,15 +1,6 @@
 How to release?
 ===============
 
-Create a new release branch from main
--------------------------------------
-
-Create a new release branch from ``main`` branch with the name ``release-<version>``.
-e.g. If you want to release version ``1.17.6``, you can create a new branch called ``release-1-17-6`` cut from ``main`` branch.
-
-Note: It is important to prefix your release branch name with ``release-``. This is because we run a CircleCI job to generate
-the constraints files only on such branches and the ``main`` branch.
-
 Decide on the new version number
 --------------------------------
 
@@ -23,8 +14,35 @@ incrementing are as follows:
 
 **Minor** and **Patch** versions should not contain any breaking changes.
 
+Update metadata and create a pull request to main
+-------------------------------------------------
+
+This includes the following steps which are detailed below.
+
+1. Create a new release branch from main
+2. Update the version number
+3. Write the changelog
+
+
+Or you can use make target ``prepare-release`` (make sure you're on the ``main`` branch and have the latest tag on your local machine)
+
+.. code-block:: shell
+
+  make ASTRO_PROVIDER_VERSION=<RELEASE_VERSION> prepare-release
+
+It creates the release branch, checkout to it, bump the version number, extract all the commit messages between the previous release to the latest commit and write them in to CHANGELOG.rst. The only thing you need to do is updating CHANGELOG.rst manually.
+
+Create a new release branch from main
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create a new release branch from ``main`` branch with the name ``release-<version>``.
+e.g. If you want to release version ``1.17.6``, you can create a new branch called ``release-1-17-6`` cut from ``main`` branch.
+
+Note: It is important to prefix your release branch name with ``release-``. This is because we run a CircleCI job to generate
+the constraints files only on such branches and the ``main`` branch.
+
 Update the version number
--------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You will need to update it in:
 
@@ -49,7 +67,7 @@ Bump versions locally
 Note: ``<RELEASE_VERSION>`` is the software version you want to release.
 
 Compare the commits introduced since the last release to aid building the CHANGELOG
------------------------------------------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use the following link to compare the commits introduced since the last release (e.g. 1.15.4)
 
@@ -58,7 +76,7 @@ You can use the following link to compare the commits introduced since the last 
 Note: Make sure to replace the last release version in the above URL
 
 Write the changelog
--------------------
+~~~~~~~~~~~~~~~~~~~
 
 Add the new release to ``CHANGELOG.rst``, along with as many release notes
 as you can (more information is always better than less, though try to group
@@ -71,7 +89,6 @@ Commit the release
 Bundle up these changes into a single commit with the message in the format
 "Release 1.2.1". Submit a pull request for this commit and wait for approval
 unless you are releasing an urgent security fix.
-
 
 Tag and push the commit
 -----------------------

--- a/dev/prepare_release_scripts/changelog_drafter.py
+++ b/dev/prepare_release_scripts/changelog_drafter.py
@@ -1,6 +1,6 @@
 import argparse
 import re
-import subprocess
+import subprocess  # nosec B404
 from datetime import datetime
 
 CHANGELOG_HEADER = """Changelog
@@ -22,7 +22,7 @@ EXCLUDE_PATTERN = (
 def draft_changelog(release_version: str) -> None:
     """Extract commit messages after release_version and write them into changelog"""
     latest_tag = (
-        subprocess.run(
+        subprocess.run(  # nosec B603 B607
             ["git", "tag", "--sort=-authordate", "--merged"],
             capture_output=True,
             text=True,
@@ -32,7 +32,9 @@ def draft_changelog(release_version: str) -> None:
     )
     print(f"The latest version is {latest_tag}")
     git_log_messages = (
-        subprocess.run(["git", "log", "--format=%s", f"{latest_tag}.."], capture_output=True, text=True)
+        subprocess.run(
+            ["git", "log", "--format=%s", f"{latest_tag}.."], capture_output=True, text=True
+        )  # nosec B603 B607
         .stdout.strip()
         .split("\n")
     )

--- a/dev/prepare_release_scripts/changelog_drafter.py
+++ b/dev/prepare_release_scripts/changelog_drafter.py
@@ -1,0 +1,68 @@
+import argparse
+import re
+import subprocess
+from datetime import datetime
+
+CHANGELOG_HEADER = """Changelog
+=========
+
+"""
+
+CHANGELOG_PATH = "CHANGELOG.rst"
+
+# fmt: off
+EXCLUDE_PATTERN = (
+    r"((\[pre\-commit\.ci\] pre-commit autoupdate)|"
+    r"((ci|tests|build)\(.*\): (.*)))"
+    r"( \(#\d+\)){0,1}"
+)
+# fmt: on
+
+
+def draft_changelog(release_version: str) -> None:
+    """Extract commit messages after release_version and write them into changelog"""
+    latest_tag = (
+        subprocess.run(
+            ["git", "tag", "--sort=-authordate", "--merged"],
+            capture_output=True,
+            text=True,
+        )
+        .stdout.split("\n")[0]
+        .strip()
+    )
+    print(f"The latest version is {latest_tag}")
+    git_log_messages = (
+        subprocess.run(["git", "log", "--format=%s", f"{latest_tag}.."], capture_output=True, text=True)
+        .stdout.strip()
+        .split("\n")
+    )
+
+    potential_included_messages = []
+    for message in git_log_messages:
+        if re.match(EXCLUDE_PATTERN, message):
+            print(f'Exclude commit: "{message}"')
+        else:
+            potential_included_messages.append(message)
+    concatenated_message = "\n.. ".join(potential_included_messages)
+
+    with open(CHANGELOG_PATH) as changelog_file:
+        changelog_content = changelog_file.read()
+
+    release_date = datetime.now().strftime("%Y-%m-%d")
+    HEADER_WITH_LATEST_SECTION = f"""{CHANGELOG_HEADER}{release_version} ({release_date})
+-------------------
+
+.. {concatenated_message}
+
+"""
+    changelog_content = changelog_content.replace(CHANGELOG_HEADER, HEADER_WITH_LATEST_SECTION)
+
+    with open(CHANGELOG_PATH, "w") as output_file:
+        output_file.write(changelog_content)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version_to_release", help="the next version to release (e.g., 1.0.0)", type=str)
+    args = parser.parse_args()
+    draft_changelog(args.version_to_release)


### PR DESCRIPTION
`make prepare-release` automates the following steps.

1. Create a new release branch from main
2. Update the version number
3. Write the changelog


This change pushes release automation one step forward. We still need to decide on the bump version and what should be included in the changelog manually, we might not be able to fully automate the process as of now
