### PR TITLE
ci(providers/amazon): extend max_attempts for resume_redshift_cluster to 20

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_redshift_cluster_management.py
@@ -98,6 +98,7 @@ with DAG(
         task_id="resume_redshift_cluster",
         cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
         aws_conn_id=AWS_CONN_ID,
+        max_attempts=20,
     )
     # [END howto_operator_redshift_resume_cluster_async]
 


### PR DESCRIPTION
closes: #1432

The default max_attempts is 10. If the status is still in the state of "resuming," it raises a failure. Extend this max_attempts for a longer waiting time and fix the master_dag failure.
