### PR TITLE
Increase min airflow version to 2.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     asgiref
     typing_extensions; python_version < "3.8"
     markupsafe>=1.1.1
+    Flask-Session<=0.5.0
 zip_safe = false
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ packages = find_namespace:
 include_package_data = true
 namespace_packages = astronomer,astronomer.providers
 install_requires =
-    apache-airflow>=2.2.0
+    apache-airflow>=2.6.0
     aiohttp
     aiofiles
     asgiref


### PR DESCRIPTION
Since, we bumped the minimum version for the Amazon provider to 8.16.0,
our constraints generation is failing in main as the provider version now needs
Airflow >= 2.6. Hence, bump the same.