### PR TITLE
Fix task name to get cluster IP using xcom

### DIFF
--- a/astronomer/providers/sftp/example_dags/example_sftp.py
+++ b/astronomer/providers/sftp/example_dags/example_sftp.py
@@ -167,7 +167,7 @@ def revoke_inbound_rules(task_instance: TaskInstance) -> None:
         FromPort=22,
         ToPort=22,
         GroupId=task_instance.xcom_pull(
-            key="create_ec2_instance", task_ids=["instance_response_master_security_group"]
+            key="instance_response_master_security_group", task_ids=["create_ec2_instance"]
         )[0],
         IpProtocol="tcp",
     )

--- a/astronomer/providers/sftp/example_dags/example_sftp.py
+++ b/astronomer/providers/sftp/example_dags/example_sftp.py
@@ -167,7 +167,7 @@ def revoke_inbound_rules(task_instance: TaskInstance) -> None:
         FromPort=22,
         ToPort=22,
         GroupId=task_instance.xcom_pull(
-            key="cluster_response_master_security_group", task_ids=["describe_created_cluster"]
+            key="create_ec2_instance", task_ids=["instance_response_master_security_group"]
         )[0],
         IpProtocol="tcp",
     )


### PR DESCRIPTION
We were not using correct task for cluster IP retrieval. Updated task name correctly.