### PR TITLE
Bump python >= 3.8 and fix constraints generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,7 @@ workflows:
             parameters:
               python_version: ["3.8", "3.9", "3.10", "3.11"]
               airflow_version: ["2.6.3", "2.7.3", "2.8.1"]
-          # <<: *main_and_release_branches
-          <<: *all_branches_and_version_tag
+          <<: *main_and_release_branches
       - build-docs:
           <<: *all_branches_and_version_tag
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,16 +37,10 @@ workflows:
           name: constraints-<< matrix.python_version >>-<< matrix.airflow_version >>
           matrix:
             parameters:
-              python_version: ["3.8", "3.9", "3.10"]
-              airflow_version: ["2.4.3", "2.5.3", "2.6.3"]
-          <<: *main_and_release_branches
-      - generate-constraints-python-3-11:
-          name: constraints-<< matrix.python_version >>-<< matrix.airflow_version >>
-          matrix:
-            parameters:
-              python_version: ["3.11"]
-              airflow_version: ["2.6.3", "2.7.0"]
-          <<: *main_and_release_branches
+              python_version: ["3.8", "3.9", "3.10", "3.11"]
+              airflow_version: ["2.6.3", "2.7.3", "2.8.1"]
+          # <<: *main_and_release_branches
+          <<: *all_branches_and_version_tag
       - build-docs:
           <<: *all_branches_and_version_tag
       - test:
@@ -245,37 +239,6 @@ jobs:
              | sort
              | grep -v "@"
              > constraints-<<parameters.python_version>>-<<parameters.airflow_version>>.txt
-      - store_artifacts:
-          path: constraints-<<parameters.python_version>>-<<parameters.airflow_version>>.txt
-  generate-constraints-python-3-11:
-    parameters:
-      python_version:
-        description: "Python Version"
-        type: string
-      airflow_version:
-        description: "Airflow Version"
-        type: string
-    description: Test Python-<<parameters.python_version>>
-    executor:
-      name: docker-executor
-      python_version: "<<parameters.python_version>>"
-    steps:
-      - checkout
-      - run:
-          name: Install Dependencies for sasl
-          command: |
-            sudo apt-get install -y --no-install-recommends build-essential
-            sudo apt-get update
-            sudo apt-get install libsasl2-dev
-      - run:
-          name: Install Dependencies
-          command: pip install -U -e .[all,tests] apache-airflow==<<parameters.airflow_version>>
-      - run:
-          name: Generate Constraints
-          command: pip freeze
-            | sort
-            | grep -v "@"
-            > constraints-<<parameters.python_version>>-<<parameters.airflow_version>>.txt
       - store_artifacts:
           path: constraints-<<parameters.python_version>>-<<parameters.airflow_version>>.txt
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -30,7 +29,7 @@ project_urls =
     Changelog=https://github.com/astronomer/astronomer-providers/blob/main/CHANGELOG.rst
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 packages = find_namespace:
 include_package_data = true
 namespace_packages = astronomer,astronomer.providers
@@ -40,7 +39,6 @@ install_requires =
     aiohttp
     aiofiles
     asgiref
-    typing_extensions; python_version < "3.8"
     markupsafe>=1.1.1
 zip_safe = false
 


### PR DESCRIPTION
Although we attempted to increase Airflow version in #1438,
constraints generation is still failing in main as we try to generate
them on Airflow 2.4.3. We no longer would need to generate constraints
for Airflow 2.4.3, as we have the min Airflow version to 2.6.0 now.
With that we also remove the duplicate job in CI for Python 3.11
constraints generation

Additionally, this PR also bumps the min Python version to 3.8,
we also do not already run tests on Python 3.7 in our CI.
