### PR TITLE
deprecate DataprocSubmitJobOperatorAsync

### DIFF
--- a/astronomer/providers/google/cloud/operators/dataproc.py
+++ b/astronomer/providers/google/cloud/operators/dataproc.py
@@ -236,7 +236,7 @@ class DataprocSubmitJobOperatorAsync(DataprocSubmitJobOperator):
     and set `deferrable` param to `True` instead.
     """
 
-    def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+    def __init__(self, *args: Any, **kwargs: Any):
         warnings.warn(
             (
                 "This module is deprecated. "

--- a/astronomer/providers/google/cloud/triggers/dataproc.py
+++ b/astronomer/providers/google/cloud/triggers/dataproc.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import asyncio
 import time
-from typing import Any, AsyncIterator, Dict, Optional, Sequence, Tuple, Union
+import warnings
+from typing import Any, AsyncIterator, Sequence
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.dataproc import DataprocHook
@@ -36,16 +39,16 @@ class DataprocCreateClusterTrigger(BaseTrigger):
     def __init__(
         self,
         *,
-        project_id: Optional[str] = None,
-        region: Optional[str] = None,
+        project_id: str | None = None,
+        region: str | None = None,
         cluster_name: str,
         end_time: float,
-        metadata: Sequence[Tuple[str, str]] = (),
+        metadata: Sequence[tuple[str, str]] = (),
         delete_on_error: bool = True,
-        cluster_config: Optional[Union[Dict[str, Any], clusters.Cluster]] = None,
-        labels: Optional[Dict[str, str]] = None,
+        cluster_config: dict[str, Any] | clusters.Cluster | None = None,
+        labels: dict[str, str] | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
+        impersonation_chain: str | Sequence[str] | None = None,
         polling_interval: float = 5.0,
         **kwargs: Any,
     ):
@@ -62,7 +65,7 @@ class DataprocCreateClusterTrigger(BaseTrigger):
         self.impersonation_chain = impersonation_chain
         self.polling_interval = polling_interval
 
-    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+    def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serializes DataprocCreateClusterTrigger arguments and classpath."""
         return (
             "astronomer.providers.google.cloud.triggers.dataproc.DataprocCreateClusterTrigger",
@@ -81,7 +84,7 @@ class DataprocCreateClusterTrigger(BaseTrigger):
             },
         )
 
-    async def run(self) -> AsyncIterator["TriggerEvent"]:
+    async def run(self) -> AsyncIterator[TriggerEvent]:
         """Check the status of cluster until reach the terminal state"""
         while self.end_time > time.time():
             try:
@@ -212,11 +215,11 @@ class DataprocDeleteClusterTrigger(BaseTrigger):
         self,
         cluster_name: str,
         end_time: float,
-        project_id: Optional[str] = None,
-        region: Optional[str] = None,
-        metadata: Sequence[Tuple[str, str]] = (),
+        project_id: str | None = None,
+        region: str | None = None,
+        metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",
-        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
+        impersonation_chain: str | Sequence[str] | None = None,
         polling_interval: float = 5.0,
         **kwargs: Any,
     ):
@@ -230,7 +233,7 @@ class DataprocDeleteClusterTrigger(BaseTrigger):
         self.impersonation_chain = impersonation_chain
         self.polling_interval = polling_interval
 
-    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+    def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serializes DataprocDeleteClusterTrigger arguments and classpath."""
         return (
             "astronomer.providers.google.cloud.triggers.dataproc.DataprocDeleteClusterTrigger",
@@ -246,7 +249,7 @@ class DataprocDeleteClusterTrigger(BaseTrigger):
             },
         )
 
-    async def run(self) -> AsyncIterator["TriggerEvent"]:
+    async def run(self) -> AsyncIterator[TriggerEvent]:
         """Wait until cluster is deleted completely"""
         hook = DataprocHookAsync(gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain)
         while self.end_time > time.time():
@@ -274,6 +277,9 @@ class DataProcSubmitTrigger(BaseTrigger):
     """
     Check for the state of a previously submitted Dataproc job.
 
+    This class is deprecated and will be removed in 2.0.0.
+    Use :class: `~ airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger` instead
+
     :param dataproc_job_id: The Dataproc job ID to poll. (templated)
     :param region: Required. The Cloud Dataproc region in which to handle the request. (templated)
     :param project_id: The ID of the google cloud project in which
@@ -293,12 +299,20 @@ class DataProcSubmitTrigger(BaseTrigger):
         self,
         *,
         dataproc_job_id: str,
-        region: Optional[str] = None,
-        project_id: Optional[str] = None,
+        region: str | None = None,
+        project_id: str | None = None,
         gcp_conn_id: str = "google_cloud_default",
-        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
+        impersonation_chain: str | Sequence[str] | None = None,
         polling_interval: float = 5.0,
     ) -> None:
+        warnings.warn(
+            (
+                "This class is deprecated and will be removed in 2.0.0."
+                "Use `airflow.providers.google.cloud.triggers.dataproc.DataprocSubmitTrigger` instead"
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__()
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
@@ -307,7 +321,7 @@ class DataProcSubmitTrigger(BaseTrigger):
         self.impersonation_chain = impersonation_chain
         self.polling_interval = polling_interval
 
-    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+    def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serializes DataProcSubmitTrigger arguments and classpath."""
         return (
             "astronomer.providers.google.cloud.triggers.dataproc.DataProcSubmitTrigger",
@@ -321,7 +335,7 @@ class DataProcSubmitTrigger(BaseTrigger):
             },
         )
 
-    async def run(self) -> AsyncIterator["TriggerEvent"]:
+    async def run(self) -> AsyncIterator[TriggerEvent]:
         """Simple loop until the job running on Google Cloud DataProc is completed or not"""
         try:
             hook = DataprocHookAsync(
@@ -338,7 +352,7 @@ class DataProcSubmitTrigger(BaseTrigger):
             yield TriggerEvent({"status": "error", "message": str(e)})
             return
 
-    async def _get_job_status(self, hook: DataprocHookAsync) -> Dict[str, str]:
+    async def _get_job_status(self, hook: DataprocHookAsync) -> dict[str, str]:
         """Gets the status of the given job_id from the Google Cloud DataProc"""
         job = await hook.get_job(job_id=self.dataproc_job_id, region=self.region, project_id=self.project_id)
         state = job.status.state

--- a/tests/google/cloud/operators/test_dataproc.py
+++ b/tests/google/cloud/operators/test_dataproc.py
@@ -227,7 +227,6 @@ class TestDataprocDeleteClusterOperatorAsync:
 
 
 class TestDataprocSubmitJobOperatorAsync:
-
     def test_init(self):
         task = DataprocSubmitJobOperatorAsync(
             task_id="task-id", job=SPARK_JOB, region=TEST_REGION, project_id=TEST_PROJECT_ID
@@ -235,6 +234,7 @@ class TestDataprocSubmitJobOperatorAsync:
 
         assert isinstance(task, DataprocSubmitJobOperator)
         assert task.deferrable is True
+
 
 class TestDataprocUpdateClusterOperatorAsync:
     OPERATOR = DataprocUpdateClusterOperatorAsync(

--- a/tests/google/cloud/operators/test_dataproc.py
+++ b/tests/google/cloud/operators/test_dataproc.py
@@ -3,9 +3,10 @@ from unittest import mock
 import pytest
 from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.providers.google.cloud.hooks.bigquery import NotFound
+from airflow.providers.google.cloud.operators.dataproc import DataprocSubmitJobOperator
 from google.api_core.exceptions import AlreadyExists
 from google.cloud import dataproc
-from google.cloud.dataproc_v1 import Cluster, JobStatus
+from google.cloud.dataproc_v1 import Cluster
 
 from astronomer.providers.google.cloud.operators.dataproc import (
     DataprocCreateClusterOperatorAsync,
@@ -16,7 +17,6 @@ from astronomer.providers.google.cloud.operators.dataproc import (
 from astronomer.providers.google.cloud.triggers.dataproc import (
     DataprocCreateClusterTrigger,
     DataprocDeleteClusterTrigger,
-    DataProcSubmitTrigger,
 )
 from tests.utils.airflow_util import create_context
 
@@ -227,82 +227,14 @@ class TestDataprocDeleteClusterOperatorAsync:
 
 
 class TestDataprocSubmitJobOperatorAsync:
-    OPERATOR = DataprocSubmitJobOperatorAsync(
-        task_id="task-id", job=SPARK_JOB, region=TEST_REGION, project_id=TEST_PROJECT_ID
-    )
 
-    @mock.patch("astronomer.providers.google.cloud.operators.dataproc.DataprocSubmitJobOperatorAsync.defer")
-    @mock.patch(f"{MODULE}.get_job")
-    @mock.patch(f"{MODULE}.submit_job")
-    def test_dataproc_operator_execute_async_done_before_defer(
-        self, mock_submit_job, mock_get_job, mock_defer
-    ):
-        mock_submit_job.return_value.reference.job_id = TEST_JOB_ID
-        mock_get_job.return_value.status.state = JobStatus.State.DONE
-
-        assert self.OPERATOR.execute(create_context(self.OPERATOR)) == TEST_JOB_ID
-        assert not mock_defer.called
-
-    @pytest.mark.parametrize("state", (JobStatus.State.CANCELLED, JobStatus.State.ERROR))
-    @mock.patch("astronomer.providers.google.cloud.operators.dataproc.DataprocSubmitJobOperatorAsync.defer")
-    @mock.patch(f"{MODULE}.get_job")
-    @mock.patch(f"{MODULE}.submit_job")
-    def test_dataproc_operator_execute_async_failed_before_defer(
-        self, mock_submit_job, mock_get_job, mock_defer, state
-    ):
-        mock_submit_job.return_value.reference.job_id = TEST_JOB_ID
-        mock_get_job.return_value.status.state = state
-        with pytest.raises(AirflowException):
-            self.OPERATOR.execute(create_context(self.OPERATOR))
-        assert not mock_defer.called
-
-    @pytest.mark.parametrize(
-        "state",
-        (
-            JobStatus.State.STATE_UNSPECIFIED,
-            JobStatus.State.PENDING,
-            JobStatus.State.SETUP_DONE,
-            JobStatus.State.RUNNING,
-            JobStatus.State.CANCEL_PENDING,
-            JobStatus.State.CANCEL_STARTED,
-            JobStatus.State.ATTEMPT_FAILURE,
-        ),
-    )
-    @mock.patch(f"{MODULE}.get_job")
-    @mock.patch(f"{MODULE}.submit_job")
-    def test_dataproc_operator_execute_async(self, mock_submit_job, mock_get_job, state):
-        """
-        Asserts that a task is deferred and a DataProcSubmitTrigger will be fired
-        when the DataprocSubmitJobOperatorAsync is executed.
-        """
-        mock_submit_job.return_value.reference.job_id = TEST_JOB_ID
-        mock_get_job.return_value.status.state = state
-        with pytest.raises(TaskDeferred) as exc:
-            self.OPERATOR.execute(create_context(self.OPERATOR))
-        assert isinstance(exc.value.trigger, DataProcSubmitTrigger), "Trigger is not a DataProcSubmitTrigger"
-
-    @pytest.mark.parametrize(
-        "event",
-        [
-            ({"status": "error", "message": "test failure message"}),
-            None,
-        ],
-    )
-    @mock.patch(f"{MODULE}.submit_job")
-    def test_dataproc_operator_execute_failure_async(self, mock_submit_job, event):
-        """Tests that an AirflowException is raised in case of error event"""
-        mock_submit_job.return_value.reference.job_id = TEST_JOB_ID
-        with pytest.raises(AirflowException):
-            self.OPERATOR.execute_complete(context=None, event=event)
-
-    @mock.patch(f"{MODULE}.submit_job")
-    def test_dataproc_operator_execute_success_async(self, mock_submit_job):
-        """Tests response message in case of success event"""
-        mock_submit_job.return_value.reference.job_id = TEST_JOB_ID
-        assert self.OPERATOR.execute_complete(
-            context=None, event={"status": "success", "message": "success", "job_id": TEST_JOB_ID}
+    def test_init(self):
+        task = DataprocSubmitJobOperatorAsync(
+            task_id="task-id", job=SPARK_JOB, region=TEST_REGION, project_id=TEST_PROJECT_ID
         )
 
+        assert isinstance(task, DataprocSubmitJobOperator)
+        assert task.deferrable is True
 
 class TestDataprocUpdateClusterOperatorAsync:
     OPERATOR = DataprocUpdateClusterOperatorAsync(


### PR DESCRIPTION
Deprecate `DataprocSubmitJobOperatorAsync` and proxy it
to its Airflow OSS provider's counterpart