### PR TITLE
Pin max versions for CNCF Kubernetes and Google Airflow providers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ apache.livy =
     apache-airflow-providers-apache-livy
     paramiko
 cncf.kubernetes =
-    apache-airflow-providers-cncf-kubernetes>=4
+    apache-airflow-providers-cncf-kubernetes>=4,<=7.8.0
     kubernetes_asyncio
 databricks =
     apache-airflow-providers-databricks>=2.2.0
@@ -62,7 +62,8 @@ databricks =
 dbt.cloud =
     apache-airflow-providers-dbt-cloud>=2.1.0
 google =
-    apache-airflow-providers-google>=8.1.0
+    apache-airflow-providers-google>=8.1.0,<=10.11.0
+    apache-airflow-providers-cncf-kubernetes>=4,<=7.8.0
     gcloud-aio-storage
     gcloud-aio-bigquery
 http =
@@ -122,9 +123,9 @@ all =
     apache-airflow-providers-amazon>=3.0.0
     apache-airflow-providers-apache-hive>=6.1.5
     apache-airflow-providers-apache-livy
-    apache-airflow-providers-cncf-kubernetes>=4
+    apache-airflow-providers-cncf-kubernetes>=4,<=7.8.0
     apache-airflow-providers-databricks>=2.2.0
-    apache-airflow-providers-google>=8.1.0
+    apache-airflow-providers-google>=8.1.0,<=10.11.0
     apache-airflow-providers-http
     apache-airflow-providers-snowflake
     apache-airflow-providers-sftp


### PR DESCRIPTION
The release of CNCF Kubernetes Airflow provider 7.9.0 includes PR https://github.com/apache/airflow/pull/35422 whih removes the PodLoggingStatus object that was getting returned that we are relying in our Async KPO operator. Since, it is a breaking change for our operator restrict the max version of the provider to 7.8.0 until which the operator works well for us. Additionally, since the Google KE engine operator also relies on the PodLoggingStatus, also restrict the max version for the Google provider to the previous stable version and restrict the dependent Kubernetes provider version to the one containing the PodLoggingStatus object