### PR TITLE
Fix ExternalDeploymentTaskSensorAsync to make async calls and resolve force closed connection errors

### DIFF
--- a/astronomer/providers/core/sensors/external_task.py
+++ b/astronomer/providers/core/sensors/external_task.py
@@ -132,8 +132,7 @@ class ExternalDeploymentTaskSensorAsync(HttpSensor):
         super().__init__(*args, **kwargs)
 
     def execute(self, context: Context) -> None:
-        # """Defers trigger class to poll for state of the job run until it reaches a failure state or success state"""
-
+        """Defers trigger class to poll for state of the job run until it reaches a failure state or success state"""
         self.defer(
             timeout=self.execution_timeout,
             trigger=ExternalDeploymentTaskTrigger(

--- a/astronomer/providers/core/sensors/external_task.py
+++ b/astronomer/providers/core/sensors/external_task.py
@@ -133,7 +133,6 @@ class ExternalDeploymentTaskSensorAsync(HttpSensor):
 
     def execute(self, context: Context) -> None:
         # """Defers trigger class to poll for state of the job run until it reaches a failure state or success state"""
-        hook = HttpHook(method="GET", http_conn_id=self.http_conn_id)
 
         self.defer(
             timeout=self.execution_timeout,

--- a/astronomer/providers/core/sensors/external_task.py
+++ b/astronomer/providers/core/sensors/external_task.py
@@ -131,31 +131,31 @@ class ExternalDeploymentTaskSensorAsync(HttpSensor):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-    # def execute(self, context: Context) -> None:
-    #     # """Defers trigger class to poll for state of the job run until it reaches a failure state or success state"""
-    #     hook = HttpHook(method="GET", http_conn_id=self.http_conn_id)
-    #
-    #     # self.defer(
-    #     #     timeout=self.execution_timeout,
-    #     #     trigger=ExternalDeploymentTaskTrigger(
-    #     #         http_conn_id=self.http_conn_id,
-    #     #         method=self.method,
-    #     #         endpoint=self.endpoint,
-    #     #         data=self.request_params,
-    #     #         headers=self.headers,
-    #     #         extra_options=self.extra_options,
-    #     #         poke_interval=self.poke_interval,
-    #     #     ),
-    #     #     method_name="execute_complete",
-    #     # )
-    #
-    # def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> Any:
-    #     """
-    #     Callback for when the trigger fires - returns immediately.
-    #     Return true and log the response if state is not success state raise ValueError
-    #     """
-    #     if event and "state" in event:
-    #         if event["state"] == "success":
-    #             self.log.info("Task Succeeded with response: %s", event)
-    #             return True
-    #     raise ValueError(f"Task Failed with response: {event}")
+    def execute(self, context: Context) -> None:
+        # """Defers trigger class to poll for state of the job run until it reaches a failure state or success state"""
+        hook = HttpHook(method="GET", http_conn_id=self.http_conn_id)
+
+        self.defer(
+            timeout=self.execution_timeout,
+            trigger=ExternalDeploymentTaskTrigger(
+                http_conn_id=self.http_conn_id,
+                method=self.method,
+                endpoint=self.endpoint,
+                data=self.request_params,
+                headers=self.headers,
+                extra_options=self.extra_options,
+                poke_interval=self.poke_interval,
+            ),
+            method_name="execute_complete",
+        )
+
+    def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> Any:
+        """
+        Callback for when the trigger fires - returns immediately.
+        Return true and log the response if state is not success state raise ValueError
+        """
+        if event and "state" in event:
+            if event["state"] == "success":
+                self.log.info("Task Succeeded with response: %s", event)
+                return True
+        raise ValueError(f"Task Failed with response: {event}")

--- a/astronomer/providers/core/sensors/external_task.py
+++ b/astronomer/providers/core/sensors/external_task.py
@@ -131,29 +131,31 @@ class ExternalDeploymentTaskSensorAsync(HttpSensor):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-    def execute(self, context: Context) -> None:
-        """Defers trigger class to poll for state of the job run until it reaches a failure state or success state"""
-        self.defer(
-            timeout=self.execution_timeout,
-            trigger=ExternalDeploymentTaskTrigger(
-                http_conn_id=self.http_conn_id,
-                method=self.method,
-                endpoint=self.endpoint,
-                data=self.request_params,
-                headers=self.headers,
-                extra_options=self.extra_options,
-                poke_interval=self.poke_interval,
-            ),
-            method_name="execute_complete",
-        )
-
-    def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> Any:
-        """
-        Callback for when the trigger fires - returns immediately.
-        Return true and log the response if state is not success state raise ValueError
-        """
-        if event and "state" in event:
-            if event["state"] == "success":
-                self.log.info("Task Succeeded with response: %s", event)
-                return True
-        raise ValueError(f"Task Failed with response: {event}")
+    # def execute(self, context: Context) -> None:
+    #     # """Defers trigger class to poll for state of the job run until it reaches a failure state or success state"""
+    #     hook = HttpHook(method="GET", http_conn_id=self.http_conn_id)
+    #
+    #     # self.defer(
+    #     #     timeout=self.execution_timeout,
+    #     #     trigger=ExternalDeploymentTaskTrigger(
+    #     #         http_conn_id=self.http_conn_id,
+    #     #         method=self.method,
+    #     #         endpoint=self.endpoint,
+    #     #         data=self.request_params,
+    #     #         headers=self.headers,
+    #     #         extra_options=self.extra_options,
+    #     #         poke_interval=self.poke_interval,
+    #     #     ),
+    #     #     method_name="execute_complete",
+    #     # )
+    #
+    # def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> Any:
+    #     """
+    #     Callback for when the trigger fires - returns immediately.
+    #     Return true and log the response if state is not success state raise ValueError
+    #     """
+    #     if event and "state" in event:
+    #         if event["state"] == "success":
+    #             self.log.info("Task Succeeded with response: %s", event)
+    #             return True
+    #     raise ValueError(f"Task Failed with response: {event}")

--- a/astronomer/providers/core/triggers/external_task.py
+++ b/astronomer/providers/core/triggers/external_task.py
@@ -9,6 +9,7 @@ from airflow.models import DagRun, TaskInstance
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils.session import provide_session
 from asgiref.sync import sync_to_async
+from aiohttp import ClientConnectionError
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
@@ -203,9 +204,18 @@ class ExternalDeploymentTaskTrigger(HttpTrigger):
                     self.poke_interval,
                 )
                 await asyncio.sleep(self.poke_interval)
+            except ClientConnectionError as exc:
+                self.log.info(
+                    "Connection issue while calling API: %s. Sleeping for %s seconds",
+                    str(exc),
+                    self.poke_interval,
+                )
+                await asyncio.sleep(self.poke_interval)
+                continue
             except AirflowException as exc:
                 self.log.info("An error occur while calling API %s", str(exc))
                 if str(exc).startswith("404"):
                     await asyncio.sleep(self.poke_interval)
+                    continue
                 yield TriggerEvent({"state": "error", "message": str(exc)})
                 return

--- a/astronomer/providers/core/triggers/external_task.py
+++ b/astronomer/providers/core/triggers/external_task.py
@@ -13,6 +13,8 @@ from asgiref.sync import sync_to_async
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from astronomer.providers.http.hooks.http import HttpHookAsync
+
 from astronomer.providers.http.triggers.http import HttpTrigger
 
 
@@ -185,7 +187,12 @@ class ExternalDeploymentTaskTrigger(HttpTrigger):
         """
         from airflow.utils.state import State
 
-        hook = self._get_async_hook()
+        # hook = self._get_async_hook()
+        hook = HttpHookAsync(
+            method=self.method,
+            http_conn_id=self.http_conn_id,
+            keep_response=True,
+        )
         while True:
             try:
                 response = await hook.run(

--- a/astronomer/providers/core/triggers/external_task.py
+++ b/astronomer/providers/core/triggers/external_task.py
@@ -14,7 +14,6 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from astronomer.providers.http.hooks.http import HttpHookAsync
-
 from astronomer.providers.http.triggers.http import HttpTrigger
 
 

--- a/astronomer/providers/core/triggers/external_task.py
+++ b/astronomer/providers/core/triggers/external_task.py
@@ -4,12 +4,12 @@ import typing
 import warnings
 from typing import Any, AsyncIterator, Dict, List, Tuple
 
+from aiohttp import ClientConnectionError
 from airflow import AirflowException
 from airflow.models import DagRun, TaskInstance
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils.session import provide_session
 from asgiref.sync import sync_to_async
-from aiohttp import ClientConnectionError
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 

--- a/astronomer/providers/core/triggers/external_task.py
+++ b/astronomer/providers/core/triggers/external_task.py
@@ -186,7 +186,6 @@ class ExternalDeploymentTaskTrigger(HttpTrigger):
         """
         from airflow.utils.state import State
 
-        # hook = self._get_async_hook()
         hook = HttpHookAsync(
             method=self.method,
             http_conn_id=self.http_conn_id,

--- a/astronomer/providers/core/triggers/external_task.py
+++ b/astronomer/providers/core/triggers/external_task.py
@@ -6,7 +6,6 @@ from typing import Any, AsyncIterator, Dict, List, Tuple
 
 from airflow import AirflowException
 from airflow.models import DagRun, TaskInstance
-from airflow.providers.http.hooks.http import HttpHook
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils.session import provide_session
 from asgiref.sync import sync_to_async
@@ -180,21 +179,21 @@ class ExternalDeploymentTaskTrigger(HttpTrigger):
 
     async def run(self) -> AsyncIterator["TriggerEvent"]:
         """
-        Makes a series of http calls via an http hook poll for state of the job
+        Makes a series of asynchronous http calls via an http hook poll for state of the job
         run until it reaches a failure state or success state. It yields a Trigger if response state is successful.
         """
         from airflow.utils.state import State
 
-        hook = HttpHook(method="GET", http_conn_id=self.http_conn_id)
+        hook = self._get_async_hook()
         while True:
             try:
-                response = hook.run(
+                response = await hook.run(
                     endpoint=self.endpoint,
                     data=self.data,
                     headers=self.headers,
                     extra_options=self.extra_options,
                 )
-                resp_json = response.json()
+                resp_json = await response.json()
                 if resp_json["state"] in State.finished:
                     yield TriggerEvent(resp_json)
                     return

--- a/tests/core/triggers/test_external_task.py
+++ b/tests/core/triggers/test_external_task.py
@@ -1,10 +1,10 @@
 import asyncio
 from unittest import mock
+from unittest.mock import AsyncMock
 
 import pytest
 from airflow import AirflowException
 from airflow.operators.empty import EmptyOperator
-from airflow.providers.http.hooks.http import HttpHook
 from airflow.triggers.base import TriggerEvent
 from airflow.utils.state import DagRunState, TaskInstanceState
 
@@ -13,6 +13,7 @@ from astronomer.providers.core.triggers.external_task import (
     ExternalDeploymentTaskTrigger,
     TaskStateTrigger,
 )
+from astronomer.providers.http.hooks.http import HttpHookAsync
 from tests.utils.airflow_util import get_dag_run, get_task_instance
 from tests.utils.config import Config
 
@@ -166,11 +167,11 @@ class TestExternalDeploymentTaskTrigger:
         }
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.http.hooks.http.HttpHook.run")
+    @mock.patch("astronomer.providers.http.hooks.http.HttpHookAsync.run")
     async def test_deployment_task_run_trigger(self, mock_run):
         """Test ExternalDeploymentTaskTrigger is triggered and in running state."""
-        mock.Mock(HttpHook)
-        mock_run.return_value.json = mock.Mock(return_value={"state": "running"})
+        mock.AsyncMock(HttpHookAsync)
+        mock_run.return_value.json = AsyncMock(return_value={"state": "running"})
         trigger = ExternalDeploymentTaskTrigger(
             endpoint=self.TEST_END_POINT,
             http_conn_id=self.CONN_ID,
@@ -185,10 +186,10 @@ class TestExternalDeploymentTaskTrigger:
         asyncio.get_event_loop().stop()
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.http.hooks.http.HttpHook.run")
+    @mock.patch("astronomer.providers.http.hooks.http.HttpHookAsync.run")
     async def test_deployment_task_exception_404(self, mock_run):
         """Test ExternalDeploymentTaskTrigger is triggered and in exception state."""
-        mock.Mock(HttpHook)
+        mock.AsyncMock(HttpHookAsync)
         mock_run.side_effect = AirflowException("404 test error")
         trigger = ExternalDeploymentTaskTrigger(
             endpoint=self.TEST_END_POINT,
@@ -204,10 +205,10 @@ class TestExternalDeploymentTaskTrigger:
         asyncio.get_event_loop().stop()
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.http.hooks.http.HttpHook.run")
+    @mock.patch("astronomer.providers.http.hooks.http.HttpHookAsync.run")
     async def test_deployment_task_exception(self, mock_run):
         """Test ExternalDeploymentTaskTrigger is triggered and in exception state."""
-        mock.Mock(HttpHook)
+        mock.AsyncMock(HttpHookAsync)
         mock_run.side_effect = AirflowException("Test exception")
         trigger = ExternalDeploymentTaskTrigger(
             endpoint=self.TEST_END_POINT,
@@ -220,11 +221,11 @@ class TestExternalDeploymentTaskTrigger:
         assert TriggerEvent({"state": "error", "message": "Test exception"}) == actual
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.http.hooks.http.HttpHook.run")
+    @mock.patch("astronomer.providers.http.hooks.http.HttpHookAsync.run")
     async def test_deployment_complete(self, mock_run):
         """Assert ExternalDeploymentTaskTrigger runs and complete the run in success state"""
-        mock.Mock(HttpHook)
-        mock_run.return_value.json = mock.Mock(return_value={"state": "success"})
+        mock.AsyncMock(HttpHookAsync)
+        mock_run.return_value.json = AsyncMock(return_value={"state": "success"})
         trigger = ExternalDeploymentTaskTrigger(
             endpoint=self.TEST_END_POINT,
             http_conn_id=self.CONN_ID,


### PR DESCRIPTION
This reverts commit cba9a8f0f1a2bd2196cd4660ce623be8fb63609f that changed the async calls to sync calls.

After switching back to async calls, we encountered forced connection close errors. To fix this, the `HttpHookAsync` is now constructed with `keep_response=True`, ensuring that the subsequent `await response.json()` call operates on an open session. Without this flag, the operation was being attempted on a closed session, resulting in failures.

closes: https://github.com/astronomer/oss-integrations-private/issues/216
