### PR TITLE
Add deprecation warning in core provider

### DIFF
--- a/astronomer/providers/core/sensors/external_task.py
+++ b/astronomer/providers/core/sensors/external_task.py
@@ -1,4 +1,5 @@
 import datetime
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from airflow.sensors.external_task import ExternalTaskSensor
@@ -23,6 +24,15 @@ class ExternalTaskSensorAsync(ExternalTaskSensor):  # noqa: D101
         poke_interval: float = 5.0,
         **kwargs: Any,
     ) -> None:
+        warnings.warn(
+            (
+                "This module is deprecated and will be removed in airflow>=2.9.0"
+                "Please use `airflow.sensors.external_task.ExternalTaskSensor` "
+                "and set deferrable to True instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(**kwargs)
         self.poke_interval = poke_interval
 

--- a/astronomer/providers/core/sensors/filesystem.py
+++ b/astronomer/providers/core/sensors/filesystem.py
@@ -23,11 +23,8 @@ class FileSensorAsync(FileSensor):
     :param recursive: when set to ``True``, enables recursive directory matching behavior of
         ``**`` in glob filepath parameter. Defaults to ``False``.
     """
-    def __init__(
-            self,
-            *args,
-            **kwargs
-    ):
+
+    def __init__(self, *args, **kwargs):
         warnings.warn(
             (
                 "This module is deprecated and will be removed in airflow>=2.9.0"

--- a/astronomer/providers/core/sensors/filesystem.py
+++ b/astronomer/providers/core/sensors/filesystem.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from datetime import timedelta
 from typing import Any, Dict, Optional
 
@@ -22,6 +23,21 @@ class FileSensorAsync(FileSensor):
     :param recursive: when set to ``True``, enables recursive directory matching behavior of
         ``**`` in glob filepath parameter. Defaults to ``False``.
     """
+    def __init__(
+            self,
+            *args,
+            **kwargs
+    ):
+        warnings.warn(
+            (
+                "This module is deprecated and will be removed in airflow>=2.9.0"
+                "Please use `airflow.sensors.filesystem.FileSensor` "
+                "and set deferrable to True instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
     def execute(self, context: Context) -> None:
         """Airflow runs this method on the worker and defers using the trigger."""

--- a/astronomer/providers/core/triggers/external_task.py
+++ b/astronomer/providers/core/triggers/external_task.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import typing
+import warnings
 from typing import Any, AsyncIterator, Dict, List, Tuple
 
 from airflow import AirflowException
@@ -105,6 +106,15 @@ class DagStateTrigger(BaseTrigger):
         execution_dates: List[datetime.datetime],
         poll_interval: float = 5.0,
     ):
+        warnings.warn(
+            (
+                "This module is deprecated and will be removed in airflow>=2.9.0"
+                "Please use `airflow.triggers.external_task.WorkflowTrigger` "
+                "and set deferrable to True instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__()
         self.dag_id = dag_id
         self.states = states

--- a/astronomer/providers/core/triggers/filesystem.py
+++ b/astronomer/providers/core/triggers/filesystem.py
@@ -2,6 +2,7 @@ import asyncio
 import datetime
 import os
 import typing
+import warnings
 from glob import glob
 from typing import Any, Dict, Tuple
 
@@ -26,6 +27,15 @@ class FileTrigger(BaseTrigger):
         recursive: bool = False,
         poll_interval: float = 5.0,
     ):
+        warnings.warn(
+            (
+                "This module is deprecated and will be removed in airflow>=2.9.0"
+                "Please use `airflow.triggers.file.FileTrigger` "
+                "and set deferrable to True instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__()
         self.filepath = filepath
         self.recursive = recursive


### PR DESCRIPTION
This PR just added a deprecation warning in the core provider to warn users about removal and encourage them to use the upcoming OSS sensor

closes: https://github.com/astronomer/astronomer-providers/issues/1413