### PR TITLE
Use env var for cache version in cache key for CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - mypy-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}
-            - mypy-main-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}
+            # yamllint disable-line rule:line-length
+            - mypy-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}-{{ .Environment.CACHE_VERSION }}
       - run:
           name: Install Dependencies for sasl
           command: |
@@ -142,7 +142,8 @@ jobs:
           paths:
             - ~/.cache/pip
             - ~/.pyenv/versions/
-          key: mypy-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}
+          # yamllint disable-line rule:line-length
+          key: mypy-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}-{{ .Environment.CACHE_VERSION }}
 
   build-docs:
     description: "Build docs"
@@ -153,8 +154,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - docs-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum ".readthedocs.yaml" }}
-            - docs-main-{{ checksum "setup.cfg" }}-{ checksum ".readthedocs.yaml" }}
+            # yamllint disable-line rule:line-length
+            - docs-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum ".readthedocs.yaml" }}-{{ .Environment.CACHE_VERSION }}
       - run:
           name: Install Dependencies for sasl
           command: |
@@ -174,7 +175,8 @@ jobs:
           paths:
             - ~/.cache/pip
             - ~/.pyenv/versions/
-          key: docs-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum ".readthedocs.yaml" }}
+          # yamllint disable-line rule:line-length
+          key: docs-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum ".readthedocs.yaml" }}-{{ .Environment.CACHE_VERSION }}
 
   # This runs unit tests for Python3.11 only and excludes the Apache Hive test since
   # Currently, the Airflow Hive provider is excluded from Python3.11 in Airflow
@@ -190,8 +192,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}
-            - deps-main-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}
+            # yamllint disable-line rule:line-length
+            - deps-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}-{{ .Environment.CACHE_VERSION }}
       - run:
           name: Install Dependencies
           command: pip install -U -e .[test_python_3_11,tests]
@@ -211,7 +213,8 @@ jobs:
           paths:
             - ~/.cache/pip
             - ~/.pyenv/versions/
-          key: deps-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}
+          # yamllint disable-line rule:line-length
+          key: deps-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}-{{ .Environment.CACHE_VERSION }}
 
   test:
     parameters:
@@ -227,8 +230,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}
-            - deps-main-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}
+            # yamllint disable-line rule:line-length
+            - deps-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}-{{ .Environment.CACHE_VERSION }}
       - run:
           name: Install Dependencies for sasl
           command: |
@@ -254,7 +257,8 @@ jobs:
           paths:
             - ~/.cache/pip
             - ~/.pyenv/versions/
-          key: deps-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}
+          # yamllint disable-line rule:line-length
+          key: deps-{{ .Branch }}-{{ checksum "setup.cfg" }}-{{ checksum "/home/circleci/.pyenv/version" }}-{{ .Environment.CACHE_VERSION }}
   generate-constraints:
     parameters:
       python_version:


### PR DESCRIPTION
Currently, main branch is using an old cache for CircleCI jobs. 
We already have a hash for setup.cfg in the key, but this does 
not allow us to use newer upstream dependencies when they 
are released as there is no change in setup.cfg due to no version 
pins. To allow bursting cache, leveraging the use of environment 
variables. Have added a CACHE_VERSION env variable in our 
project settings and set the value for it to today's date. We can 
update it as and when needed by changing the value to new date 
the next time we feel the need to burst the cache.