### PR TITLE
Enable test connection for increasing local dev productivity

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -16,4 +16,8 @@ COPY pyproject.toml ${AIRFLOW_HOME}/astronomer_providers/pyproject.toml
 
 RUN pip install -e "${AIRFLOW_HOME}/astronomer_providers[all,tests,mypy]"
 RUN pip install apache-airflow-providers-slack
+
+# Enable test connection for increasing local development productivity
+ENV AIRFLOW__CORE__TEST_CONNECTION=Enabled
+
 USER astro


### PR DESCRIPTION
Sets `AIRFLOW__CORE__TEST_CONNECTION=Enabled` in the 
Docker image to allow testing connections in a quick go.