### PR TITLE
Downgrade pendulum version 

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -89,4 +89,5 @@ RUN cp astronomer_migration_dag.py  ${AIRFLOW_HOME}/dags/
 RUN cp nuke-config.yml  ${AIRFLOW_HOME}/dags/
 # we have an issue with connexion==3.0.0, so for now pinning previous stable version
 RUN pip install connexion==2.14.2
+RUN pip install pendulum==2.1.2
 USER astro

--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -89,5 +89,6 @@ RUN cp astronomer_migration_dag.py  ${AIRFLOW_HOME}/dags/
 RUN cp nuke-config.yml  ${AIRFLOW_HOME}/dags/
 # we have an issue with connexion==3.0.0, so for now pinning previous stable version
 RUN pip install connexion==2.14.2
+# Temporary pin of pendulum until the required changes for pendulum 3.0 are handled in Astro
 RUN pip install pendulum==2.1.2
 USER astro


### PR DESCRIPTION
Airflow operator readiness probes make use of Pendulum 2.x. With the release of Pendulum 3.x, the deployment is breaking. A [PR](https://github.com/astronomer/airflow-operator/pull/1775/files) has already been raised in the operator to address this issue. However, the fix has not been released yet. Therefore, downgrading the Pendulum version until the release is available.