### PR TITLE
Replacing deprecating provider with overrides with container_overrides

### DIFF
--- a/astronomer/providers/amazon/aws/example_dags/example_batch.py
+++ b/astronomer/providers/amazon/aws/example_dags/example_batch.py
@@ -282,7 +282,7 @@ with DAG(
         job_name=JOB_NAME,
         job_queue=JOB_QUEUE,
         job_definition=JOB_DEFINITION,
-        overrides=JOB_OVERRIDES,
+        container_overrides=JOB_OVERRIDES,
         aws_conn_id=AWS_CONN_ID,
         region_name=AWS_DEFAULT_REGION,
     )


### PR DESCRIPTION
With [PR](https://github.com/apache/airflow/issues/42882) deprecated all deprecated stuff is being removed as there would be a new major release of AWS provider. Is PR update example DAG with same