### PR TITLE
Deprecate SageMakerTrainingOperatorAsync

### DIFF
--- a/astronomer/providers/amazon/aws/operators/sagemaker.py
+++ b/astronomer/providers/amazon/aws/operators/sagemaker.py
@@ -1,27 +1,15 @@
 from __future__ import annotations
 
 import json
-import time
 import warnings
 from typing import Any
 
-from airflow.exceptions import AirflowException
-from airflow.providers.amazon.aws.hooks.sagemaker import (
-    LogState,
-    secondary_training_status_message,
-)
 from airflow.providers.amazon.aws.operators.sagemaker import (
     SageMakerProcessingOperator,
     SageMakerTrainingOperator,
     SageMakerTransformOperator,
 )
 from airflow.utils.json import AirflowJsonEncoder
-
-from astronomer.providers.amazon.aws.triggers.sagemaker import (
-    SagemakerTrainingWithLogTrigger,
-    SagemakerTrigger,
-)
-from astronomer.providers.utils.typing_compat import Context
 
 
 def serialize(result: dict[str, Any]) -> str:
@@ -71,137 +59,19 @@ class SageMakerTransformOperatorAsync(SageMakerTransformOperator):
 
 class SageMakerTrainingOperatorAsync(SageMakerTrainingOperator):
     """
-    SageMakerTrainingOperatorAsync starts a model training job and polls for the status asynchronously.
-    After training completes, Amazon SageMaker saves the resulting model artifacts to an Amazon S3 location
-    that you specify.
-
-    .. seealso::
-        For more information on how to use this operator, take a look at the guide:
-        :ref:``howto/operator:SageMakerTrainingOperator``
-
-    :param config: The configuration necessary to start a training job (templated).
-        For details of the configuration parameter see ``SageMaker.Client.create_training_job``
-    :param aws_conn_id: The AWS connection ID to use.
-    :param print_log: if the operator should print the cloudwatch log during training
-    :param check_interval: if wait is set to be true, this is the time interval
-        in seconds which the operator will check the status of the training job
-    :param max_ingestion_time: The operation fails if the training job
-        doesn't finish within max_ingestion_time seconds. If you set this parameter to None,
-        the operation does not timeout.
-    :param check_if_job_exists: If set to true, then the operator will check whether a training job
-        already exists for the name in the config.
-    :param action_if_job_exists: Behaviour if the job name already exists. Possible options are "increment"
-        (default) and "fail".
-        This is only relevant if check_if_job_exists is True.
+    This class is deprecated.
+    Please use :class: `~airflow.providers.amazon.aws.operators.sagemaker.SageMakerTrainingOperator`
+    and set `deferrable` param to `True` instead.
     """
 
-    def execute(self, context: Context) -> dict[str, Any] | None:  # type: ignore[override]
-        """
-        Creates SageMaker training job via sync hook `create_training_job` and pass the
-        control to trigger and polls for the status of the training job in async
-        """
-        self.preprocess_config()
-        if self.check_if_job_exists:  # pragma: no cover
-            try:
-                # for apache-airflow-providers-amazon<=7.2.1
-                self._check_if_job_exists()  # type: ignore[call-arg]
-            except TypeError:
-                # for apache-airflow-providers-amazon>=7.3.0
-                self.config["TrainingJobName"] = self._get_unique_job_name(
-                    self.config["TrainingJobName"],
-                    self.action_if_job_exists == "fail",
-                    self.hook.describe_training_job,
-                )
-        self.log.info("Creating SageMaker training job %s.", self.config["TrainingJobName"])
-        response = self.hook.create_training_job(
-            self.config,
-            wait_for_completion=False,
-            print_log=False,
-            check_interval=self.check_interval,
-            max_ingestion_time=self.max_ingestion_time,
+    def __init__(self, **kwargs: Any) -> None:
+        warnings.warn(
+            (
+                "This module is deprecated."
+                "Please use `airflow.providers.amazon.aws.operators.sagemaker.SageMakerTrainingOperator`"
+                "and set `deferrable` param to `True` instead."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
         )
-        if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
-            raise AirflowException(f"Sagemaker Training Job creation failed: {response}")
-
-        end_time: float | None = None
-        if self.max_ingestion_time is not None:
-            end_time = time.time() + self.max_ingestion_time
-
-        description = self.hook.describe_training_job(self.config["TrainingJobName"])
-        status = description["TrainingJobStatus"]
-        if self.print_log:
-            instance_count = description["ResourceConfig"]["InstanceCount"]
-            last_describe_job_call = time.monotonic()
-            job_already_completed = status not in self.hook.non_terminal_states
-            _, last_description, last_describe_job_call = self.hook.describe_training_job_with_log(
-                self.config["TrainingJobName"],
-                {},
-                [],
-                instance_count,
-                LogState.TAILING if job_already_completed else LogState.COMPLETE,
-                description,
-                last_describe_job_call,
-            )
-
-            self.log.info(secondary_training_status_message(description, None))
-
-            if status in self.hook.failed_states:
-                reason = last_description.get("FailureReason", "(No reason provided)")
-                raise AirflowException(f"SageMaker job failed because {reason}")
-            elif status == "Completed":
-                billable_time = (
-                    last_description["TrainingEndTime"] - last_description["TrainingStartTime"]
-                ) * instance_count
-                self.log.info(
-                    f"Billable seconds: {int(billable_time.total_seconds()) + 1}\n"
-                    f"{self.task_id} completed successfully."
-                )
-                return {"Training": serialize(description)}
-
-            self.defer(
-                timeout=self.execution_timeout,
-                trigger=SagemakerTrainingWithLogTrigger(
-                    poke_interval=self.check_interval,
-                    end_time=end_time,
-                    aws_conn_id=self.aws_conn_id,
-                    job_name=self.config["TrainingJobName"],
-                    instance_count=int(instance_count),
-                    status=status,
-                ),
-                method_name="execute_complete",
-            )
-        else:
-            if status in self.hook.failed_states:
-                raise AirflowException(f"SageMaker job failed because {description['FailureReason']}")
-            elif status == "Completed":
-                self.log.info(f"{self.task_id} completed successfully.")
-                return {"Training": serialize(description)}
-
-            self.defer(
-                timeout=self.execution_timeout,
-                trigger=SagemakerTrigger(
-                    poke_interval=self.check_interval,
-                    end_time=end_time,
-                    aws_conn_id=self.aws_conn_id,
-                    job_name=self.config["TrainingJobName"],
-                    job_type="Training",
-                    response_key="TrainingJobStatus",
-                ),
-                method_name="execute_complete",
-            )
-
-        # for bypassing mypy missing return error
-        return None  # pragma: no cover
-
-    def execute_complete(self, context: Context, event: dict[str, Any]) -> dict[str, Any]:  # type: ignore[override]
-        """
-        Callback for when the trigger fires - returns immediately.
-        Relies on trigger to throw an exception, otherwise it assumes execution was
-        successful.
-        """
-        if event and event["status"] == "success":
-            self.log.info("%s completed successfully.", self.task_id)
-            return {"Training": serialize(event["message"])}
-        if event and event["status"] == "error":
-            raise AirflowException(event["message"])
-        raise AirflowException("No event received in trigger callback")
+        super().__init__(deferrable=True, **kwargs)

--- a/astronomer/providers/amazon/aws/triggers/sagemaker.py
+++ b/astronomer/providers/amazon/aws/triggers/sagemaker.py
@@ -189,6 +189,9 @@ class SagemakerTrainingWithLogTrigger(BaseTrigger):
     """
     SagemakerTrainingWithLogTrigger is fired as deferred class with params to run the task in triggerer.
 
+    This class is deprecated and will be removed in 2.0.0.
+    Use :class: `~airflow.providers.amazon.aws.triggers.sagemaker.SageMakerTrainingPrintLogTrigger` instead
+
     :param job_name: name of the job to check status
     :param instance_count: count of the instance created for running the training job
     :param status: The status of the training job created.
@@ -209,6 +212,14 @@ class SagemakerTrainingWithLogTrigger(BaseTrigger):
         end_time: float | None = None,
         aws_conn_id: str = "aws_default",
     ):
+        warnings.warn(
+            (
+                "This module is deprecated and will be removed in 2.0.0."
+                "Please use `airflow.providers.amazon.aws.hooks.sagemaker.SageMakerTrainingPrintLogTrigger`"
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__()
         self.job_name = job_name
         self.instance_count = instance_count

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,8 @@ zip_safe = false
 
 [options.extras_require]
 amazon =
-    apache-airflow-providers-amazon>=8.17.0
+    # Update version when the below RC is released
+    apache-airflow-providers-amazon>=8.18.0rc1
     aiobotocore>=2.1.1
 apache.hive =
     apache-airflow-providers-apache-hive>=6.1.5
@@ -118,7 +119,8 @@ mypy =
 # All extras from above except 'mypy', 'docs' and 'tests'
 all =
     aiobotocore>=2.1.1
-    apache-airflow-providers-amazon>=8.17.0
+    # Update version when the below RC is released
+    apache-airflow-providers-amazon>=8.18.0rc1
     apache-airflow-providers-apache-hive>=6.1.5
     apache-airflow-providers-apache-livy>=3.7.1
     apache-airflow-providers-cncf-kubernetes>=4

--- a/setup.cfg
+++ b/setup.cfg
@@ -120,7 +120,7 @@ mypy =
 all =
     aiobotocore>=2.1.1
     # Update version when the below RC is released
-    apache-airflow-providers-amazon>=8.18.0rc1
+    apache-airflow-providers-amazon>=8.18.0rc2
     apache-airflow-providers-apache-hive>=6.1.5
     apache-airflow-providers-apache-livy>=3.7.1
     apache-airflow-providers-cncf-kubernetes>=4

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ zip_safe = false
 [options.extras_require]
 amazon =
     # Update version when the below RC is released
-    apache-airflow-providers-amazon>=8.18.0rc1
+    apache-airflow-providers-amazon>=8.18.0rc2
     aiobotocore>=2.1.1
 apache.hive =
     apache-airflow-providers-apache-hive>=6.1.5

--- a/tests/amazon/aws/operators/test_sagemaker.py
+++ b/tests/amazon/aws/operators/test_sagemaker.py
@@ -1,23 +1,13 @@
-from unittest import mock
-
-import pytest
-from airflow.exceptions import AirflowException, TaskDeferred
-from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
-from airflow.providers.amazon.aws.operators import sagemaker
 from airflow.providers.amazon.aws.operators.sagemaker import (
     SageMakerProcessingOperator,
+    SageMakerTrainingOperator,
     SageMakerTransformOperator,
 )
-from airflow.utils.timezone import datetime
 
 from astronomer.providers.amazon.aws.operators.sagemaker import (
     SageMakerProcessingOperatorAsync,
     SageMakerTrainingOperatorAsync,
     SageMakerTransformOperatorAsync,
-)
-from astronomer.providers.amazon.aws.triggers.sagemaker import (
-    SagemakerTrainingWithLogTrigger,
-    SagemakerTrigger,
 )
 
 CREATE_TRANSFORM_PARAMS: dict = {
@@ -172,201 +162,7 @@ class TestSagemakerTrainingOperatorAsync:
     CHECK_INTERVAL = 5
     MAX_INGESTION_TIME = 60 * 60 * 24 * 7
 
-    @pytest.mark.parametrize(
-        "mock_print_log_attr,mock_trigger_class, mock_trigger_name",
-        [
-            (True, SagemakerTrainingWithLogTrigger, "SagemakerTrainingWithLogTrigger"),
-            (False, SagemakerTrigger, "SagemakerTrigger"),
-        ],
-    )
-    @mock.patch("astronomer.providers.amazon.aws.operators.sagemaker.SageMakerTrainingOperatorAsync.defer")
-    @mock.patch.object(
-        SageMakerHook,
-        "describe_training_job_with_log",
-        return_value=(
-            ...,
-            {
-                "TrainingJobStatus": "Completed",
-                "ResourceConfig": {"InstanceCount": 1},
-                "TrainingEndTime": datetime(2023, 5, 15),
-                "TrainingStartTime": datetime(2023, 5, 16),
-            },
-            datetime(2023, 5, 16),
-        ),
-    )
-    @mock.patch.object(
-        SageMakerHook,
-        "describe_training_job",
-        return_value={
-            "TrainingJobStatus": "Completed",
-            "ResourceConfig": {"InstanceCount": 1},
-        },
-    )
-    @mock.patch.object(SageMakerHook, "get_conn")
-    @mock.patch.object(SageMakerHook, "create_training_job")
-    @mock.patch.object(sagemaker, "serialize", return_value="")
-    @mock.patch.object(SageMakerHook, "list_training_jobs", return_value=[])
-    def test_sagemaker_training_op_async_complete_before_defer(
-        self,
-        mock_list_training_job,
-        mock_serialize,
-        mock_create_training_job,
-        mock_get_conn,
-        mock_describe_training_job,
-        mock_describe_training_job_with_log,
-        mock_defer,
-        mock_print_log_attr,
-        mock_trigger_class,
-        mock_trigger_name,
-    ):
-        mock_create_training_job.return_value = {
-            "TrainingJobArn": "test_arn",
-            "ResponseMetadata": {"HTTPStatusCode": 200},
-        }
-        task = SageMakerTrainingOperatorAsync(
-            config=TRAINING_CONFIG,
-            task_id=self.TASK_ID,
-            check_if_job_exists=False,
-            print_log=mock_print_log_attr,
-            check_interval=self.CHECK_INTERVAL,
-            max_ingestion_time=self.MAX_INGESTION_TIME,
-        )
-        task.execute(None)
-
-        assert not mock_defer.called
-
-    @pytest.mark.parametrize(
-        "mock_print_log_attr,mock_trigger_class, mock_trigger_name",
-        [
-            (True, SagemakerTrainingWithLogTrigger, "SagemakerTrainingWithLogTrigger"),
-            (False, SagemakerTrigger, "SagemakerTrigger"),
-        ],
-    )
-    @mock.patch("astronomer.providers.amazon.aws.operators.sagemaker.SageMakerTrainingOperatorAsync.defer")
-    @mock.patch.object(
-        SageMakerHook,
-        "describe_training_job_with_log",
-        return_value=(
-            ...,
-            {
-                "TrainingJobStatus": "Failed",
-                "ResourceConfig": {"InstanceCount": 1},
-                "FailureReason": "it just failed",
-            },
-            datetime(2023, 5, 16),
-        ),
-    )
-    @mock.patch.object(
-        SageMakerHook,
-        "describe_training_job",
-        return_value={
-            "TrainingJobStatus": "Failed",
-            "ResourceConfig": {"InstanceCount": 1},
-            "FailureReason": "it just failed",
-        },
-    )
-    @mock.patch.object(SageMakerHook, "get_conn")
-    @mock.patch.object(SageMakerHook, "create_training_job")
-    @mock.patch.object(sagemaker, "serialize", return_value="")
-    @mock.patch.object(SageMakerHook, "list_training_jobs", return_value=[])
-    def test_sagemaker_training_op_async_failed_before_defer(
-        self,
-        mock_list_training_job,
-        mock_serialize,
-        mock_create_training_job,
-        mock_get_conn,
-        mock_describe_training_job,
-        mock_describe_training_job_with_log,
-        mock_defer,
-        mock_print_log_attr,
-        mock_trigger_class,
-        mock_trigger_name,
-    ):
-        mock_create_training_job.return_value = {
-            "TrainingJobArn": "test_arn",
-            "ResponseMetadata": {"HTTPStatusCode": 200},
-        }
-        task = SageMakerTrainingOperatorAsync(
-            config=TRAINING_CONFIG,
-            task_id=self.TASK_ID,
-            check_if_job_exists=False,
-            print_log=mock_print_log_attr,
-            check_interval=self.CHECK_INTERVAL,
-            max_ingestion_time=self.MAX_INGESTION_TIME,
-        )
-        with pytest.raises(AirflowException):
-            task.execute(None)
-
-        assert not mock_defer.called
-
-    @pytest.mark.parametrize(
-        "mock_print_log_attr,mock_trigger_class, mock_trigger_name",
-        [
-            (True, SagemakerTrainingWithLogTrigger, "SagemakerTrainingWithLogTrigger"),
-            (False, SagemakerTrigger, "SagemakerTrigger"),
-        ],
-    )
-    @mock.patch.object(
-        SageMakerHook,
-        "describe_training_job_with_log",
-        return_value=(
-            ...,
-            {
-                "TrainingJobStatus": "InProgress",
-                "ResourceConfig": {"InstanceCount": 1},
-            },
-            datetime(2023, 5, 16),
-        ),
-    )
-    @mock.patch.object(
-        SageMakerHook,
-        "describe_training_job",
-        return_value={
-            "TrainingJobStatus": "InProgress",
-            "ResourceConfig": {"InstanceCount": 1},
-        },
-    )
-    @mock.patch.object(SageMakerHook, "get_conn")
-    @mock.patch.object(SageMakerHook, "create_training_job")
-    @mock.patch.object(sagemaker, "serialize", return_value="")
-    @mock.patch.object(SageMakerHook, "list_training_jobs", return_value=[])
-    def test_sagemaker_training_op_async(
-        self,
-        mock_list_training_job,
-        mock_serialize,
-        mock_create_training_job,
-        mock_get_conn,
-        mock_describe_training_job,
-        mock_describe_training_job_with_log,
-        mock_print_log_attr,
-        mock_trigger_class,
-        mock_trigger_name,
-    ):
-        """Assert SageMakerTrainingOperatorAsync deferred properly"""
-        mock_create_training_job.return_value = {
-            "TrainingJobArn": "test_arn",
-            "ResponseMetadata": {"HTTPStatusCode": 200},
-        }
-        task = SageMakerTrainingOperatorAsync(
-            config=TRAINING_CONFIG,
-            task_id=self.TASK_ID,
-            check_if_job_exists=False,
-            print_log=mock_print_log_attr,
-            check_interval=self.CHECK_INTERVAL,
-            max_ingestion_time=self.MAX_INGESTION_TIME,
-        )
-        with pytest.raises(TaskDeferred) as exc:
-            task.execute(None)
-        assert isinstance(exc.value.trigger, mock_trigger_class), f"Trigger is not a {mock_trigger_name}"
-
-    @mock.patch.object(
-        SageMakerHook,
-        "create_training_job",
-        return_value={"TrainingJobArn": "test_arn", "ResponseMetadata": {"HTTPStatusCode": 404}},
-    )
-    @mock.patch.object(SageMakerHook, "list_training_jobs", return_value=[])
-    def test_sagemaker_training_op_async_execute_failure(self, mock_hook, mock_training_job):
-        """Tests that an AirflowException is raised in case of error event from create_training_job"""
+    def test_init(self):
         task = SageMakerTrainingOperatorAsync(
             config=TRAINING_CONFIG,
             task_id=self.TASK_ID,
@@ -374,36 +170,5 @@ class TestSagemakerTrainingOperatorAsync:
             check_interval=self.CHECK_INTERVAL,
             max_ingestion_time=self.MAX_INGESTION_TIME,
         )
-        with pytest.raises(AirflowException):
-            task.execute(None)
-
-    @pytest.mark.parametrize(
-        "mock_event",
-        [{"status": "error", "message": "test failure message"}, None],
-    )
-    def test_sagemaker_training_op_async_execute_complete_failure(self, mock_event):
-        """Tests that an AirflowException is raised in case of error event"""
-        task = SageMakerTrainingOperatorAsync(
-            config=TRAINING_CONFIG,
-            task_id=self.TASK_ID,
-            check_interval=self.CHECK_INTERVAL,
-            max_ingestion_time=self.MAX_INGESTION_TIME,
-        )
-        with pytest.raises(AirflowException):
-            task.execute_complete(context=None, event=mock_event)
-
-    @pytest.mark.parametrize(
-        "mock_event",
-        [{"status": "success", "message": "Job completed"}],
-    )
-    def test_sagemaker_training_op_async_execute_complete(self, mock_event):
-        """Asserts that logging occurs as expected"""
-        task = SageMakerTrainingOperatorAsync(
-            config=TRAINING_CONFIG,
-            task_id=self.TASK_ID,
-            check_interval=self.CHECK_INTERVAL,
-            max_ingestion_time=self.MAX_INGESTION_TIME,
-        )
-        with mock.patch.object(task.log, "info") as mock_log_info:
-            task.execute_complete(context=None, event=mock_event)
-        mock_log_info.assert_called_with("%s completed successfully.", self.TASK_ID)
+        assert isinstance(task, SageMakerTrainingOperator)
+        assert task.deferrable is True


### PR DESCRIPTION
Deprecate SageMakerTrainingOperatorAsync and proxy them to their Airflow OSS provider's counterpart.

this needs to wait for the release of https://github.com/apache/airflow/pull/36685
