### PR TITLE
Add non-ASCII logs check task in master dag

### DIFF
--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -199,13 +199,9 @@ with DAG(
         ],
     )
 
-    """
-    This task is specifically added to test the astronomer logging
-    provider for non-ASCII character testing, as we have providers'
-    tests running on all cloud providers, and we do not want
-    multiple deployments for this.
-    """
-
+    # The below task `check_non_ascii_data` is specifically added to test the astronomer logging
+    # providers for non-ASCII characters, as we have providers' tests running on all
+    # cloud providers, and we do not want multiple deployments for this.
     check_non_ascii_data = PythonOperator(
         task_id="check_non_ascii_data",
         python_callable=check_log,

--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -199,8 +199,15 @@ with DAG(
         ],
     )
 
-    check_swedish_data = PythonOperator(
-        task_id="check_swedish_data",
+    """
+    This task is specifically added to test the astronomer logging
+    provider for non-ASCII character testing, as we have providers'
+    tests running on all cloud providers, and we do not want
+    multiple deployments for this.
+    """
+
+    check_non_ascii_data = PythonOperator(
+        task_id="check_non_ascii_data",
         python_callable=check_log,
         op_args=[
             "get_airflow_version",
@@ -209,7 +216,7 @@ with DAG(
         ],
     )
 
-    airflow_version_check = (get_airflow_version, check_logs_data, check_swedish_data)
+    airflow_version_check = (get_airflow_version, check_logs_data, check_non_ascii_data)
     chain(*airflow_version_check)
 
     get_airflow_executor = BashOperator(

--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -200,7 +200,7 @@ with DAG(
     )
 
     check_encoded_data = PythonOperator(
-        task_id="check_logs",
+        task_id="check_encoded_data",
         python_callable=check_log,
         op_args=[
             "get_airflow_version",

--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -199,8 +199,8 @@ with DAG(
         ],
     )
 
-    check_encoded_data = PythonOperator(
-        task_id="check_encoded_data",
+    check_swedish_data = PythonOperator(
+        task_id="check_swedish_data",
         python_callable=check_log,
         op_args=[
             "get_airflow_version",
@@ -209,7 +209,7 @@ with DAG(
         ],
     )
 
-    airflow_version_check = (get_airflow_version, check_logs_data, check_encoded_data)
+    airflow_version_check = (get_airflow_version, check_logs_data, check_swedish_data)
     chain(*airflow_version_check)
 
     get_airflow_executor = BashOperator(

--- a/.circleci/integration-tests/master_dag.py
+++ b/.circleci/integration-tests/master_dag.py
@@ -187,7 +187,7 @@ with DAG(
     )
 
     get_airflow_version = BashOperator(
-        task_id="get_airflow_version", bash_command="airflow version", do_xcom_push=True
+        task_id="get_airflow_version", bash_command="airflow version && echo åäö", do_xcom_push=True
     )
     check_logs_data = PythonOperator(
         task_id="check_logs",
@@ -199,7 +199,17 @@ with DAG(
         ],
     )
 
-    airflow_version_check = (get_airflow_version, check_logs_data)
+    check_encoded_data = PythonOperator(
+        task_id="check_logs",
+        python_callable=check_log,
+        op_args=[
+            "get_airflow_version",
+            "åäö",
+            "this_string_should_not_be_present_in_logs",
+        ],
+    )
+
+    airflow_version_check = (get_airflow_version, check_logs_data, check_encoded_data)
     chain(*airflow_version_check)
 
     get_airflow_executor = BashOperator(


### PR DESCRIPTION
This PR is to test the astronomer logging provider for non-ASCII character, as we have providers tests running on all cloud providers daily, This will help us test daily without creating additional deployments.