### PR TITLE
Bump hive version to 3.1.3

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -38,7 +38,7 @@ RUN apt-get update -y \
 
 
 # Set Hive and Hadoop versions.
-ENV HIVE_LIBRARY_VERSION=hive-2.3.9
+ENV HIVE_LIBRARY_VERSION=hive-3.1.3
 ENV HADOOP_LIBRARY_VERSION=hadoop-2.10.1
 
 # install AWS CLI


### PR DESCRIPTION
Look like 2.3.9 has been removed from https://downloads.apache.org/hive/

see the EOL: https://hive.apache.org/general/downloads/

CI is failing: https://github.com/astronomer/astronomer-providers/actions/runs/9192672500/job/25281901096 

CI with new version: https://github.com/astronomer/astronomer-providers/actions/runs/9194370319/job/25287620589