### PR TITLE
Adding packages libxml2,libxslt, zlib1g-dev 

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -8,7 +8,7 @@ USER root
 
 RUN apt-get update -y \
     && apt-get install -y software-properties-common \
-    && apt-get install -y wget procps gnupg2
+    && apt-get install -y wget procps gnupg2 \
     && libxml2-dev libxslt-dev zlib1g-dev
 
 # Install openjdk-8

--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -75,7 +75,7 @@ ENV PATH $PATH:$JAVA_HOME/bin::$HIVE_HOME/bin:$HADOOP_HOME/bin
 COPY astronomer-providers /tmp/astronomer-providers
 RUN  python3 -m pip install --upgrade pip
 # Ideally we should install using constraints file
-RUN pip install  --upgrade --no-cache-dir /tmp/astronomer-providers[all]
+RUN pip install  --upgrade --force-reinstall  --no-cache-dir /tmp/astronomer-providers[all]
 RUN pip install apache-airflow-providers-slack
 
 # Install astronomer-starship-provider needed for the astronomer_migration_dag to transfer Airflow metadata between deployments

--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -75,7 +75,7 @@ ENV PATH $PATH:$JAVA_HOME/bin::$HIVE_HOME/bin:$HADOOP_HOME/bin
 COPY astronomer-providers /tmp/astronomer-providers
 RUN  python3 -m pip install --upgrade pip
 # Ideally we should install using constraints file
-RUN pip install  --upgrade --force-reinstall  --no-cache-dir /tmp/astronomer-providers[all]
+RUN pip install  --upgrade --no-cache-dir /tmp/astronomer-providers[all]
 RUN pip install apache-airflow-providers-slack
 
 # Install astronomer-starship-provider needed for the astronomer_migration_dag to transfer Airflow metadata between deployments

--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -9,7 +9,7 @@ USER root
 RUN apt-get update -y \
     && apt-get install -y software-properties-common \
     && apt-get install -y wget procps gnupg2 \
-    && libxml2-dev libxslt-dev zlib1g-dev
+    && apt-get install -y build-essential libxml2-dev libxslt-dev zlib1g-dev
 
 # Install openjdk-8
 RUN apt-add-repository 'deb http://archive.debian.org/debian stretch main' \

--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -9,6 +9,7 @@ USER root
 RUN apt-get update -y \
     && apt-get install -y software-properties-common \
     && apt-get install -y wget procps gnupg2
+    && libxml2-dev libxslt-dev zlib1g-dev
 
 # Install openjdk-8
 RUN apt-add-repository 'deb http://archive.debian.org/debian stretch main' \

--- a/setup.cfg
+++ b/setup.cfg
@@ -139,6 +139,7 @@ all =
     openlineage-airflow>=0.12.0
     paramiko
     snowflake-sqlalchemy>=1.4.4  # Temporary solution for https://github.com/astronomer/astronomer-providers/issues/958, we should pin apache-airflow-providers-snowflake version after it pins this package to great than or equal to 1.4.4.
+    libxml2<5.0.0 # temporary fix due to issue while install 5.0.0
 
 [options.packages.find]
 include =

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,6 @@ zip_safe = false
 amazon =
     apache-airflow-providers-amazon>=3.0.0
     aiobotocore>=2.1.1
-    libxml==4.9.4  # temporary fix due to issue while install 5.0.0
 apache.hive =
     apache-airflow-providers-apache-hive>=6.1.5
     impyla
@@ -140,7 +139,7 @@ all =
     openlineage-airflow>=0.12.0
     paramiko
     snowflake-sqlalchemy>=1.4.4  # Temporary solution for https://github.com/astronomer/astronomer-providers/issues/958, we should pin apache-airflow-providers-snowflake version after it pins this package to great than or equal to 1.4.4.
-
+    lxml==4.9.4  # temporary fix due to issue while install 5.0.0
 [options.packages.find]
 include =
     astronomer.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -139,7 +139,7 @@ all =
     openlineage-airflow>=0.12.0
     paramiko
     snowflake-sqlalchemy>=1.4.4  # Temporary solution for https://github.com/astronomer/astronomer-providers/issues/958, we should pin apache-airflow-providers-snowflake version after it pins this package to great than or equal to 1.4.4.
-    libxml2<5.0.0 # temporary fix due to issue while install 5.0.0
+    libxml==4.9.4 # temporary fix due to issue while install 5.0.0
 
 [options.packages.find]
 include =

--- a/setup.cfg
+++ b/setup.cfg
@@ -139,6 +139,7 @@ all =
     openlineage-airflow>=0.12.0
     paramiko
     snowflake-sqlalchemy>=1.4.4  # Temporary solution for https://github.com/astronomer/astronomer-providers/issues/958, we should pin apache-airflow-providers-snowflake version after it pins this package to great than or equal to 1.4.4.
+
 [options.packages.find]
 include =
     astronomer.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -139,7 +139,6 @@ all =
     openlineage-airflow>=0.12.0
     paramiko
     snowflake-sqlalchemy>=1.4.4  # Temporary solution for https://github.com/astronomer/astronomer-providers/issues/958, we should pin apache-airflow-providers-snowflake version after it pins this package to great than or equal to 1.4.4.
-    lxml==4.9.4  # temporary fix due to issue while install 5.0.0
 [options.packages.find]
 include =
     astronomer.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ zip_safe = false
 amazon =
     apache-airflow-providers-amazon>=3.0.0
     aiobotocore>=2.1.1
+    libxml==4.9.4  # temporary fix due to issue while install 5.0.0
 apache.hive =
     apache-airflow-providers-apache-hive>=6.1.5
     impyla
@@ -139,7 +140,6 @@ all =
     openlineage-airflow>=0.12.0
     paramiko
     snowflake-sqlalchemy>=1.4.4  # Temporary solution for https://github.com/astronomer/astronomer-providers/issues/958, we should pin apache-airflow-providers-snowflake version after it pins this package to great than or equal to 1.4.4.
-    libxml==4.9.4 # temporary fix due to issue while install 5.0.0
 
 [options.packages.find]
 include =


### PR DESCRIPTION
It seems that there is a breaking change in the latest version of lxml (5.0.0), which now requires libxml2 and libxslt. Unfortunately, these packages are not available in Python 3.8 and Python 3.9, causing a failure. I am adding these libxml2,libxslt, zlib1g-dev as temp fix, any user with python3.8, 3.9  tries to install amazon provider they will encounter this issue.

For permanent solutions:-
1. we can add these packages in airflow repo
2. Pin lxml version==4.9.4 in redshift_connector till it get resolved in lxml