### PR TITLE
Remove sync wait for deletion of EKS cluster in EMR EKS DAG

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_delete_eks_cluster_and_role_policies.sh
+++ b/astronomer/providers/amazon/aws/example_dags/example_delete_eks_cluster_and_role_policies.sh
@@ -75,7 +75,6 @@ else
 fi
 
 
-# Command to delete the EKS cluster and node group attached with it. Make sure to wait for the cluster to be deleted so
-# that the task reports for any potential failures.
-eksctl delete cluster $EKS_CLUSTER_NAME --wait --force --timeout 60m0s --region $AWS_DEFAULT_REGION
-echo "EKS cluster '$EKS_CLUSTER_NAME' deleted."
+# Command to delete the EKS cluster and node group attached with it.
+eksctl delete cluster $EKS_CLUSTER_NAME --force --region $AWS_DEFAULT_REGION
+echo "EKS cluster '$EKS_CLUSTER_NAME' delete initiated."


### PR DESCRIPTION
It is observed that the EKS cluster DAGs sometimes hangs 
on the CloudFormation Stack to be deleted. It just prolongs 
the task from its completion. Removing the sync wait as we 
could rely on it finishing async and if it fails, the Nuke DAG 
can take care of the deletion.