### PR TITLE
Show deprecation status of operators and sensors on the docs operator list page

### DIFF
--- a/astronomer/providers/amazon/aws/operators/batch.py
+++ b/astronomer/providers/amazon/aws/operators/batch.py
@@ -23,6 +23,9 @@ class BatchOperatorAsync(BatchOperator):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.amazon.aws.operators.batch import BatchOperator"
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(
             (

--- a/astronomer/providers/amazon/aws/operators/emr.py
+++ b/astronomer/providers/amazon/aws/operators/emr.py
@@ -9,6 +9,11 @@ class EmrContainerOperatorAsync(EmrContainerOperator):
     Please use :class: `~airflow.providers.amazon.aws.operators.emr.EmrContainerOperator`.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.amazon.aws.operators.emr import EmrContainerOperator"
+    )
+
     def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         warnings.warn(
             (

--- a/astronomer/providers/amazon/aws/operators/redshift_cluster.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_cluster.py
@@ -13,6 +13,11 @@ class RedshiftDeleteClusterOperatorAsync(RedshiftDeleteClusterOperator):
     Please use :class: `~airflow.providers.amazon.aws.operators.redshift_cluster.RedshiftDeleteClusterOperator`.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.amazon.aws.operators.redshift_cluster import RedshiftDeleteClusterOperator"
+    )
+
     def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         warnings.warn(
             (
@@ -32,6 +37,11 @@ class RedshiftResumeClusterOperatorAsync(RedshiftResumeClusterOperator):
     Please use :class: `~airflow.providers.amazon.aws.operators.redshift_cluster.RedshiftResumeClusterOperator`.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.amazon.aws.operators.redshift_cluster import RedshiftResumeClusterOperator"
+    )
+
     def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         warnings.warn(
             (
@@ -50,6 +60,11 @@ class RedshiftPauseClusterOperatorAsync(RedshiftPauseClusterOperator):
     This class is deprecated.
     Please use :class: `~airflow.providers.amazon.aws.operators.redshift_cluster.RedshiftPauseClusterOperator`.
     """
+
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.amazon.aws.operators.redshift_cluster import RedshiftPauseClusterOperator"
+    )
 
     def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         warnings.warn(

--- a/astronomer/providers/amazon/aws/operators/redshift_data.py
+++ b/astronomer/providers/amazon/aws/operators/redshift_data.py
@@ -11,6 +11,11 @@ class RedshiftDataOperatorAsync(RedshiftDataOperator):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.amazon.aws.operators.redshift_data import RedshiftDataOperator"
+    )
+
     def __init__(
         self,
         **kwargs: Any,

--- a/astronomer/providers/amazon/aws/operators/sagemaker.py
+++ b/astronomer/providers/amazon/aws/operators/sagemaker.py
@@ -24,6 +24,11 @@ class SageMakerProcessingOperatorAsync(SageMakerProcessingOperator):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.amazon.aws.operators.sagemaker import SageMakerProcessingOperator"
+    )
+
     def __init__(self, **kwargs: Any) -> None:
         warnings.warn(
             (
@@ -44,6 +49,11 @@ class SageMakerTransformOperatorAsync(SageMakerTransformOperator):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.amazon.aws.operators.sagemaker import SageMakerTransformOperator"
+    )
+
     def __init__(self, **kwargs: Any) -> None:
         warnings.warn(
             (
@@ -63,6 +73,11 @@ class SageMakerTrainingOperatorAsync(SageMakerTrainingOperator):
     Please use :class: `~airflow.providers.amazon.aws.operators.sagemaker.SageMakerTrainingOperator`
     and set `deferrable` param to `True` instead.
     """
+
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.amazon.aws.operators.sagemaker import SageMakerTrainingOperator"
+    )
 
     def __init__(self, **kwargs: Any) -> None:
         warnings.warn(

--- a/astronomer/providers/amazon/aws/sensors/batch.py
+++ b/astronomer/providers/amazon/aws/sensors/batch.py
@@ -9,6 +9,9 @@ class BatchSensorAsync(BatchSensor):
     Please use :class: `~airflow.providers.amazon.aws.sensors.batch.BatchSensor`.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.amazon.aws.sensors.batch import BatchSensor"
+
     def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         warnings.warn(
             (

--- a/astronomer/providers/amazon/aws/sensors/emr.py
+++ b/astronomer/providers/amazon/aws/sensors/emr.py
@@ -15,6 +15,9 @@ class EmrContainerSensorAsync(EmrContainerSensor):
     Please use :class: `~airflow.providers.amazon.aws.sensors.emr.EmrContainerSensor`.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.amazon.aws.sensors.emr import EmrContainerSensor"
+
     def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         poll_interval = kwargs.pop("poll_interval")
         if poll_interval:
@@ -44,6 +47,9 @@ class EmrStepSensorAsync(EmrStepSensor):
     Please use :class: `~airflow.providers.amazon.aws.sensors.emr.EmrStepSensor`.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.amazon.aws.sensors.emr import EmrStepSensor"
+
     def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         warnings.warn(
             (
@@ -62,6 +68,9 @@ class EmrJobFlowSensorAsync(EmrJobFlowSensor):
     This class is deprecated.
     Please use :class: `~airflow.providers.amazon.aws.sensors.emr.EmrJobFlowSensor`.
     """
+
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.amazon.aws.sensors.emr import EmrJobFlowSensor"
 
     def __init__(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
         warnings.warn(

--- a/astronomer/providers/amazon/aws/sensors/redshift_cluster.py
+++ b/astronomer/providers/amazon/aws/sensors/redshift_cluster.py
@@ -11,6 +11,11 @@ class RedshiftClusterSensorAsync(RedshiftClusterSensor):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.amazon.aws.sensors.redshift_cluster import RedshiftClusterSensor"
+    )
+
     def __init__(
         self,
         **kwargs: Any,

--- a/astronomer/providers/amazon/aws/sensors/s3.py
+++ b/astronomer/providers/amazon/aws/sensors/s3.py
@@ -14,6 +14,9 @@ class S3KeySensorAsync(S3KeySensor):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.amazon.aws.sensors.s3 import S3KeySensor"
+
     def __init__(self, **kwargs: Any) -> None:
         warnings.warn(
             (
@@ -30,8 +33,11 @@ class S3KeySensorAsync(S3KeySensor):
 class S3KeySizeSensorAsync(S3KeySensorAsync):
     """
     This class is deprecated.
-    Please use :class: `~astronomer.providers.amazon.aws.sensor.s3.S3KeySensorAsync`.
+    Please use :class: `~airflow.providers.amazon.aws.sensors.s3.S3KeySensor`.
     """
+
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.amazon.aws.sensors.s3 import S3KeySensor"
 
     def __init__(
         self,
@@ -42,7 +48,7 @@ class S3KeySizeSensorAsync(S3KeySensorAsync):
         warnings.warn(
             """
             S3KeySizeSensorAsync is deprecated.
-            Please use `astronomer.providers.amazon.aws.sensor.s3.S3KeySensorAsync`.
+            Please use `airflow.providers.amazon.aws.sensors.s3.S3KeySensor`.
             """,
             DeprecationWarning,
             stacklevel=2,
@@ -56,6 +62,9 @@ class S3KeysUnchangedSensorAsync(S3KeysUnchangedSensor):
     This class is deprecated.
     Please use :class: `~airflow.providers.amazon.aws.sensors.s3.S3KeysUnchangedSensor`.
     """
+
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.amazon.aws.sensors.s3 import S3KeysUnchangedSensor"
 
     def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         warnings.warn(
@@ -73,8 +82,11 @@ class S3KeysUnchangedSensorAsync(S3KeysUnchangedSensor):
 class S3PrefixSensorAsync(BaseSensorOperator):
     """
     This class is deprecated.
-    Please use :class: `~astronomer.providers.amazon.aws.sensor.s3.S3KeySensorAsync`.
+    Please use :class: `~airflow.providers.amazon.aws.sensors.s3.S3KeySensor`.
     """
+
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.amazon.aws.sensors.s3 import S3KeySensor"
 
     def __init__(
         self,
@@ -89,7 +101,7 @@ class S3PrefixSensorAsync(BaseSensorOperator):
         warnings.warn(
             """
             S3PrefixSensor is deprecated.
-            Please use `astronomer.providers.amazon.aws.sensor.s3.S3KeySensorAsync`.
+            Please use `airflow.providers.amazon.aws.sensors.s3.S3KeySensor`.
             """,
             DeprecationWarning,
             stacklevel=2,

--- a/astronomer/providers/apache/livy/operators/livy.py
+++ b/astronomer/providers/apache/livy/operators/livy.py
@@ -15,6 +15,9 @@ class LivyOperatorAsync(LivyOperator):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.apache.livy.operators.livy import LivyOperator"
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(
             "This class is deprecated. "

--- a/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/astronomer/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -21,6 +21,11 @@ class KubernetesPodOperatorAsync(KubernetesPodOperator):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator"
+    )
+
     def __init__(self, **kwargs: Any):
         warnings.warn(
             (

--- a/astronomer/providers/core/sensors/external_task.py
+++ b/astronomer/providers/core/sensors/external_task.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
 
 
 class ExternalTaskSensorAsync(ExternalTaskSensor):  # noqa: D101
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.sensors.external_task import ExternalTaskSensor"
+
     def __init__(
         self,
         poke_interval: float = 5.0,

--- a/astronomer/providers/core/sensors/filesystem.py
+++ b/astronomer/providers/core/sensors/filesystem.py
@@ -26,6 +26,9 @@ class FileSensorAsync(FileSensor):
         ``**`` in glob filepath parameter. Defaults to ``False``.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.sensors.filesystem import FileSensor"
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(
             (

--- a/astronomer/providers/databricks/hooks/databricks.py
+++ b/astronomer/providers/databricks/hooks/databricks.py
@@ -128,7 +128,7 @@ class DatabricksHookAsync(DatabricksHook):
                         json=json if method in ("POST", "PATCH") else None,
                         params=json if method == "GET" else None,
                         headers=headers,
-                        timeout=self.timeout_seconds,
+                        timeout=self.timeout_seconds,  # type: ignore[arg-type]
                     )
                     response.raise_for_status()
                     return cast(Dict[str, Any], await response.json())

--- a/astronomer/providers/databricks/operators/databricks.py
+++ b/astronomer/providers/databricks/operators/databricks.py
@@ -16,6 +16,11 @@ class DatabricksSubmitRunOperatorAsync(DatabricksSubmitRunOperator):
     `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.databricks.operators.databricks import DatabricksSubmitRunOperator"
+    )
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(
             "This class is deprecated."
@@ -31,6 +36,11 @@ class DatabricksRunNowOperatorAsync(DatabricksRunNowOperator):
     Use :class: `~airflow.providers.databricks.operators.databricks.DatabricksRunNowOperator` and set
     `deferrable` param to `True` instead.
     """
+
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.databricks.operators.databricks import DatabricksRunNowOperator"
+    )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(

--- a/astronomer/providers/dbt/cloud/operators/dbt.py
+++ b/astronomer/providers/dbt/cloud/operators/dbt.py
@@ -17,6 +17,11 @@ class DbtCloudRunJobOperatorAsync(DbtCloudRunJobOperator):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.dbt.cloud.operators.dbt import DbtCloudRunJobOperator"
+    )
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(
             (

--- a/astronomer/providers/dbt/cloud/sensors/dbt.py
+++ b/astronomer/providers/dbt/cloud/sensors/dbt.py
@@ -13,6 +13,9 @@ class DbtCloudJobRunSensorAsync(DbtCloudJobRunSensor):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.dbt.cloud.sensors import DbtCloudJobRunSensor"
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(
             (

--- a/astronomer/providers/google/cloud/operators/bigquery.py
+++ b/astronomer/providers/google/cloud/operators/bigquery.py
@@ -23,6 +23,9 @@ class BigQueryInsertJobOperatorAsync(BigQueryInsertJobOperator):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from google.cloud.operators.bigquery import BigQueryInsertJobOperator"
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(
             (
@@ -45,6 +48,9 @@ class BigQueryCheckOperatorAsync(BigQueryCheckOperator):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from google.cloud.operators.bigquery import BigQueryCheckOperator"
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(
             (
@@ -64,6 +70,9 @@ class BigQueryGetDataOperatorAsync(BigQueryGetDataOperator):
     Please use :class: `~airflow.providers.google.cloud.operators.bigquery.BigQueryGetDataOperator`
     and set `deferrable` param to `True` instead.
     """
+
+    is_deprecated = True
+    post_deprecation_replacement = "from google.cloud.operators.bigquery import BigQueryGetDataOperator"
 
     def __init__(self, *args: Any, use_legacy_sql: bool = False, **kwargs: Any) -> None:
         warnings.warn(
@@ -86,6 +95,9 @@ class BigQueryIntervalCheckOperatorAsync(BigQueryIntervalCheckOperator):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from google.cloud.operators.bigquery import BigQueryIntervalCheckOperator"
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(
             (
@@ -105,6 +117,9 @@ class BigQueryValueCheckOperatorAsync(BigQueryValueCheckOperator):
     Please use :class: `~airflow.providers.google.cloud.operators.bigquery.BigQueryValueCheckOperator`
     and set `deferrable` param to `True` instead.
     """
+
+    is_deprecated = True
+    post_deprecation_replacement = "from google.cloud.operators.bigquery import BigQueryValueCheckOperator"
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(

--- a/astronomer/providers/google/cloud/operators/dataproc.py
+++ b/astronomer/providers/google/cloud/operators/dataproc.py
@@ -20,6 +20,11 @@ class DataprocCreateClusterOperatorAsync(DataprocCreateClusterOperator):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.google.cloud.operators.dataproc import DataprocCreateClusterOperator"
+    )
+
     def __init__(
         self,
         *,
@@ -45,6 +50,11 @@ class DataprocDeleteClusterOperatorAsync(DataprocDeleteClusterOperator):
     Please use :class: `~airflow.providers.google.cloud.operators.dataproc.DataprocDeleteClusterOperator`
     and set `deferrable` param to `True` instead.
     """
+
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.google.cloud.operators.dataproc import DataprocDeleteClusterOperator"
+    )
 
     def __init__(
         self,
@@ -74,6 +84,11 @@ class DataprocSubmitJobOperatorAsync(DataprocSubmitJobOperator):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.google.cloud.operators.dataproc import DataprocSubmitJobOperator"
+    )
+
     def __init__(self, *args: Any, **kwargs: Any):
         warnings.warn(
             (
@@ -93,6 +108,11 @@ class DataprocUpdateClusterOperatorAsync(DataprocUpdateClusterOperator):
     Please use :class: `~airflow.providers.google.cloud.operators.dataproc.DataprocUpdateClusterOperator`
     and set `deferrable` param to `True` instead.
     """
+
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.google.cloud.operators.dataproc import DataprocUpdateClusterOperator"
+    )
 
     def __init__(
         self,

--- a/astronomer/providers/google/cloud/operators/kubernetes_engine.py
+++ b/astronomer/providers/google/cloud/operators/kubernetes_engine.py
@@ -15,6 +15,11 @@ class GKEStartPodOperatorAsync(GKEStartPodOperator):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.google.cloud.operators.kubernetes_engine import GKEStartPodOperator"
+    )
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(
             (

--- a/astronomer/providers/google/cloud/sensors/bigquery.py
+++ b/astronomer/providers/google/cloud/sensors/bigquery.py
@@ -15,6 +15,11 @@ class BigQueryTableExistenceSensorAsync(BigQueryTableExistenceSensor):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.google.cloud.sensors.bigquery import BigQueryTableExistenceSensor"
+    )
+
     def __init__(
         self,
         gcp_conn_id: str = "google_cloud_default",

--- a/astronomer/providers/google/cloud/sensors/gcs.py
+++ b/astronomer/providers/google/cloud/sensors/gcs.py
@@ -20,6 +20,11 @@ class GCSObjectExistenceSensorAsync(GCSObjectExistenceSensor):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.google.cloud.sensors.gcs import GCSObjectExistenceSensor"
+    )
+
     def __init__(
         self,
         *args: Any,
@@ -54,6 +59,11 @@ class GCSObjectsWithPrefixExistenceSensorAsync(GCSObjectsWithPrefixExistenceSens
     Please use :class: `~airflow.providers.google.cloud.sensors.gcs.GCSObjectsWithPrefixExistenceSensor`
     and set `deferrable` param to `True` instead.
     """
+
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.google.cloud.sensors.gcs import GCSObjectsWithPrefixExistenceSensor"
+    )
 
     def __init__(
         self,
@@ -90,6 +100,11 @@ class GCSUploadSessionCompleteSensorAsync(GCSUploadSessionCompleteSensor):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.google.cloud.sensors.gcs import GCSUploadSessionCompleteSensor"
+    )
+
     def __init__(
         self,
         *args: Any,
@@ -125,6 +140,11 @@ class GCSObjectUpdateSensorAsync(GCSObjectUpdateSensor):
     Please use :class: `~airflow.providers.google.cloud.sensors.gcs.GCSObjectUpdateSensor`
     and set `deferrable` param to `True` instead.
     """
+
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.google.cloud.sensors.gcs import GCSObjectUpdateSensor"
+    )
 
     def __init__(
         self,

--- a/astronomer/providers/http/sensors/http.py
+++ b/astronomer/providers/http/sensors/http.py
@@ -11,6 +11,9 @@ class HttpSensorAsync(HttpSensor):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.http.sensors.http import HttpSensor"
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(
             (

--- a/astronomer/providers/microsoft/azure/hooks/wasb.py
+++ b/astronomer/providers/microsoft/azure/hooks/wasb.py
@@ -36,9 +36,9 @@ class WasbHookAsync(WasbHook):
         )
         self.conn_id = wasb_conn_id
         self.public_read = public_read
-        self.blob_service_client: BlobServiceClient = self.get_conn()
+        self.blob_service_client: BlobServiceClient = self.get_conn()  # type: ignore[assignment]
 
-    def get_conn(self) -> BlobServiceClient:
+    def get_conn(self) -> BlobServiceClient:  # type: ignore[override]
         """Return the async BlobServiceClient object."""
         conn = self.get_connection(self.conn_id)
         extra = conn.extra_dejson or {}
@@ -87,7 +87,7 @@ class WasbHookAsync(WasbHook):
             **extra,
         )
 
-    def _get_blob_client(self, container_name: str, blob_name: str) -> BlobClient:
+    def _get_blob_client(self, container_name: str, blob_name: str) -> BlobClient:  # type: ignore[override]
         """
         Instantiate a blob client.
 
@@ -110,7 +110,7 @@ class WasbHookAsync(WasbHook):
             return False
         return True
 
-    def _get_container_client(self, container_name: str) -> ContainerClient:
+    def _get_container_client(self, container_name: str) -> ContainerClient:  # type: ignore[override]
         """
         Instantiate a container client.
 

--- a/astronomer/providers/microsoft/azure/operators/data_factory.py
+++ b/astronomer/providers/microsoft/azure/operators/data_factory.py
@@ -12,6 +12,9 @@ class AzureDataFactoryRunPipelineOperatorAsync(AzureDataFactoryRunPipelineOperat
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.microsoft.azure.operators.data_factory import AzureDataFactoryRunPipelineOperator"
+
     def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         warnings.warn(
             (

--- a/astronomer/providers/microsoft/azure/sensors/data_factory.py
+++ b/astronomer/providers/microsoft/azure/sensors/data_factory.py
@@ -11,6 +11,9 @@ class AzureDataFactoryPipelineRunStatusSensorAsync(AzureDataFactoryPipelineRunSt
     instead and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.microsoft.azure.sensors.data_factory import AzureDataFactoryPipelineRunStatusSensor"
+
     def __init__(
         self,
         *args: Any,

--- a/astronomer/providers/microsoft/azure/sensors/wasb.py
+++ b/astronomer/providers/microsoft/azure/sensors/wasb.py
@@ -14,6 +14,9 @@ class WasbBlobSensorAsync(WasbBlobSensor):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.microsoft.azure.sensors.wasb import WasbBlobSensor"
+
     def __init__(
         self,
         *args: Any,
@@ -47,6 +50,11 @@ class WasbPrefixSensorAsync(WasbPrefixSensor):
     Use :class: `~airflow.providers.microsoft.azure.sensors.wasb.WasbPrefixSensor` instead
     and set `deferrable` param to `True` instead.
     """
+
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.microsoft.azure.sensors.wasb import WasbPrefixSensor"
+    )
 
     def __init__(
         self,

--- a/astronomer/providers/sftp/sensors/sftp.py
+++ b/astronomer/providers/sftp/sensors/sftp.py
@@ -11,6 +11,9 @@ class SFTPSensorAsync(SFTPSensor):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = "from airflow.providers.sftp.sensors.sftp import SFTPSensor"
+
     def __init__(
         self,
         *args: Any,

--- a/astronomer/providers/snowflake/operators/snowflake.py
+++ b/astronomer/providers/snowflake/operators/snowflake.py
@@ -216,6 +216,11 @@ class SnowflakeSqlApiOperatorAsync(SnowflakeSqlApiOperator):
     and set `deferrable` param to `True` instead.
     """
 
+    is_deprecated = True
+    post_deprecation_replacement = (
+        "from airflow.providers.snowflake.operators.snowflake import SnowflakeSqlApiOperator"
+    )
+
     def __init__(self, *args: Any, **kwargs: Any):
         warnings.warn(
             (

--- a/docs/_ext/traverse_operators_sensors.py
+++ b/docs/_ext/traverse_operators_sensors.py
@@ -24,7 +24,7 @@ def collect_elements(
     directory_path: str,
     files: list[str],
     element_type: str,
-    elements_list: list[tuple[str, str, str, str]],
+    elements_list: list[tuple[str, bool, str, str]],
     current_module_path: str,
 ):
     """
@@ -51,7 +51,8 @@ def collect_elements(
                     if element_type in element_name and ASYNC_SUBSTRING in element_name:
                         module = importlib.import_module(module_import_path)
                         cls = getattr(module, element_name)
-                        is_deprecated = "Yes" if getattr(cls, "is_deprecated", False) else "No"
+                        is_deprecated = bool(getattr(cls, "is_deprecated", False))
+                        # is_deprecated = "✅" if getattr(cls, "is_deprecated", False) else "❌"
                         post_deprecation_replacement = str(getattr(cls, "post_deprecation_replacement", ""))
                         elements_list.append(
                             (element_name, is_deprecated, module_import_path, post_deprecation_replacement)
@@ -91,21 +92,23 @@ class TraverseOperatorsSensors(SphinxDirective):
             "<table>"
             "<th>#</th>"
             "<th>Operator name</th>"
-            "<th>Is deprecated</th>"
+            "<th>Deprecated</th>"
             "<th>Import path</th>"
-            "<th>Post deprecation replacement</th>"
         )
         for index, operator in enumerate(operators, start=1):
-            class_def_link = operator[1].replace(".", "/") + "/index.html#" + operator[1] + "." + operator[0]
+            class_def_link = operator[2].replace(".", "/") + "/index.html#" + operator[2] + "." + operator[0]
             operators_html += (
                 f"<tr>"
                 f"<td>{index}</td>"
                 f"<td><span><a id={operator[0]}>{operator[0]}</a></span></td>"
-                f"<td style='text-align: center;'>{operator[1]}</td>"
-                f"<td><span><pre><code class='python'>from {operator[2]} import {operator[0]}</code></pre></span></td>"
-                f"<td><span><pre><code class='python'>{operator[3]}</code></pre></span></td>"
-                f"</tr>"
             )
+            if operator[1]:
+                operators_html += "<td style='text-align: center;'>✅</td>"
+                operators_html += f"<td><b>Old Path:</b>\n <span><pre><code class='python'>from {operator[2]} import {operator[0]}</code></pre></span>\n <b>New Path:</b> \n<span><pre><code class='python'>{operator[3]}</code></pre></span></td>"
+            else:
+                operators_html += "<td style='text-align: center;'>❌</td>"
+                operators_html += f"<td><span><pre><code class='python'>from {operator[2]} import {operator[0]}</code></pre></span></td>"
+            operators_html += "</tr>"
             # The below script generates the URL for the class definition by extracting the selected doc version from
             # the current browser URL location.
             operators_html += (
@@ -122,21 +125,23 @@ class TraverseOperatorsSensors(SphinxDirective):
             "<table>"
             "<th>#</th>"
             "<th>Sensor name</th>"
-            "<th>Is deprecated</th>"
+            "<th>Deprecated</th>"
             "<th>Import path</th>"
-            "<th>Replacement import path</th>"
         )
         for index, sensor in enumerate(sensors, start=1):
-            class_def_link = sensor[1].replace(".", "/") + "/index.html#" + sensor[1] + "." + sensor[0]
+            class_def_link = sensor[2].replace(".", "/") + "/index.html#" + sensor[2] + "." + sensor[0]
             sensors_html += (
                 f"<tr>"
                 f"<td>{index}</td>"
                 f"<td><span><a id={sensor[0]}>{sensor[0]}</a></span></td>"
-                f"<td style='text-align: center;'>{sensor[1]}</td>"
-                f"<td><span><pre><code class='python'>from {sensor[2]} import {sensor[0]}</code></pre></span></td>"
-                f"<td><span><pre><code class='python'>{sensor[3]}</code></pre></span></td>"
-                f"</tr>"
             )
+            if sensor[1]:
+                sensors_html += "<td style='text-align: center;'>✅</td>"
+                sensors_html += f"<td><b>Old Path:</b>\n <span><pre><code class='python'>from {sensor[2]} import {sensor[0]}</code></pre></span>\n <b>New Path:</b> \n<span><pre><code class='python'>{sensor[3]}</code></pre></span></td>"
+            else:
+                sensors_html += "<td style='text-align: center;'>❌</td>"
+                sensors_html += f"<td><span><pre><code class='python'>from {sensor[2]} import {sensor[0]}</code></pre></span></td>"
+            sensors_html += "</tr>"
             sensors_html += (
                 f"<script> "
                 f"var base_url = '' + window.location.pathname.split('/providers/')[0] + '/_api/';"

--- a/docs/_ext/traverse_operators_sensors.py
+++ b/docs/_ext/traverse_operators_sensors.py
@@ -29,7 +29,8 @@ def collect_elements(
 ):
     """
     Checks that ``Async`` class definitions exist using ``ast.parse`` in the given files, that those are
-    ``operators/sensors`` and appends the operator/sensor along with its import path to the given output list.
+    ``operators/sensors`` and appends the operator/sensor along with its import path and deprecation status to the
+    given output list.
 
     :param directory_path: path of the directory in which the given ``files`` are located
     :param files: list of files to look for async operator/sensor class definitions
@@ -98,9 +99,7 @@ class TraverseOperatorsSensors(SphinxDirective):
         for index, operator in enumerate(operators, start=1):
             class_def_link = operator[2].replace(".", "/") + "/index.html#" + operator[2] + "." + operator[0]
             operators_html += (
-                f"<tr>"
-                f"<td>{index}</td>"
-                f"<td><span><a id={operator[0]}>{operator[0]}</a></span></td>"
+                f"<tr>" f"<td>{index}</td>" f"<td><span><a id={operator[0]}>{operator[0]}</a></span></td>"
             )
             if operator[1]:
                 operators_html += "<td style='text-align: center;'>✅</td>"
@@ -131,9 +130,7 @@ class TraverseOperatorsSensors(SphinxDirective):
         for index, sensor in enumerate(sensors, start=1):
             class_def_link = sensor[2].replace(".", "/") + "/index.html#" + sensor[2] + "." + sensor[0]
             sensors_html += (
-                f"<tr>"
-                f"<td>{index}</td>"
-                f"<td><span><a id={sensor[0]}>{sensor[0]}</a></span></td>"
+                f"<tr>" f"<td>{index}</td>" f"<td><span><a id={sensor[0]}>{sensor[0]}</a></span></td>"
             )
             if sensor[1]:
                 sensors_html += "<td style='text-align: center;'>✅</td>"

--- a/docs/providers/operators_and_sensors_list.rst
+++ b/docs/providers/operators_and_sensors_list.rst
@@ -1,6 +1,12 @@
 Available Operators and Sensors
 -------------------------------
 
+Since ``astronomer-providers>=1.19.0``, most of the operators and sensors are now deprecated and their instantiations
+are proxied to their upstream Apache Airflow providers' deferrable counterparts.
+Please check the deprecation status in the ``Is deprecated`` column in the tables below. If the status is ``Yes``,
+then you're suggested to use the replacement suggestion provided in the ``Post deprecation replacement`` column and
+pass the ``deferrable=True`` param to the operator/sensor instantiation in your DAG.
+
 .. traverse_operators_sensors::
   :hidden:
   :maxdepth: 2

--- a/docs/providers/operators_and_sensors_list.rst
+++ b/docs/providers/operators_and_sensors_list.rst
@@ -3,8 +3,8 @@ Available Operators and Sensors
 
 Since ``astronomer-providers>=1.19.0``, most of the operators and sensors are now deprecated and their instantiations
 are proxied to their upstream Apache Airflow providers' deferrable counterparts.
-Please check the deprecation status in the ``Is deprecated`` column in the tables below. If the status is ``Yes``,
-then you're suggested to use the replacement suggestion provided in the ``Post deprecation replacement`` column and
+Please check the deprecation status in the ``Deprecated`` column in the tables below. If the status is ``Yes``,
+then you're suggested to use the replacement suggestion provided as ``New Path`` in the ``Import path`` column and
 pass the ``deferrable=True`` param to the operator/sensor instantiation in your DAG.
 
 .. traverse_operators_sensors::

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,10 +78,6 @@ snowflake =
 openlineage =
     openlineage-airflow>=0.12.0
 
-docs =
-    sphinx
-    sphinx-autoapi
-    sphinx-copybutton
 tests =
     aioresponses
     asynctest
@@ -138,6 +134,12 @@ all =
     openlineage-airflow>=0.12.0
     paramiko
     snowflake-sqlalchemy>=1.4.4  # Temporary solution for https://github.com/astronomer/astronomer-providers/issues/958, we should pin apache-airflow-providers-snowflake version after it pins this package to great than or equal to 1.4.4.
+
+docs =
+    sphinx
+    sphinx-autoapi
+    sphinx-copybutton
+    astronomer-providers[all]
 
 [options.packages.find]
 include =


### PR DESCRIPTION
This PR introduces enhancements to the documentation for operators and sensors, specifically to indicate their deprecation status and suggest replacements where applicable.

# Changes

## New Attributes
Added `is_deprecated` and `post_deprecation_replacement` attributes to operator and sensor classes.
1. Deprecation Information: The `is_deprecated` attribute is a boolean that flags whether a class is deprecated.
2. Replacement Suggestion: The `post_deprecation_replacement` attribute provides a string with the import path for the recommended replacement.

## Script changes that builds the operators list
The script `docs/_ext/traverse_operators_sensors.py` that builds in to the documentation the list of operators and sensors now uses the above newly added attributes to denote whether the operators have been deprecated

closes: #1567 