### PR TITLE
Revert "Pin max versions for CNCF Kubernetes and Google Airflow providers (#1359)"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ apache.livy =
     apache-airflow-providers-apache-livy
     paramiko
 cncf.kubernetes =
-    apache-airflow-providers-cncf-kubernetes>=4,<=7.8.0
+    apache-airflow-providers-cncf-kubernetes>=4
     kubernetes_asyncio
 databricks =
     apache-airflow-providers-databricks>=2.2.0
@@ -62,8 +62,7 @@ databricks =
 dbt.cloud =
     apache-airflow-providers-dbt-cloud>=2.1.0
 google =
-    apache-airflow-providers-google>=8.1.0,<=10.11.0
-    apache-airflow-providers-cncf-kubernetes>=4,<=7.8.0
+    apache-airflow-providers-google>=8.1.0
     gcloud-aio-storage
     gcloud-aio-bigquery
 http =
@@ -123,9 +122,9 @@ all =
     apache-airflow-providers-amazon>=3.0.0
     apache-airflow-providers-apache-hive>=6.1.5
     apache-airflow-providers-apache-livy
-    apache-airflow-providers-cncf-kubernetes>=4,<=7.8.0
+    apache-airflow-providers-cncf-kubernetes>=4
     apache-airflow-providers-databricks>=2.2.0
-    apache-airflow-providers-google>=8.1.0,<=10.11.0
+    apache-airflow-providers-google>=8.1.0
     apache-airflow-providers-http
     apache-airflow-providers-snowflake
     apache-airflow-providers-sftp


### PR DESCRIPTION
This reverts commit 76d082c502a391bdb704e548cc56c1a421e2ffa3. 
Since even if we pin the max version, there could be a possibility that 
the cncf kubernetes provider version is upgraded in the deployment 
and hence the pin won't be effective. It was decided to revert the 
removal of required PodLoggingStatus object in Airflow OSS and 
corresponding PR has been merged which can be tracked in the linked 
issue.

closes: #1366