### PR TITLE
Upgrade GitHub Actions Ubuntu version

### DIFF
--- a/.github/workflows/reuse-wf-check-rc-release.yaml
+++ b/.github/workflows/reuse-wf-check-rc-release.yaml
@@ -56,7 +56,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   check-rc-testing-announcement:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     if: github.event_name == 'schedule'
     env:
       GH_TOKEN: ${{ github.token }}
@@ -121,7 +121,7 @@ jobs:
       rc_issue_url: ${{ steps.export-rc-issue-url.outputs.rc_issue_url }}
 
   validate-manual-input:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     if: github.event_name == 'workflow_dispatch'
     steps:
       - name: Validate user input
@@ -134,7 +134,7 @@ jobs:
 
   create-branch-for-testing-rc-release:
     needs: [validate-manual-input, check-rc-testing-announcement]
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     if: |
       always() &&
       (
@@ -236,7 +236,7 @@ jobs:
         needs.validate-manual-input.result == 'success' &&
         inputs.rc_testing_branch
       )
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     steps:
       - name: export rc_testing_branch
         id: export-rc-testing-branch-name-step

--- a/.github/workflows/reuse-wf-deploy-to-astro-cloud.yaml
+++ b/.github/workflows/reuse-wf-deploy-to-astro-cloud.yaml
@@ -32,7 +32,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   deploy-to-astro-cloud:
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-latest'
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/reuse-wf-trigger-dag.yaml
+++ b/.github/workflows/reuse-wf-trigger-dag.yaml
@@ -32,7 +32,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   wait-for-deployment-to-be-ready-and-trigger-dag:
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-latest'
     steps:
 
       - name: Wait for deployment to be healthy

--- a/.github/workflows/runtime-image-update.yaml
+++ b/.github/workflows/runtime-image-update.yaml
@@ -12,7 +12,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   runtime-image-tag-update-job:
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-latest'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01:

https://github.com/actions/runner-images/issues/11101

Used the following command to replace all the ocurrences:
```
find . -type f -exec sed -i -e 's/ubuntu-20.04/ubuntu-latest/g' {} +
```