### PR TITLE
FIxing provider system test path

### DIFF
--- a/.github/workflows/reuse-wf-deploy-to-astro-cloud.yaml
+++ b/.github/workflows/reuse-wf-deploy-to-astro-cloud.yaml
@@ -48,7 +48,7 @@ jobs:
         working-directory: .circleci/integration-tests
         run: |
             git clone https://github.com/apache/airflow.git
-            cp -r airflow/tests/system/providers/databricks .
+            cp -r airflow/providers/tests/system/databricks .
             python ../../.github/scripts/refactor_dag.py databricks/example_databricks_workflow.py
             cat databricks/example_databricks_workflow.py
 


### PR DESCRIPTION
Recent https://github.com/apache/airflow/pull/42505 in airflow updated path of providers and system test. This PR addresses that.