### PR TITLE
add-condition-for-cloning-system-tests

### DIFF
--- a/.github/workflows/reuse-wf-deploy-to-astro-cloud.yaml
+++ b/.github/workflows/reuse-wf-deploy-to-astro-cloud.yaml
@@ -45,6 +45,7 @@ jobs:
 
 
       - name: Clone airflow and copy system tests
+        if: ${{ github.repository == 'astronomer-providers' }}
         working-directory: .circleci/integration-tests
         run: |
             git clone https://github.com/apache/airflow.git


### PR DESCRIPTION
[PR](https://github.com/astronomer/astronomer-providers/pull/1565) introduced a new step of cloning airflow and system test in a reusable wf [here](https://github.com/astronomer/astronomer-providers/pull/1565/files#diff-5681502dadc6c6fb56b8bd817f11c08de363c6ec13c3d020ee14858d2d317b0dR47). As it is a reusable workflow it's used in astronomer-providers-logging wf which started failing also we do not need that step in logging providers tests. This PR address this issue by running step only when repo is astronomer-providers