### PR TITLE
Update upstream providers versions from RC versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,8 +53,7 @@ apache.livy =
     apache-airflow-providers-apache-livy>=3.7.1
     paramiko
 cncf.kubernetes =
-    # TODO: Update version when below RC is released
-    apache-airflow-providers-cncf-kubernetes @https://files.pythonhosted.org/packages/c9/82/c7422f848a249e437b2c5810b9ccc266b80ffd767322722b16ac97cc3013/apache_airflow_providers_cncf_kubernetes-8.0.0rc2.tar.gz
+    apache-airflow-providers-cncf-kubernetes>=8.0.0
     kubernetes_asyncio
 databricks =
     apache-airflow-providers-databricks>=6.1.0
@@ -122,8 +121,7 @@ all =
     apache-airflow-providers-amazon>=8.18.0
     apache-airflow-providers-apache-hive>=6.1.5
     apache-airflow-providers-apache-livy>=3.7.1
-    # TODO: Update version when below RC is released
-    apache-airflow-providers-cncf-kubernetes @https://files.pythonhosted.org/packages/c9/82/c7422f848a249e437b2c5810b9ccc266b80ffd767322722b16ac97cc3013/apache_airflow_providers_cncf_kubernetes-8.0.0rc2.tar.gz
+    apache-airflow-providers-cncf-kubernetes>=8.0.0
     apache-airflow-providers-databricks>=6.1.0
     apache-airflow-providers-google>=10.15.0
     apache-airflow-providers-http>=4.9.0


### PR DESCRIPTION
In PRs
1. #1463 
2. #1464 
3. #1465 

I had pinned RC2 versions of the upstream providers and merged 
to main so that we can test regressions together on main.

This PR updates the RC2 versions to their corresponding release
versions. 

closes: #1418 
closes: #1411  
closes: #1410 