### PR TITLE
add keep_response parameter to HttpHookAsync 

### DIFF
--- a/astronomer/providers/http/hooks/http.py
+++ b/astronomer/providers/http/hooks/http.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import asyncio
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable
 
 import aiohttp
 from aiohttp import ClientResponseError
@@ -48,10 +50,10 @@ class HttpHookAsync(BaseHook):
 
     async def run(
         self,
-        endpoint: Optional[str] = None,
-        data: Optional[Union[Dict[str, Any], str]] = None,
-        headers: Optional[Dict[str, Any]] = None,
-        extra_options: Optional[Dict[str, Any]] = None,
+        endpoint: str | Nonr = None,
+        data: dict[str, Any] | str | None = None,
+        headers: dict[str, Any] | None = None,
+        extra_options: dict[str, Any] | None = None,
     ) -> "ClientResponse":
         r"""
         Performs an asynchronous HTTP request call

--- a/astronomer/providers/http/hooks/http.py
+++ b/astronomer/providers/http/hooks/http.py
@@ -50,7 +50,7 @@ class HttpHookAsync(BaseHook):
 
     async def run(
         self,
-        endpoint: str | Nonr = None,
+        endpoint: str | None = None,
         data: dict[str, Any] | str | None = None,
         headers: dict[str, Any] | None = None,
         extra_options: dict[str, Any] | None = None,
@@ -80,10 +80,10 @@ class HttpHookAsync(BaseHook):
                 # schema defaults to HTTP
                 schema = conn.schema if conn.schema else "http"
                 host = conn.host if conn.host else ""
-                self.base_url = schema + "://" + host
+                self.base_url = f"{schema}://{host}"
 
             if conn.port:
-                self.base_url = self.base_url + ":" + str(conn.port)
+                self.base_url = f"{self.base_url}:{conn.port}"
             if conn.login:
                 auth = self.auth_type(conn.login, conn.password)
             if conn.extra:
@@ -95,7 +95,7 @@ class HttpHookAsync(BaseHook):
             _headers.update(headers)
 
         if self.base_url and not self.base_url.endswith("/") and endpoint and not endpoint.startswith("/"):
-            url = self.base_url + "/" + endpoint
+            url = f"{self.base_url}/{endpoint}"
         else:
             url = (self.base_url or "") + (endpoint or "")
 
@@ -133,7 +133,7 @@ class HttpHookAsync(BaseHook):
                             self.log.exception("HTTP error with status: %s", e.status)
                             # In this case, the user probably made a mistake.
                             # Don't retry.
-                            raise AirflowException(str(e.status) + ":" + e.message)
+                            raise AirflowException(f"{e.status}:{e.message}")
 
                 attempt_num += 1
                 await asyncio.sleep(self.retry_delay)

--- a/astronomer/providers/http/hooks/http.py
+++ b/astronomer/providers/http/hooks/http.py
@@ -23,7 +23,7 @@ class HttpHookAsync(BaseHook):
         headers can also be specified in the Extra field in json format.
     :param auth_type: The auth type for the service
     :param keep_response: Keep the aiohttp response returned by run method without releasing it.
-        Use it with caution. Withouing properly releasing response, it might cause "Unclosed connection" error.
+        Use it with caution. Without properly releasing response, it might cause "Unclosed connection" error.
         See https://github.com/astronomer/astronomer-providers/issues/909
     :type auth_type: AuthBase of python aiohttp lib
     """

--- a/astronomer/providers/http/hooks/http.py
+++ b/astronomer/providers/http/hooks/http.py
@@ -23,7 +23,7 @@ class HttpHookAsync(BaseHook):
         headers can also be specified in the Extra field in json format.
     :param auth_type: The auth type for the service
     :param keep_response: Keep the aiohttp response returned by run method without releasing it.
-        Use it with caution. Withouing properly releasing reponse, it might cause "Unclosed connection" error.
+        Use it with caution. Withouing properly releasing response, it might cause "Unclosed connection" error.
         See https://github.com/astronomer/astronomer-providers/issues/909
     :type auth_type: AuthBase of python aiohttp lib
     """
@@ -60,7 +60,7 @@ class HttpHookAsync(BaseHook):
         data: dict[str, Any] | str | None = None,
         headers: dict[str, Any] | None = None,
         extra_options: dict[str, Any] | None = None,
-    ) -> "ClientResponse":
+    ) -> ClientResponse:
         r"""
         Performs an asynchronous HTTP request call
 

--- a/astronomer/providers/http/hooks/http.py
+++ b/astronomer/providers/http/hooks/http.py
@@ -40,6 +40,7 @@ class HttpHookAsync(BaseHook):
         auth_type: Any = aiohttp.BasicAuth,
         retry_limit: int = 3,
         retry_delay: float = 1.0,
+        *,
         keep_response: bool = False,
     ) -> None:
         self.http_conn_id = http_conn_id

--- a/astronomer/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/astronomer/providers/snowflake/hooks/snowflake_sql_api.py
@@ -9,9 +9,10 @@ import aiohttp
 import requests
 from airflow import AirflowException
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from astronomer.providers.snowflake.hooks.sql_api_generate_jwt import JWTGenerator
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
+
+from astronomer.providers.snowflake.hooks.sql_api_generate_jwt import JWTGenerator
 
 
 class SnowflakeSqlApiHookAsync(SnowflakeHook):

--- a/astronomer/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/astronomer/providers/snowflake/hooks/snowflake_sql_api.py
@@ -9,10 +9,9 @@ import aiohttp
 import requests
 from airflow import AirflowException
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
+from astronomer.providers.snowflake.hooks.sql_api_generate_jwt import JWTGenerator
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-
-from astronomer.providers.snowflake.hooks.sql_api_generate_jwt import JWTGenerator
 
 
 class SnowflakeSqlApiHookAsync(SnowflakeHook):
@@ -141,7 +140,7 @@ class SnowflakeSqlApiHookAsync(SnowflakeHook):
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:  # pragma: no cover
             raise AirflowException(
-                f"Response: {e.response.content}, " f"Status Code: {e.response.status_code}"
+                f"Response: {e.response.content!r}, " f"Status Code: {e.response.status_code}"
             )  # pragma: no cover
         json_response = response.json()
         self.log.info("Snowflake SQL POST API response: %s", json_response)
@@ -204,7 +203,7 @@ class SnowflakeSqlApiHookAsync(SnowflakeHook):
                 self.log.info(response.json())
             except requests.exceptions.HTTPError as e:
                 raise AirflowException(
-                    f"Response: {e.response.content}, Status Code: {e.response.status_code}"
+                    f"Response: {e.response.content!r}, Status Code: {e.response.status_code}"
                 )
 
     @staticmethod

--- a/tests/http/hooks/test_http.py
+++ b/tests/http/hooks/test_http.py
@@ -5,6 +5,7 @@ import pytest
 from aiohttp.client_exceptions import ClientConnectionError
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
+
 from astronomer.providers.http.hooks.http import HttpHookAsync
 
 
@@ -93,7 +94,7 @@ class TestHttpHookAsync:
         ):
             resp = await hook.run("v1/test")
             with pytest.raises(ClientConnectionError, match="Connection closed"):
-                resp_payload = await resp.json()
+                await resp.json()
 
     @pytest.mark.asyncio
     async def test_post_request_and_get_json_with_keep_response(self, aioresponse):

--- a/tests/http/hooks/test_http.py
+++ b/tests/http/hooks/test_http.py
@@ -2,9 +2,9 @@ import logging
 from unittest import mock
 
 import pytest
+from aiohttp.client_exceptions import ClientConnectionError
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
-
 from astronomer.providers.http.hooks.http import HttpHookAsync
 
 
@@ -54,7 +54,8 @@ class TestHttpHookAsync:
         return Connection(
             conn_id="http_default",
             conn_type="http",
-            host="test:8080/",
+            host="test",
+            port=8080,
             extra='{"bearer": "test"}',
         )
 
@@ -74,6 +75,45 @@ class TestHttpHookAsync:
         ):
             resp = await hook.run("v1/test")
             assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_post_request_and_get_json_without_keep_response(self, aioresponse):
+        hook = HttpHookAsync()
+        payload = '{"status":{"status": 200}}'
+
+        aioresponse.post(
+            "http://test:8080/v1/test",
+            status=200,
+            payload=payload,
+            reason="OK",
+        )
+
+        with mock.patch(
+            "airflow.hooks.base.BaseHook.get_connection", side_effect=self.get_airflow_connection
+        ):
+            resp = await hook.run("v1/test")
+            with pytest.raises(ClientConnectionError, match="Connection closed"):
+                resp_payload = await resp.json()
+
+    @pytest.mark.asyncio
+    async def test_post_request_and_get_json_with_keep_response(self, aioresponse):
+        hook = HttpHookAsync(keep_response=True)
+        payload = '{"status":{"status": 200}}'
+
+        aioresponse.post(
+            "http://test:8080/v1/test",
+            status=200,
+            payload=payload,
+            reason="OK",
+        )
+
+        with mock.patch(
+            "airflow.hooks.base.BaseHook.get_connection", side_effect=self.get_airflow_connection
+        ):
+            resp = await hook.run("v1/test")
+            resp_payload = await resp.json()
+            assert resp.status == 200
+            assert resp_payload == payload
 
     @pytest.mark.asyncio
     async def test_post_request_with_error_code(self, aioresponse):


### PR DESCRIPTION
add keep_response parameter to HttpHookAsync to allow user to use the response after running HttpHookAsync.run

closes: #1321