### PR TITLE
Correct google cloud-sdk download URL protocol to https from http

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -27,7 +27,7 @@ RUN apt-get update -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get install -y curl gnupg \
-    && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
     && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - \
     && apt-get update -y \
     && apt-get install -y \


### PR DESCRIPTION
Recently, we have been observing failures to build our 
integration tests docker images precisely at the step 
where we download the google cloud-sdk library. It has 
been observed that the previously working http URL is 
no longer available and we need to use a https URL. 
This PR corrects the same for successful build of the image.

closes: #1488