### PR TITLE
Adding Python version in Master DAG slack report

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -70,6 +70,7 @@ def get_report(dag_run_ids: List[str], **context: Any) -> None:
             f"*{header}:* `{value}`\n"
             for header, value in [
                 ("Runtime version", os.getenv("ASTRONOMER_RUNTIME_VERSION", "N/A")),
+                ("Python version", os.getenv("PYTHON_VERSION", "N/A")),
                 ("Airflow version", airflow_version),
                 ("Executor", airflow_executor),
                 ("astronomer-providers version", astronomer_providers_version),


### PR DESCRIPTION
Recently we started testing example dags with runtime Python version images and we observed a need to get Python version info in report