### PR TITLE
Update JDK17 in Dockerfile as per Bookworm requirement

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -10,10 +10,10 @@ RUN apt-get update -y \
     && apt-get install -y software-properties-common \
     && apt-get install -y wget procps gnupg2
 
-# Install openjdk-8
+# Install openjdk-17
 RUN apt-add-repository 'deb http://archive.debian.org/debian stretch main' \
-    && apt-get update && apt-get install -y openjdk-8-jdk
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
+    && apt-get update && apt-get install -y openjdk-17-jdk
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64/
 
 RUN apt-get update -y \
     && apt-get install -y \


### PR DESCRIPTION
We have migrated to Bookworm from Bullseye in runtime12. Astronomer providers' tests are now also moved to runtime12. Since Bookworm does not have JDK8, we are upgrading to the latest version to resolve this issue.