### PR TITLE
Update test-rc job schedule to run only once at midnight

### DIFF
--- a/.github/workflows/test-rc-release.yaml
+++ b/.github/workflows/test-rc-release.yaml
@@ -3,7 +3,7 @@ name: Test providers RC releases
 
 on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron: "0 0,12 * * *"
+    - cron: "0 0 * * *"
   workflow_dispatch:
     inputs:
       rc_testing_branch:


### PR DESCRIPTION
This is with an intent to save some costs and running once at midnight should be sufficient.