### PR TITLE
Bump hive version to 4.0.0 as 2.x.x is EOL

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -38,7 +38,7 @@ RUN apt-get update -y \
 
 
 # Set Hive and Hadoop versions.
-ENV HIVE_LIBRARY_VERSION=hive-2.3.9
+ENV HIVE_LIBRARY_VERSION=hive-4.0.0
 ENV HADOOP_LIBRARY_VERSION=hadoop-2.10.1
 
 # install AWS CLI


### PR DESCRIPTION
Bump hive version to  4.0.0