### PR TITLE
Fixing failures due to hive version

### DIFF
--- a/.circleci/integration-tests/Dockerfile.astro_cloud
+++ b/.circleci/integration-tests/Dockerfile.astro_cloud
@@ -38,7 +38,7 @@ RUN apt-get update -y \
 
 
 # Set Hive and Hadoop versions.
-ENV HIVE_LIBRARY_VERSION=hive-3.1.3
+ENV HIVE_LIBRARY_VERSION=hive-4.0.1
 ENV HADOOP_LIBRARY_VERSION=hadoop-2.10.1
 
 # install AWS CLI


### PR DESCRIPTION
Noticed [CI](https://github.com/astronomer/astronomer-providers/actions/runs/11307013444/job/31448269612) job is failing due to hive version. Bumping the version